### PR TITLE
週次ダイアログのアクセシビリティ改善: label紐づけとUT修正

### DIFF
--- a/src/app/admin/weekly-schedules/_components/CancelShiftDialog/CancelShiftDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/CancelShiftDialog/CancelShiftDialog.test.tsx
@@ -104,7 +104,7 @@ describe('CancelShiftDialog', () => {
 
 		// 理由を入力
 		await user.type(
-			screen.getByPlaceholderText(/キャンセル理由/),
+			screen.getByLabelText('キャンセル理由（必須）'),
 			'体調不良のため',
 		);
 
@@ -140,7 +140,7 @@ describe('CancelShiftDialog', () => {
 
 		// 理由のみ入力
 		await user.type(
-			screen.getByPlaceholderText(/キャンセル理由/),
+			screen.getByLabelText('キャンセル理由（必須）'),
 			'体調不良のため',
 		);
 
@@ -174,7 +174,7 @@ describe('CancelShiftDialog', () => {
 
 		// 理由を入力
 		await user.type(
-			screen.getByPlaceholderText(/キャンセル理由/),
+			screen.getByLabelText('キャンセル理由（必須）'),
 			'体調不良のため',
 		);
 

--- a/src/app/admin/weekly-schedules/_components/CancelShiftDialog/CancelShiftDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/CancelShiftDialog/CancelShiftDialog.tsx
@@ -3,7 +3,7 @@
 import { cancelShiftAction } from '@/app/actions/shifts';
 import { useActionResultHandler } from '@/hooks/useActionResultHandler';
 import type { CancelShiftCategory } from '@/models/shiftActionSchemas';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { ShiftInfoCard } from '../ShiftInfoCard';
 
 export type CancelShiftDialogShift = {
@@ -35,6 +35,9 @@ export const CancelShiftDialog = ({
 	onClose,
 	onSuccess,
 }: CancelShiftDialogProps) => {
+	const inputIdBase = useId();
+	const reasonTextareaId = `${inputIdBase}-reason`;
+
 	const [category, setCategory] = useState<CancelShiftCategory | null>(null);
 	const [reason, setReason] = useState('');
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -133,12 +136,13 @@ export const CancelShiftDialog = ({
 
 					{/* キャンセル理由詳細 */}
 					<div>
-						<label className="label">
+						<label className="label" htmlFor={reasonTextareaId}>
 							<span className="label-text font-medium">
 								キャンセル理由（必須）
 							</span>
 						</label>
 						<textarea
+							id={reasonTextareaId}
 							className="textarea-bordered textarea w-full"
 							rows={3}
 							placeholder="キャンセル理由を入力してください"

--- a/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/ChangeStaffDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/ChangeStaffDialog.test.tsx
@@ -124,7 +124,9 @@ describe('ChangeStaffDialog', () => {
 		);
 
 		// スタッフを選択ボタンをクリック
-		const selectButton = screen.getByRole('button', { name: '佐藤次郎' });
+		const selectButton = screen.getByRole('button', {
+			name: /新しい担当者/,
+		});
 		await user.click(selectButton);
 
 		// StaffPickerDialogが開く（別のダイアログ）
@@ -179,7 +181,9 @@ describe('ChangeStaffDialog', () => {
 		);
 
 		// スタッフを選択ボタンをクリック
-		const selectButton = screen.getByRole('button', { name: '佐藤次郎' });
+		const selectButton = screen.getByRole('button', {
+			name: /新しい担当者/,
+		});
 		await user.click(selectButton);
 
 		// スタッフを選択
@@ -199,7 +203,7 @@ describe('ChangeStaffDialog', () => {
 		});
 
 		// 変更理由を入力
-		const reasonTextarea = screen.getByPlaceholderText(/変更理由/);
+		const reasonTextarea = screen.getByLabelText('変更理由（任意）');
 		await user.type(reasonTextarea, '緊急対応のため');
 
 		// 変更ボタンをクリック
@@ -247,7 +251,9 @@ describe('ChangeStaffDialog', () => {
 		);
 
 		// スタッフを選択ボタンをクリック
-		const selectButton = screen.getByRole('button', { name: '佐藤次郎' });
+		const selectButton = screen.getByRole('button', {
+			name: /新しい担当者/,
+		});
 		await user.click(selectButton);
 
 		// スタッフを選択
@@ -318,7 +324,11 @@ describe('ChangeStaffDialog', () => {
 		await user.type(endInput, '13:00');
 
 		// スタッフを選択
-		await user.click(screen.getByRole('button', { name: '佐藤次郎' }));
+		await user.click(
+			screen.getByRole('button', {
+				name: /新しい担当者/,
+			}),
+		);
 		await waitFor(() => {
 			expect(screen.getByText('担当者を選択')).toBeInTheDocument();
 		});

--- a/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/ChangeStaffDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/ChangeStaffDialog.tsx
@@ -2,6 +2,7 @@
 
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
 import { StaffPickerDialog } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import { useId } from 'react';
 import { ShiftInfoCard } from '../ShiftInfoCard';
 import { StaffConflictWarning } from '../StaffConflictWarning';
 import { useChangeStaffDialog } from './useChangeStaffDialog';
@@ -32,6 +33,9 @@ export const ChangeStaffDialog = ({
 	onClose,
 	onSuccess,
 }: ChangeStaffDialogProps) => {
+	const inputIdBase = useId();
+	const reasonTextareaId = `${inputIdBase}-reason`;
+
 	const {
 		showStaffPicker,
 		setShowStaffPicker,
@@ -145,6 +149,11 @@ export const ChangeStaffDialog = ({
 							<button
 								type="button"
 								className="btn w-full btn-outline"
+								aria-label={
+									selectedStaff
+										? `新しい担当者: ${selectedStaff.name}`
+										: '新しい担当者'
+								}
 								onClick={() => setShowStaffPicker(true)}
 								disabled={isSubmitting}
 							>
@@ -162,10 +171,11 @@ export const ChangeStaffDialog = ({
 
 						{/* 変更理由 */}
 						<div>
-							<label className="label">
+							<label className="label" htmlFor={reasonTextareaId}>
 								<span className="label-text">変更理由（任意）</span>
 							</label>
 							<textarea
+								id={reasonTextareaId}
 								className="textarea-bordered textarea w-full"
 								rows={3}
 								placeholder="変更理由を入力してください（任意）"

--- a/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.test.tsx
@@ -86,7 +86,7 @@ describe('CreateOneOffShiftDialog', () => {
 			/>,
 		);
 
-		const serviceTypeSelect = screen.getAllByRole('combobox')[1];
+		const serviceTypeSelect = screen.getByLabelText('サービス種別');
 		await user.selectOptions(serviceTypeSelect, 'life-support');
 
 		await user.click(screen.getByRole('button', { name: '保存' }));
@@ -230,7 +230,7 @@ describe('CreateOneOffShiftDialog', () => {
 			/>,
 		);
 
-		const clientSelect = screen.getAllByRole('combobox')[0];
+		const clientSelect = screen.getByLabelText('利用者');
 		expect(clientSelect).toHaveValue(TEST_IDS.CLIENT_2);
 	});
 
@@ -249,7 +249,7 @@ describe('CreateOneOffShiftDialog', () => {
 			/>,
 		);
 
-		const clientSelect = screen.getAllByRole('combobox')[0];
+		const clientSelect = screen.getByLabelText('利用者');
 		expect(clientSelect).toHaveValue(TEST_IDS.CLIENT_1);
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
@@ -105,6 +105,9 @@ export const CreateOneOffShiftDialog = ({
 	const dateInputId = `${inputIdBase}-date`;
 	const startTimeInputId = `${inputIdBase}-start-time`;
 	const endTimeInputId = `${inputIdBase}-end-time`;
+	const clientSelectId = `${inputIdBase}-client`;
+	const serviceTypeSelectId = `${inputIdBase}-service-type`;
+	const staffSelectId = `${inputIdBase}-staff`;
 
 	const router = useRouter();
 	const { handleActionResult } = useActionResultHandler();
@@ -256,10 +259,11 @@ export const CreateOneOffShiftDialog = ({
 					</div>
 
 					<div>
-						<label className="label">
+						<label className="label" htmlFor={clientSelectId}>
 							<span className="label-text font-medium">利用者</span>
 						</label>
 						<select
+							id={clientSelectId}
 							className="select-bordered select w-full"
 							value={clientId}
 							onChange={(e) => setClientId(e.target.value)}
@@ -274,10 +278,11 @@ export const CreateOneOffShiftDialog = ({
 					</div>
 
 					<div>
-						<label className="label">
+						<label className="label" htmlFor={serviceTypeSelectId}>
 							<span className="label-text font-medium">サービス種別</span>
 						</label>
 						<select
+							id={serviceTypeSelectId}
 							className="select-bordered select w-full"
 							value={serviceTypeId}
 							onChange={(e) =>
@@ -295,10 +300,11 @@ export const CreateOneOffShiftDialog = ({
 					</div>
 
 					<div>
-						<label className="label">
+						<label className="label" htmlFor={staffSelectId}>
 							<span className="label-text font-medium">スタッフ（任意）</span>
 						</label>
 						<select
+							id={staffSelectId}
 							className="select-bordered select w-full"
 							value={staffId}
 							onChange={(e) => setStaffId(e.target.value)}


### PR DESCRIPTION
概要
- 週次画面にある3つのダイアログのアクセシビリティを改善しました。

変更点
- 週次3ダイアログのlabel紐づけ
- useIdでid生成
- UTをgetByLabelText/getByRole(name)に寄せた

関連
- Refs #47 (Phase 1)

テスト
- `pnpm test:ut --run` の結果: 691 passed | 1 skipped (692)
