### PR TITLE
feat: ダッシュボードにクイックアクセスセクションを追加

### DIFF
--- a/docs/tasks/plan-2026-02-03-16-00.md
+++ b/docs/tasks/plan-2026-02-03-16-00.md
@@ -1,0 +1,333 @@
+# 実装計画: ダッシュボードにスケジュール画面へのナビゲーションリンクを追加
+
+## Issue情報
+
+- **Issue番号**: #4
+- **タイトル**: ダッシュボードにスケジュール画面へのナビゲーションリンクを追加
+- **作成日**: 2026-02-03
+- **ブランチ名**: `feature/issue-4-dashboard-quick-access`
+
+## 概要
+
+`Dashboard.tsx`）に「クイックアクセス」セクションを新設し、基本スケジュール・週次スケジュール画面へのリンクカードを配置する。
+
+## 受け入れ基準
+
+- [ ] `DashboardQuickAccess` コンポーネントが作成されている
+- [ ] ダッシュボードから基本スケジュール画面（`/admin/basic-schedules`）へのリンクが存在する
+- [ ] ダッシュボードから週次スケジュール画面（`/admin/weekly-schedules`）へのリンクが存在する
+- [ ] リンクカードはdaisyUIの `card` コンポーネントで統一されている
+- [ ] アイコンは `Icon` コンポーネント（Material Symbols）を使用している
+- [ ] レスポンシブデザインに対応している（モバイル: 1列、デスクトップ: 2列）
+- [ ] 単体テスト（Vitest + Testing Library）が追加されている
+- [ ] Storybookストーリーが作成されている
+- [ ] アクセシビリティ対応（リンクに適切な `aria-label` がある）
+
+## リンクカード仕様
+
+| ラベル           | アイコン             | リンク先                  | 説明テキスト                 |
+| ---------------- | -------------------- | ------------------------- | ---------------------------- |
+| 基本スケジュール | `calendar_month`     | `/admin/basic-schedules`  | 定期的なシフトパターンを管理 |
+| 週次スケジュール | `calendar_view_week` | `/admin/weekly-schedules` | 週ごとのシフトを確認・編集   |
+
+## 作成/変更するファイル
+
+### 新規作成ファイル
+
+| ファイルパス                                                                | 概要                               |
+| --------------------------------------------------------------------------- | ---------------------------------- |
+| `src/app/_components/DashboardQuickAccess/DashboardQuickAccess.tsx`         | クイックアクセスコンポーネント本体 |
+| `src/app/_components/DashboardQuickAccess/DashboardQuickAccess.test.tsx`    | 単体テスト                         |
+| `src/app/_components/DashboardQuickAccess/DashboardQuickAccess.stories.tsx` | Storybookストーリー                |
+| `src/app/_components/DashboardQuickAccess/index.ts`                         | named export                       |
+
+### 変更ファイル
+
+| ファイルパス                                          | 変更内容                                              |
+| ----------------------------------------------------- | ----------------------------------------------------- |
+| `src/app/_components/Dashboard/Dashboard.tsx`         | `DashboardQuickAccess` を `DashboardStats` の下に追加 |
+| `src/app/_components/Dashboard/Dashboard.test.tsx`    | クイックアクセスセクションのテストを追加              |
+| `src/app/_components/Dashboard/Dashboard.stories.tsx` | ストーリーの更新（必要に応じて）                      |
+
+## 実装詳細
+
+### 1. DashboardQuickAccess コンポーネント
+
+```tsx
+// src/app/_components/DashboardQuickAccess/DashboardQuickAccess.tsx
+// daisyUI の card コンポーネントを使用
+// Next.js の Link コンポーネントでナビゲーション
+// Icon コンポーネントでアイコン表示
+// レスポンシブ: grid-cols-1 md:grid-cols-2
+```
+
+**主な実装ポイント:**
+
+1. **レイアウト**
+   - `grid` レイアウトを使用
+   - モバイル: `grid-cols-1`（縦並び）
+   - デスクトップ: `md:grid-cols-2`（横並び）
+
+2. **カードデザイン**
+   - daisyUI の `card` クラスを使用
+   - ホバー時のインタラクション（`hover:shadow-lg` など）
+   - アイコン + ラベル + 説明テキスト
+
+3. **アクセシビリティ**
+   - `aria-label` でリンクの目的を明示
+   - キーボードナビゲーション対応（Next.js Linkは標準対応）
+
+### 2. コンポーネント構造
+
+```
+DashboardQuickAccess/
+ DashboardQuickAccess.tsx      # メインコンポーネント
+ DashboardQuickAccess.test.tsx # テストファイル
+ DashboardQuickAccess.stories.tsx # Storybook
+ index.ts                       # export
+```
+
+### 3. Dashboard への組み込み
+
+```tsx
+// Dashboard.tsx での配置
+<section>
+  <DashboardStats {...stats} />
+</section>
+
+{/* 新規追加: クイックアクセスセクション */}
+<section>
+  <DashboardQuickAccess />
+</section>
+
+<DashboardTimeline timeline={timeline} />
+<DashboardAlerts alerts={alerts} />
+```
+
+## 実装順序（TDDアプローチ）
+
+### フェーズ1: DashboardQuickAccess コンポーネントの作成
+
+1. **テストファイルの作成** (`DashboardQuickAccess.test.tsx`)
+   - リンクカードが2つ表示されることをテスト
+   - 各リンクの `href` が正しいことをテスト
+   - アイコンが表示されることをテスト
+   - アクセシビリティ属性のテスト
+
+2. **コンポーネント本体の実装** (`DashboardQuickAccess.tsx`)
+   - テストを通過する最小限の実装
+   - daisyUI card を使用したスタイリング
+   - レスポンシブ対応
+
+3. **index.ts の作成**
+   - named export の追加
+
+4. **Storybook の作成** (`DashboardQuickAccess.stories.tsx`)
+   - デフォルトストーリー
+   - モバイル表示のストーリー（viewport parameter）
+
+### フェーズ2: Dashboard への統合
+
+5. **Dashboard.test.tsx の更新**
+   - クイックアクセスセクションの存在確認テスト
+   - リンクが正しく表示されることのテスト
+
+6. **Dashboard.tsx の更新**
+   - `DashboardQuickAccess` のインポートと配置
+
+7. **Dashboard.stories.tsx の確認**
+   - 既存のストーリーで新しいセクションが表示されることを確認
+
+### フェーズ3: 最終確認
+
+8. **全テストの実行**
+
+   ```bash
+   pnpm test:ut --run
+   ```
+
+9. **Storybook でのビジュアル確認**
+
+   ```bash
+   pnpm storybook
+   ```
+
+10. **フォーマットとリント**
+    ```bash
+    pnpm format
+    ```
+
+## 使用する既存リソース
+
+### コンポーネント
+
+- `Icon` (`src/app/_components/Icon/`) - アイコン表示
+  - `calendar_month` - 基本スケジュール用
+  - `calendar_view_week` - 週次スケジュール用
+
+### テストユーティリティ
+
+- `renderWithUser` (`src/testUtils.tsx`) - コンポーネントテスト用
+
+### スタイル
+
+- daisyUI: `card`, `card-body`, `card-title`
+- Tailwind CSS: `grid`, `gap`, `hover:*`, レスポンシブプレフィックス
+
+## コード例
+
+### DashboardQuickAccess.tsx（実装イメージ）
+
+```tsx
+import { Icon } from '@/app/_components/Icon';
+import Link from 'next/link';
+
+type QuickAccessItem = {
+	label: string;
+	description: string;
+	href: string;
+	icon: 'calendar_month' | 'calendar_view_week';
+};
+
+const quickAccessItems: QuickAccessItem[] = [
+	{
+		label: '基本スケジュール',
+		description: '定期的なシフトパターンを管理',
+		href: '/admin/basic-schedules',
+		icon: 'calendar_month',
+	},
+	{
+		label: '週次スケジュール',
+		description: '週ごとのシフトを確認・編集',
+		href: '/admin/weekly-schedules',
+		icon: 'calendar_view_week',
+	},
+];
+
+export const DashboardQuickAccess = () => {
+	return (
+		<div className="space-y-2">
+			<h2 className="text-lg font-semibold">クイックアクセス</h2>
+			<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+				{quickAccessItems.map((item) => (
+					<Link
+						key={item.href}
+						href={item.href}
+						aria-label={`${item.label}画面へ移動`}
+						className="card bg-base-100 shadow transition-shadow hover:shadow-lg"
+					>
+						<div className="card-body flex-row items-center gap-4">
+							<Icon name={item.icon} className="text-3xl text-primary" />
+							<div>
+								<h3 className="card-title text-base">{item.label}</h3>
+								<p className="text-sm text-base-content/70">
+									{item.description}
+								</p>
+							</div>
+						</div>
+					</Link>
+				))}
+			</div>
+		</div>
+	);
+};
+```
+
+### DashboardQuickAccess.test.tsx（テストイメージ）
+
+```tsx
+import { renderWithUser } from '@/testUtils';
+import { screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { DashboardQuickAccess } from './DashboardQuickAccess';
+
+describe('DashboardQuickAccess', () => {
+	const render = () => renderWithUser(<DashboardQuickAccess />);
+
+	describe('表示', () => {
+		test('セクションタイトル「クイックアクセス」が表示される', () => {
+			render();
+			expect(screen.getByText('クイックアクセス')).toBeInTheDocument();
+		});
+
+		test('基本スケジュールリンクが表示される', () => {
+			render();
+			expect(screen.getByText('基本スケジュール')).toBeInTheDocument();
+			expect(
+				screen.getByText('定期的なシフトパターンを管理'),
+			).toBeInTheDocument();
+		});
+
+		test('週次スケジュールリンクが表示される', () => {
+			render();
+			expect(screen.getByText('週次スケジュール')).toBeInTheDocument();
+			expect(
+				screen.getByText('週ごとのシフトを確認・編集'),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe('ナビゲーション', () => {
+		test('基本スケジュールリンクのhrefが正しい', () => {
+			render();
+			const link = screen.getByRole('link', {
+				name: /基本スケジュール画面へ移動/,
+			});
+			expect(link).toHaveAttribute('href', '/admin/basic-schedules');
+		});
+
+		test('週次スケジュールリンクのhrefが正しい', () => {
+			render();
+			const link = screen.getByRole('link', {
+				name: /週次スケジュール画面へ移動/,
+			});
+			expect(link).toHaveAttribute('href', '/admin/weekly-schedules');
+		});
+	});
+
+	describe('アクセシビリティ', () => {
+		test('リンクにaria-labelが設定されている', () => {
+			render();
+			expect(
+				screen.getByRole('link', { name: /基本スケジュール画面へ移動/ }),
+			).toBeInTheDocument();
+			expect(
+				screen.getByRole('link', { name: /週次スケジュール画面へ移動/ }),
+			).toBeInTheDocument();
+		});
+	});
+});
+```
+
+## 作業見積もり
+
+| フェーズ  | 作業内容                                | 見積もり時間 |
+| --------- | --------------------------------------- | ------------ |
+| フェーズ1 | DashboardQuickAccess コンポーネント作成 | 1.5時間      |
+| フェーズ2 | Dashboard への統合                      | 0.5時間      |
+| フェーズ3 | 最終確認・調整                          | 0.5時間      |
+| **合計**  |                                         | **2.5時間**  |
+
+## 注意事項
+
+1. **コンポーネント配置規則に従う**
+   - 本体 + テスト + Storybook + index.ts をセットで作成
+
+2. **既存の Icon コンポーネントを使用**
+   - `calendar_month` と `calendar_view_week` は既にICON_NAMESに定義済み
+
+3. **daisyUI の card コンポーネントを活用**
+   - 既存の DashboardStats と視覚的に調和するデザイン
+
+4. **レスポンシブデザイン**
+   - モバイルファーストで実装（`grid-cols-1` → `md:grid-cols-2`）
+
+5. **TDDアプローチ**
+   - テストを先に書き、最小限の実装で動作確認しながら進める
+
+## 関連ドキュメント
+
+- [daisyUI Card](https://daisyui.com/components/card/)
+- [MVP仕様書](../../MVP.md)
+- [画面設計: admin-weekly-schedules](../../screens/admin-weekly-schedules.md)
+- [画面設計: admin-basic-schedules](../../screens/admin-basic-schedules.md)

--- a/src/app/_components/Dashboard/Dashboard.test.tsx
+++ b/src/app/_components/Dashboard/Dashboard.test.tsx
@@ -101,6 +101,25 @@ describe('Dashboard', () => {
 		});
 	});
 
