### PR TITLE
fix: useBasicScheduleFormSubmitの型エラーを修正

### DIFF
--- a/src/app/admin/basic-schedules/_components/BasicScheduleForm/useBasicScheduleFormSubmit.ts
+++ b/src/app/admin/basic-schedules/_components/BasicScheduleForm/useBasicScheduleFormSubmit.ts
@@ -5,6 +5,8 @@ import {
 import { createQuickServiceUserAction } from '@/app/actions/serviceUsers';
 import { useActionResultHandler } from '@/hooks/useActionResultHandler';
 import type { BasicScheduleRecord } from '@/models/basicScheduleActionSchemas';
+import type { ServiceTypeId } from '@/models/valueObjects/serviceTypeId';
+import type { TimeValue } from '@/models/valueObjects/time';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import type { UseFormReset } from 'react-hook-form';
@@ -42,7 +44,12 @@ const buildDefaultValues = (
 };
 
 type ValidationResult =
-	| { valid: true; start: string; end: string }
+	| {
+			valid: true;
+			start: TimeValue;
+			end: TimeValue;
+			serviceTypeId: ServiceTypeId;
+	  }
 	| { valid: false; error: string };
 
 const validateFormValues = (
@@ -56,7 +63,7 @@ const validateFormValues = (
 	if (!values.serviceTypeId) {
 		return { valid: false, error: 'サービス区分を選択してください' };
 	}
-	return { valid: true, start, end };
+	return { valid: true, start, end, serviceTypeId: values.serviceTypeId };
 };
 
 type NewClientResult =
@@ -115,7 +122,7 @@ export const useBasicScheduleFormSubmit = ({
 
 		const payload = {
 			client_id: clientResult.clientId,
-			service_type_id: values.serviceTypeId,
+			service_type_id: validation.serviceTypeId,
 			weekday: values.weekday,
 			start_time: validation.start,
 			end_time: validation.end,

--- a/src/app/admin/clients/_components/ClientModal/ClientModal.tsx
+++ b/src/app/admin/clients/_components/ClientModal/ClientModal.tsx
@@ -60,7 +60,7 @@ export const ClientModal = (props: ClientModalProps) => {
 		if (mode === 'edit' && client) {
 			reset({
 				name: client.name,
-				address: client.address,
+				address: client.address ?? '',
 				contract_status: client.contract_status,
 			});
 		} else {


### PR DESCRIPTION
## 概要
mainブランチでのビルドエラーを修正しました。

## 修正内容

### 1. useBasicScheduleFormSubmit.ts
- `ValidationResult`型の`start`と`end`を`string`から`TimeValue`に変更
  - `parseTimeString`関数は`{ hour: number; minute: number; }`型を返すため
- `ValidationResult`に`serviceTypeId`フィールドを追加
  - TypeScriptの型絞り込みにより空文字列を除外

### 2. ClientModal.tsx
- `client.address`が`null`の場合を`?? ''`でハンドリング

## 確認結果
- `pnpm build`: 成功
- `pnpm test:ut --run`: 518件パス