### PR TITLE
style: 単発シフト追加の日時入力UIを統一

### DIFF
--- a/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.test.tsx
@@ -143,7 +143,7 @@ describe('CreateOneOffShiftDialog', () => {
 		const weekStartDate = new Date('2026-02-16T00:00:00Z');
 		const defaultDateStr = '2026-02-18';
 
-		const { container } = render(
+		render(
 			<CreateOneOffShiftDialog
 				isOpen
 				weekStartDate={weekStartDate}
@@ -154,16 +154,15 @@ describe('CreateOneOffShiftDialog', () => {
 			/>,
 		);
 
-		const dateInput = container.querySelector(
-			'input[type="date"]',
-		) as HTMLInputElement | null;
-		expect(dateInput).not.toBeNull();
-		expect(dateInput?.value).toBe(defaultDateStr);
+		const dateInput = screen.getByLabelText(
+			'日付（週内のみ）',
+		) as HTMLInputElement;
+		expect(dateInput.value).toBe(defaultDateStr);
 	});
 
 	it('defaultDateStr を変更して rerender すると日付入力が更新される', async () => {
 		const weekStartDate = new Date('2026-02-16T00:00:00Z');
-		const { container, rerender } = render(
+		const { rerender } = render(
 			<CreateOneOffShiftDialog
 				isOpen
 				weekStartDate={weekStartDate}
@@ -186,12 +185,34 @@ describe('CreateOneOffShiftDialog', () => {
 		);
 
 		await waitFor(() => {
-			const dateInput = container.querySelector(
-				'input[type="date"]',
-			) as HTMLInputElement | null;
-			expect(dateInput).not.toBeNull();
-			expect(dateInput?.value).toBe('2026-02-19');
+			const dateInput = screen.getByLabelText(
+				'日付（週内のみ）',
+			) as HTMLInputElement;
+			expect(dateInput.value).toBe('2026-02-19');
 		});
+	});
+
+	it('日時入力はラベルクリックでフォーカスされる', async () => {
+		const user = userEvent.setup();
+		render(
+			<CreateOneOffShiftDialog
+				isOpen
+				weekStartDate={new Date('2026-02-16T00:00:00Z')}
+				clientOptions={[{ id: TEST_IDS.CLIENT_1, name: '利用者A' }]}
+				staffOptions={[]}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		const startInput = screen.getByLabelText('開始');
+		expect(startInput).not.toHaveFocus();
+		await user.click(screen.getByText('開始'));
+		expect(startInput).toHaveFocus();
+
+		const endInput = screen.getByLabelText('終了');
+		expect(endInput).not.toHaveFocus();
+		await user.click(screen.getByText('終了'));
+		expect(endInput).toHaveFocus();
 	});
 
 	it('defaultClientId を指定して open すると利用者selectがその値で初期化される（optionsに存在する場合）', () => {

--- a/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
@@ -11,7 +11,7 @@ import {
 import { addJstDays, formatJstDateString } from '@/utils/date';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 
 export type CreateOneOffShiftDialogClientOption = {
 	id: string;
@@ -101,6 +101,11 @@ export const CreateOneOffShiftDialog = ({
 	staffOptions,
 	onClose,
 }: CreateOneOffShiftDialogProps) => {
+	const inputIdBase = useId();
+	const dateInputId = `${inputIdBase}-date`;
+	const startTimeInputId = `${inputIdBase}-start-time`;
+	const endTimeInputId = `${inputIdBase}-end-time`;
+
 	const router = useRouter();
 	const { handleActionResult } = useActionResultHandler();
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -204,10 +209,11 @@ export const CreateOneOffShiftDialog = ({
 				<div className="mt-4 grid grid-cols-1 gap-4">
 					<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
 						<div>
-							<label className="label">
+							<label className="label" htmlFor={dateInputId}>
 								<span className="label-text font-medium">日付（週内のみ）</span>
 							</label>
 							<input
+								id={dateInputId}
 								type="date"
 								className="input-bordered input w-full"
 								value={dateStr}
@@ -220,10 +226,11 @@ export const CreateOneOffShiftDialog = ({
 						</div>
 
 						<div>
-							<label className="label">
+							<label className="label" htmlFor={startTimeInputId}>
 								<span className="label-text font-medium">開始</span>
 							</label>
 							<input
+								id={startTimeInputId}
 								type="time"
 								className="input-bordered input w-full"
 								value={startTimeStr}
@@ -233,10 +240,11 @@ export const CreateOneOffShiftDialog = ({
 							/>
 						</div>
 						<div>
-							<label className="label">
+							<label className="label" htmlFor={endTimeInputId}>
 								<span className="label-text font-medium">終了</span>
 							</label>
 							<input
+								id={endTimeInputId}
 								type="time"
 								className="input-bordered input w-full"
 								value={endTimeStr}


### PR DESCRIPTION
Closes #45

変更内容: CreateOneOffShiftDialog の日時入力（日付/開始/終了）を sm以上で1行に並ぶようにして、編集ダイアログと揃えた

仕様不変: payload/バリデーション/文言は変更なし

テスト: `pnpm test:ut --run` 実行済み
