### PR TITLE
feat: 日時変更リクエストのスキーマ追加

### DIFF
--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -1,6 +1,6 @@
+import { ClientStaffAssignmentRepository } from '@/backend/repositories/clientStaffAssignmentRepository';
 import { ShiftRepository } from '@/backend/repositories/shiftRepository';
 import { StaffRepository } from '@/backend/repositories/staffRepository';
-import { ClientStaffAssignmentRepository } from '@/backend/repositories/clientStaffAssignmentRepository';
 import { Database } from '@/backend/types/supabase';
 import { Shift } from '@/models/shift';
 import { Staff, StaffWithServiceTypes } from '@/models/staff';
@@ -211,9 +211,14 @@ describe('ShiftAdjustmentSuggestionService', () => {
 		expect(result.affected).toHaveLength(1);
 		const [affected] = result.affected;
 		expect(affected.shift.id).toBe(TEST_IDS.SCHEDULE_1);
-		expect(
-			affected.suggestions.map((s) => s.operations[0].to_staff_id),
-		).toEqual([candidateAId, candidateDId]);
+		const toStaffIds = affected.suggestions.map((s) => {
+			const op = s.operations[0];
+			if (!op || op.type !== 'change_staff') {
+				throw new Error(`unexpected operation type: ${op?.type ?? 'missing'}`);
+			}
+			return op.to_staff_id;
+		});
+		expect(toStaffIds).toEqual([candidateAId, candidateDId]);
 		expect(affected.suggestions[0]?.rationale.map((r) => r.code)).toEqual([
 			'service_type_ok',
 			'no_conflict',
@@ -296,9 +301,13 @@ describe('ShiftAdjustmentSuggestionService', () => {
 			endDate: new Date('2026-02-28T00:00:00+09:00'),
 		});
 
-		const toStaffIds = result.affected[0]?.suggestions.map(
-			(s) => s.operations[0].to_staff_id,
-		);
+		const toStaffIds = result.affected[0]?.suggestions.map((s) => {
+			const op = s.operations[0];
+			if (!op || op.type !== 'change_staff') {
+				throw new Error(`unexpected operation type: ${op?.type ?? 'missing'}`);
+			}
+			return op.to_staff_id;
+		});
 		expect(toStaffIds).toEqual([helperCandidateId]);
 		expect(toStaffIds).not.toContain(adminCandidateId);
 	});
@@ -360,9 +369,13 @@ describe('ShiftAdjustmentSuggestionService', () => {
 			endDate: new Date('2026-02-28T00:00:00+09:00'),
 		});
 
-		const toStaffIds = result.affected[0]?.suggestions.map(
-			(s) => s.operations[0].to_staff_id,
-		);
+		const toStaffIds = result.affected[0]?.suggestions.map((s) => {
+			const op = s.operations[0];
+			if (!op || op.type !== 'change_staff') {
+				throw new Error(`unexpected operation type: ${op?.type ?? 'missing'}`);
+			}
+			return op.to_staff_id;
+		});
 		expect(toStaffIds).toEqual([allowedCandidateId]);
 		expect(toStaffIds).not.toContain(notAllowedCandidateId);
 	});

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -1,6 +1,11 @@
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { describe, expect, it } from 'vitest';
-import { StaffAbsenceInputSchema } from './shiftAdjustmentActionSchemas';
+import {
+	ShiftAdjustmentOperationSchema,
+	ShiftAdjustmentRequestSchema,
+	StaffAbsenceInputSchema,
+	SuggestShiftAdjustmentsOutputSchema,
+} from './shiftAdjustmentActionSchemas';
 
 describe('StaffAbsenceInputSchema', () => {
 	it('start=1日目, end=14日目 は OK（最大14日）', () => {
@@ -44,5 +49,99 @@ describe('StaffAbsenceInputSchema', () => {
 			);
 			expect(result.error.issues[0]?.path).toEqual(['endDate']);
 		}
+	});
+
+	it('startDate === endDate は OK（回帰）', () => {
+		const result = StaffAbsenceInputSchema.safeParse({
+			staffId: TEST_IDS.STAFF_1,
+			startDate: '2026-02-01',
+			endDate: '2026-02-01',
+		});
+
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('ShiftAdjustmentRequestSchema', () => {
+	it('type=staff_absence を受け付ける', () => {
+		const result = ShiftAdjustmentRequestSchema.safeParse({
+			type: 'staff_absence',
+			payload: {
+				staffId: TEST_IDS.STAFF_1,
+				startDate: '2026-02-01',
+				endDate: '2026-02-01',
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('type=client_datetime_change を受け付ける', () => {
+		const result = ShiftAdjustmentRequestSchema.safeParse({
+			type: 'client_datetime_change',
+			payload: {
+				shiftId: TEST_IDS.SCHEDULE_1,
+				newDate: '2026-02-03',
+				newStartTime: { hour: 9, minute: 0 },
+				newEndTime: { hour: 10, minute: 0 },
+				memo: '利用者都合',
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('ShiftAdjustmentOperationSchema', () => {
+	it('type=change_staff を受け付ける', () => {
+		const result = ShiftAdjustmentOperationSchema.safeParse({
+			type: 'change_staff',
+			shift_id: TEST_IDS.SCHEDULE_1,
+			from_staff_id: TEST_IDS.STAFF_1,
+			to_staff_id: TEST_IDS.STAFF_2,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('type=update_shift_schedule を受け付ける', () => {
+		const result = ShiftAdjustmentOperationSchema.safeParse({
+			type: 'update_shift_schedule',
+			shift_id: TEST_IDS.SCHEDULE_1,
+			new_date: '2026-02-03',
+			new_start_time: { hour: 9, minute: 0 },
+			new_end_time: { hour: 10, minute: 0 },
+		});
+
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('SuggestShiftAdjustmentsOutputSchema', () => {
+	it('meta が無くてもパースできる（後方互換）', () => {
+		const result = SuggestShiftAdjustmentsOutputSchema.safeParse({
+			absence: {
+				staffId: TEST_IDS.STAFF_1,
+				startDate: '2026-02-01',
+				endDate: '2026-02-01',
+			},
+			affected: [],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('meta.timedOut を受け付ける', () => {
+		const result = SuggestShiftAdjustmentsOutputSchema.safeParse({
+			meta: { timedOut: true },
+			absence: {
+				staffId: TEST_IDS.STAFF_1,
+				startDate: '2026-02-01',
+				endDate: '2026-02-01',
+			},
+			affected: [],
+		});
+
+		expect(result.success).toBe(true);
 	});
 });

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -107,7 +107,10 @@ export const ShiftSnapshotSchema = z.object({
 export type ShiftSnapshot = z.infer<typeof ShiftSnapshotSchema>;
 
 /**
- * 操作（Phase 1: change_staff のみ、1手のみ）
+ * 操作（`change_staff` または `update_shift_schedule`）
+ *
+ * - `ShiftAdjustmentOperationSchema` は上記2種類の discriminated union
+ * - 提案（ShiftAdjustmentSuggestion）では operations が最大2件になり得る
  */
 const ChangeStaffShiftAdjustmentOperationSchema = z.object({
 	type: z.literal('change_staff'),
@@ -180,6 +183,7 @@ export type ShiftAdjustmentShiftSuggestion = z.infer<
 export const SuggestShiftAdjustmentsOutputSchema = z.object({
 	meta: z
 		.object({
+			// 後方互換のため optional（旧クライアントでもパースできるようにする）
 			timedOut: z.boolean().optional(),
 		})
 		.optional(),

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -8,6 +8,24 @@ import { TimeRangeSchema } from './valueObjects/timeRange';
 
 const toJstDay = (date: Date) => dateJst(date).startOf('day');
 
+const addTimeRangeValidationIssues = (
+	ctx: z.core.$RefinementCtx,
+	start: unknown,
+	end: unknown,
+	startField: string,
+	endField: string,
+) => {
+	const parsed = TimeRangeSchema.safeParse({ start, end });
+	if (!parsed.success) {
+		parsed.error.issues.forEach((issue) => {
+			const mappedPath = issue.path.map((p) =>
+				p === 'start' ? startField : p === 'end' ? endField : p,
+			);
+			ctx.addIssue({ ...issue, path: mappedPath });
+		});
+	}
+};
+
 /**
  * staff_absence（スタッフ急休）入力（Phase 1: DB永続化なし）
  */
@@ -51,18 +69,13 @@ export const ClientDatetimeChangeInputSchema = z
 		memo: z.string().max(500).optional(),
 	})
 	.superRefine((val, ctx) => {
-		const parsed = TimeRangeSchema.safeParse({
-			start: val.newStartTime,
-			end: val.newEndTime,
-		});
-		if (!parsed.success) {
-			parsed.error.issues.forEach((issue) => {
-				const mappedPath = issue.path.map((p) =>
-					p === 'start' ? 'newStartTime' : p === 'end' ? 'newEndTime' : p,
-				);
-				ctx.addIssue({ ...issue, path: mappedPath });
-			});
-		}
+		addTimeRangeValidationIssues(
+			ctx,
+			val.newStartTime,
+			val.newEndTime,
+			'newStartTime',
+			'newEndTime',
+		);
 	});
 
 export type ClientDatetimeChangeInput = z.output<
@@ -128,18 +141,13 @@ const UpdateShiftScheduleShiftAdjustmentOperationSchema = z
 		new_end_time: TimeValueSchema,
 	})
 	.superRefine((val, ctx) => {
-		const parsed = TimeRangeSchema.safeParse({
-			start: val.new_start_time,
-			end: val.new_end_time,
-		});
-		if (!parsed.success) {
-			parsed.error.issues.forEach((issue) => {
-				const mappedPath = issue.path.map((p) =>
-					p === 'start' ? 'new_start_time' : p === 'end' ? 'new_end_time' : p,
-				);
-				ctx.addIssue({ ...issue, path: mappedPath });
-			});
-		}
+		addTimeRangeValidationIssues(
+			ctx,
+			val.new_start_time,
+			val.new_end_time,
+			'new_start_time',
+			'new_end_time',
+		);
 	});
 
 export const ShiftAdjustmentOperationSchema = z.discriminatedUnion('type', [


### PR DESCRIPTION
## 概要
- 日時変更リクエスト用のスキーマを追加します（モデルのみ）。

## 変更点（要点）
- `request` union に `client_datetime_change` を追加
- `operations` union に `update_shift_schedule` を追加
- `output` に `meta.timedOut` を optional（後方互換のため）で追加

## 備考（最小追随）
- 型変更に伴う最小限の追随対応を含めています。具体的には `ShiftAdjustmentDialog` と関連する service のテストを更新しています。

## テスト
- ユニットテストを実行済み: `pnpm test:ut --run`

## 関連
- Refs #54

---
レビューとマージの際は `meta.timedOut` が optional であることに注意してください（後方互換のため）。
