### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Vitest Run
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [main, develop] # 必要に応じてブランチ名を調整


### PR DESCRIPTION
Potential fix for [https://github.com/ebi311/rhubarb/security/code-scanning/1](https://github.com/ebi311/rhubarb/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions in the workflow to the least privilege required. For this workflow, it only needs to read repository contents to allow `actions/checkout` and dependency installation, so `contents: read` at the workflow or job level is sufficient.

The best way to fix this without changing existing functionality is to add a top-level `permissions` block right under the workflow name. This will apply to all jobs that do not define their own `permissions`. We’ll set `contents: read`, which is the minimal permission needed for `actions/checkout@v4` to fetch the code. No other steps (pnpm setup, Node.js setup, installs, and tests) require additional GitHub API permissions. Concretely, in `.github/workflows/main.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Vitest Run`). No imports or extra definitions are needed since this is just YAML configuration for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