+	describe('クイックアクセスセクション', () => {
+		it('クイックアクセスセクションが表示される', () => {
+			renderComponent();
+			expect(screen.getByText('クイックアクセス')).toBeInTheDocument();
+		});
+
+		it('基本スケジュールへのリンクが表示される', () => {
+			renderComponent();
+			const link = screen.getByRole('link', { name: /基本スケジュール/ });
+			expect(link).toHaveAttribute('href', '/admin/basic-schedules');
+		});
+
+		it('週次スケジュールへのリンクが表示される', () => {
+			renderComponent();
+			const link = screen.getByRole('link', { name: /週次スケジュール/ });
+			expect(link).toHaveAttribute('href', '/admin/weekly-schedules');
+		});
+	});
+
 	describe('レスポンシブ対応', () => {
 		it('ダッシュボードコンテナが存在する', () => {
 			renderComponent();

--- a/src/app/_components/Dashboard/Dashboard.tsx
+++ b/src/app/_components/Dashboard/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { DashboardAlerts } from '@/app/_components/DashboardAlerts';
+import { DashboardQuickAccess } from '@/app/_components/DashboardQuickAccess';
 import { DashboardStats } from '@/app/_components/DashboardStats';
 import { DashboardTimeline } from '@/app/_components/DashboardTimeline';
 import type { DashboardData } from '@/models/dashboardActionSchemas';
@@ -19,6 +20,9 @@ export const Dashboard = ({ data }: Props) => {
 			<section>
 				<DashboardStats {...stats} />
 			</section>
+
+			{/* クイックアクセス */}
+			<DashboardQuickAccess />
 
 			{/* 今日のタイムライン */}
 			<DashboardTimeline timeline={timeline} />

--- a/src/app/_components/DashboardQuickAccess/DashboardQuickAccess.stories.tsx
+++ b/src/app/_components/DashboardQuickAccess/DashboardQuickAccess.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { DashboardQuickAccess } from './DashboardQuickAccess';
+
+const meta: Meta<typeof DashboardQuickAccess> = {
+	title: 'Components/DashboardQuickAccess',
+	component: DashboardQuickAccess,
+	tags: ['autodocs'],
+	decorators: [
+		(Story) => (
+			<div className="max-w-2xl p-4">
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardQuickAccess>;
+
+/**
+ * デフォルト表示
+ * 基本スケジュールと週次スケジュールへのクイックアクセスカードを表示します。
+ */
+export const Default: Story = {};

--- a/src/app/_components/DashboardQuickAccess/DashboardQuickAccess.test.tsx
+++ b/src/app/_components/DashboardQuickAccess/DashboardQuickAccess.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DashboardQuickAccess } from './DashboardQuickAccess';
+
+const renderComponent = () => {
+	return render(<DashboardQuickAccess />);
+};
+
+describe('DashboardQuickAccess', () => {
+	describe('タイトル', () => {
+		it('「クイックアクセス」というタイトルが表示される', () => {
+			renderComponent();
+			expect(screen.getByText('クイックアクセス')).toBeInTheDocument();
+		});
+	});
+
+	describe('基本スケジュールリンク', () => {
+		it('基本スケジュールへのリンクが表示される', () => {
+			renderComponent();
+			const link = screen.getByRole('link', { name: /基本スケジュール/ });
+			expect(link).toBeInTheDocument();
+			expect(link).toHaveAttribute('href', '/admin/basic-schedules');
+		});
+
+		it('calendar_month アイコンが表示される', () => {
+			renderComponent();
+			const card = screen.getByRole('link', { name: /基本スケジュール/ });
+			expect(card).toContainHTML('calendar_month');
+		});
+	});
+
+	describe('週次スケジュールリンク', () => {
+		it('週次スケジュールへのリンクが表示される', () => {
+			renderComponent();
+			const link = screen.getByRole('link', { name: /週次スケジュール/ });
+			expect(link).toBeInTheDocument();
+			expect(link).toHaveAttribute('href', '/admin/weekly-schedules');
+		});
+
+		it('calendar_view_week アイコンが表示される', () => {
+			renderComponent();
+			const card = screen.getByRole('link', { name: /週次スケジュール/ });
+			expect(card).toContainHTML('calendar_view_week');
+		});
+	});
+
+	describe('レスポンシブ対応', () => {
+		it('コンテナにグリッドレイアウトのクラスが適用されている', () => {
+			renderComponent();
+			const container = screen.getByTestId('quick-access-grid');
+			expect(container).toHaveClass('grid');
+		});
+	});
+
+	describe('アクセシビリティ', () => {
+		it('各リンクに適切な aria-label が設定されている', () => {
+			renderComponent();
+			expect(
+				screen.getByRole('link', { name: /基本スケジュール/ }),
+			).toHaveAttribute('aria-label');
+			expect(
+				screen.getByRole('link', { name: /週次スケジュール/ }),
+			).toHaveAttribute('aria-label');
+		});
+	});
+});

--- a/src/app/_components/DashboardQuickAccess/DashboardQuickAccess.tsx
+++ b/src/app/_components/DashboardQuickAccess/DashboardQuickAccess.tsx
@@ -1,0 +1,57 @@
+import { Icon } from '@/app/_components/Icon';
+import Link from 'next/link';
+
+type QuickAccessItem = {
+	href: string;
+	iconName: 'calendar_month' | 'calendar_view_week';
+	title: string;
+	description: string;
+};
+
+const quickAccessItems: QuickAccessItem[] = [
+	{
+		href: '/admin/basic-schedules',
+		iconName: 'calendar_month',
+		title: '基本スケジュール',
+		description: '定期的なシフトパターンを管理',
+	},
+	{
+		href: '/admin/weekly-schedules',
+		iconName: 'calendar_view_week',
+		title: '週次スケジュール',
+		description: '週ごとのシフトを確認・編集',
+	},
+];
+
+export const DashboardQuickAccess = () => {
+	return (
+		<section>
+			<h2 className="mb-4 text-lg font-semibold">クイックアクセス</h2>
+			<div
+				className="grid grid-cols-1 gap-4 md:grid-cols-2"
+				data-testid="quick-access-grid"
+			>
+				{quickAccessItems.map((item) => (
+					<Link
+						key={item.href}
+						href={item.href}
+						aria-label={`${item.title} - ${item.description}`}
+						className="card bg-base-100 shadow-md transition-shadow hover:shadow-lg focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
+					>
+						<div className="card-body flex-row items-center gap-4">
+							<div className="rounded-full bg-primary/10 p-3">
+								<Icon name={item.iconName} className="text-2xl text-primary" />
+							</div>
+							<div>
+								<h3 className="card-title text-base">{item.title}</h3>
+								<p className="text-sm text-base-content/70">
+									{item.description}
+								</p>
+							</div>
+						</div>
+					</Link>
+				))}
+			</div>
+		</section>
+	);
+};

--- a/src/app/_components/DashboardQuickAccess/index.ts
+++ b/src/app/_components/DashboardQuickAccess/index.ts
@@ -1,0 +1,1 @@
+export { DashboardQuickAccess } from './DashboardQuickAccess';


### PR DESCRIPTION
## 概要

Issue #4 の実装です。ダッシュボードに「クイックアクセス」セクションを新設し、基本スケジュール・週次スケジュール画面へのリンクカードを配置しました。

## 変更内容

### 新規作成
- `DashboardQuickAccess` コンポーネント
  - 基本スケジュール画面へのリンクカード（`calendar_month` アイコン）
  - 週次スケジュール画面へのリンクカード（`calendar_view_week` アイコン）
- ユニットテスト（7テスト）
- Storybook ストーリー

### 変更
- `Dashboard.tsx`: `DashboardQuickAccess` を統合
- `Dashboard.test.tsx`: クイックアクセスセクションのテストを追加

## 機能詳細

| リンク | アイコン | リンク先 | 説明 |
|--------|----------|----------|------|
| 基本スケジュール | calendar_month | /admin/basic-schedules | 定期的なシフトパターンを管理 |
| 週次スケジュール | calendar_view_week | /admin/weekly-schedules | 週ごとのシフトを確認・編集 |

## 対応項目

- [x] レスポンシブ対応（モバイル: 1列、デスクトップ: 2列）
- [x] アクセシビリティ対応（aria-label, focus-visible）
- [x] daisyUI card コンポーネント使用
- [x] Material Symbols アイコン使用

## テスト結果

- ✅ ユニットテスト: 全474テスト通過
- ✅ Storybookテスト: 全145テスト通過
- ✅ TypeScriptコンパイル: エラーなし

Closes #4