### PR TITLE
fix: StaffPickerFilters の a11y ラベル追加

### DIFF
--- a/src/app/admin/basic-schedules/_components/StaffPickerDialog/StaffPickerDialog.test.tsx
+++ b/src/app/admin/basic-schedules/_components/StaffPickerDialog/StaffPickerDialog.test.tsx
@@ -40,15 +40,12 @@ describe('StaffPickerDialog', () => {
 		const user = userEvent.setup();
 		renderDialog();
 
-		await user.type(
-			screen.getByPlaceholderText('氏名・サービス区分で検索'),
-			'花子',
-		);
+		await user.type(screen.getByLabelText('担当者検索'), '花子');
 		expect(screen.queryByText('山田太郎')).not.toBeInTheDocument();
 		expect(screen.getByText('佐藤花子')).toBeInTheDocument();
 
-		await user.clear(screen.getByPlaceholderText('氏名・サービス区分で検索'));
-		await user.selectOptions(screen.getByDisplayValue('すべて'), 'ヘルパー');
+		await user.clear(screen.getByLabelText('担当者検索'));
+		await user.selectOptions(screen.getByLabelText('ロール'), 'ヘルパー');
 		expect(screen.queryByText('山田太郎')).not.toBeInTheDocument();
 		expect(screen.getByText('佐藤花子')).toBeInTheDocument();
 	});

--- a/src/app/admin/basic-schedules/_components/StaffPickerDialog/StaffPickerFilters.test.tsx
+++ b/src/app/admin/basic-schedules/_components/StaffPickerDialog/StaffPickerFilters.test.tsx
@@ -31,18 +31,15 @@ describe('StaffPickerFilters', () => {
 			/>,
 		);
 
-		fireEvent.change(screen.getByPlaceholderText('氏名・サービス区分で検索'), {
+		fireEvent.change(screen.getByLabelText('担当者検索'), {
 			target: { value: 'taro' },
 		});
 		expect(handleKeywordChange).toHaveBeenLastCalledWith('taro');
 
-		await user.selectOptions(screen.getByDisplayValue('すべて'), '管理者');
+		await user.selectOptions(screen.getByLabelText('ロール'), '管理者');
 		expect(handleRoleFilterChange).toHaveBeenLastCalledWith('admin');
 
-		await user.selectOptions(
-			screen.getByDisplayValue('すべてのサービス区分'),
-			'身体介護',
-		);
+		await user.selectOptions(screen.getByLabelText('サービス区分'), '身体介護');
 		expect(handleServiceFilterChange).toHaveBeenLastCalledWith('physical-care');
 
 		await user.click(screen.getByRole('button', { name: '選択をクリア' }));

--- a/src/app/admin/basic-schedules/_components/StaffPickerDialog/StaffPickerFilters.tsx
+++ b/src/app/admin/basic-schedules/_components/StaffPickerDialog/StaffPickerFilters.tsx
@@ -31,12 +31,14 @@ export const StaffPickerFilters = ({
 	<div className="mt-4 flex flex-col gap-3 sm:flex-row">
 		<input
 			type="search"
+			aria-label="担当者検索"
 			placeholder="氏名・サービス区分で検索"
 			className="input-bordered input w-full"
 			value={keyword}
 			onChange={(event) => onKeywordChange(event.target.value)}
 		/>
 		<FormSelect
+			aria-label="ロール"
 			className="select-bordered select w-full sm:max-w-40"
 			value={roleFilter}
 			onChange={(event) => onRoleFilterChange(event.target.value as RoleFilter)}
@@ -46,6 +48,7 @@ export const StaffPickerFilters = ({
 			}))}
 		/>
 		<FormSelect
+			aria-label="サービス区分"
 			className="select-bordered select w-full sm:max-w-48"
 			value={serviceFilter}
 			onChange={(event) =>


### PR DESCRIPTION
変更点:
- 検索/ロール/サービス区分に aria-label 追加
- UT を getByLabelText に移行

テスト: `pnpm test:ut --run` 実行済み

Closes #47
