### PR TITLE
fix: stacked PR56 を develop に取り込み

### DIFF
--- a/.github/agents/implement.agent.md
+++ b/.github/agents/implement.agent.md
@@ -46,7 +46,7 @@ tools:
     github/update_pull_request_branch,
     todo,
   ]
-model: Claude Opus 4.5 (copilot)
+model: GPT-5.3-Codex (copilot)
 ---
 
 あなたは TDD の原則に従って実装を行うエージェントです。指定された計画に基づき、テストを先に書いてから最小限の実装を行います。

--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -80,6 +80,28 @@ const createShift = (overrides: Partial<Shift> = {}): Shift => ({
 	...overrides,
 });
 
+type ShiftListFilters = Parameters<ShiftRepository['list']>[0];
+
+const buildShiftListKey = (filters: ShiftListFilters = {}): string => {
+	// JSON.stringify は Date を toJSON() (= ISO文字列) に変換する
+	// undefined は省略されるので、filters の組み合わせで一意なキーになる
+	return JSON.stringify({
+		officeId: filters.officeId,
+		clientId: filters.clientId,
+		status: filters.status,
+		startDate: filters.startDate,
+		endDate: filters.endDate,
+		startDateTime: filters.startDateTime,
+		endDateTime: filters.endDateTime,
+	});
+};
+
+const createShiftListMock = (table: Record<string, Shift[]>) => {
+	return async (filters: ShiftListFilters = {}) => {
+		return table[buildShiftListKey(filters)] ?? [];
+	};
+};
+
 describe('ShiftAdjustmentSuggestionService', () => {
 	let service: ShiftAdjustmentSuggestionService;
 	let mockStaffRepo: Mocked<StaffRepository>;
@@ -680,27 +702,22 @@ describe('ShiftAdjustmentSuggestionService', () => {
 				service_type_id: 'life-support',
 			});
 
-			mockShiftRepo.list.mockImplementation(async (filters = {}) => {
-				const start = filters.startDate?.toISOString();
-				const end = filters.endDate?.toISOString();
-				if (
-					filters.officeId === TEST_IDS.OFFICE_1 &&
-					filters.clientId === TEST_IDS.CLIENT_1 &&
-					start === targetShift.date.toISOString() &&
-					end === targetShift.date.toISOString()
-				) {
-					return [targetShift];
-				}
-				if (
-					filters.officeId === TEST_IDS.OFFICE_1 &&
-					filters.status === 'scheduled' &&
-					start === new Date('2026-02-25T00:00:00+09:00').toISOString() &&
-					end === new Date('2026-02-25T00:00:00+09:00').toISOString()
-				) {
-					return [conflictShiftForA];
-				}
-				return [];
-			});
+			mockShiftRepo.list.mockImplementation(
+				createShiftListMock({
+					[buildShiftListKey({
+						officeId: TEST_IDS.OFFICE_1,
+						clientId: TEST_IDS.CLIENT_1,
+						startDate: targetShift.date,
+						endDate: targetShift.date,
+					})]: [targetShift],
+					[buildShiftListKey({
+						officeId: TEST_IDS.OFFICE_1,
+						status: 'scheduled',
+						startDate: new Date('2026-02-25T00:00:00+09:00'),
+						endDate: new Date('2026-02-25T00:00:00+09:00'),
+					})]: [conflictShiftForA],
+				}),
+			);
 
 			mockClientStaffAssignmentRepo.listLinksByOfficeAndClientIds.mockResolvedValueOnce(
 				[
@@ -792,27 +809,22 @@ describe('ShiftAdjustmentSuggestionService', () => {
 				service_type_id: 'life-support',
 			});
 
-			mockShiftRepo.list.mockImplementation(async (filters = {}) => {
-				const start = filters.startDate?.toISOString();
-				const end = filters.endDate?.toISOString();
-				if (
-					filters.officeId === TEST_IDS.OFFICE_1 &&
-					filters.clientId === TEST_IDS.CLIENT_1 &&
-					start === targetShift.date.toISOString() &&
-					end === targetShift.date.toISOString()
-				) {
-					return [targetShift];
-				}
-				if (
-					filters.officeId === TEST_IDS.OFFICE_1 &&
-					filters.status === 'scheduled' &&
-					start === new Date('2026-02-25T00:00:00+09:00').toISOString() &&
-					end === new Date('2026-02-25T00:00:00+09:00').toISOString()
-				) {
-					return [conflictShift];
-				}
-				return [];
-			});
+			mockShiftRepo.list.mockImplementation(
+				createShiftListMock({
+					[buildShiftListKey({
+						officeId: TEST_IDS.OFFICE_1,
+						clientId: TEST_IDS.CLIENT_1,
+						startDate: targetShift.date,
+						endDate: targetShift.date,
+					})]: [targetShift],
+					[buildShiftListKey({
+						officeId: TEST_IDS.OFFICE_1,
+						status: 'scheduled',
+						startDate: new Date('2026-02-25T00:00:00+09:00'),
+						endDate: new Date('2026-02-25T00:00:00+09:00'),
+					})]: [conflictShift],
+				}),
+			);
 
 			mockClientStaffAssignmentRepo.listLinksByOfficeAndClientIds.mockResolvedValueOnce(
 				[
@@ -912,27 +924,22 @@ describe('ShiftAdjustmentSuggestionService', () => {
 				service_type_id: 'life-support',
 			});
 			mockShiftRepo.findById.mockResolvedValueOnce(targetShift);
-			mockShiftRepo.list.mockImplementation(async (filters = {}) => {
-				const start = filters.startDate?.toISOString();
-				const end = filters.endDate?.toISOString();
-				if (
-					filters.officeId === TEST_IDS.OFFICE_1 &&
-					filters.clientId === TEST_IDS.CLIENT_1 &&
-					start === targetShift.date.toISOString() &&
-					end === targetShift.date.toISOString()
-				) {
-					return [targetShift];
-				}
-				if (
-					filters.officeId === TEST_IDS.OFFICE_1 &&
-					filters.status === 'scheduled' &&
-					start === new Date('2026-02-25T00:00:00+09:00').toISOString() &&
-					end === new Date('2026-02-25T00:00:00+09:00').toISOString()
-				) {
-					return [conflictShiftForA];
-				}
-				return [];
-			});
+			mockShiftRepo.list.mockImplementation(
+				createShiftListMock({
+					[buildShiftListKey({
+						officeId: TEST_IDS.OFFICE_1,
+						clientId: TEST_IDS.CLIENT_1,
+						startDate: targetShift.date,
+						endDate: targetShift.date,
+					})]: [targetShift],
+					[buildShiftListKey({
+						officeId: TEST_IDS.OFFICE_1,
+						status: 'scheduled',
+						startDate: new Date('2026-02-25T00:00:00+09:00'),
+						endDate: new Date('2026-02-25T00:00:00+09:00'),
+					})]: [conflictShiftForA],
+				}),
+			);
 
 			mockClientStaffAssignmentRepo.listLinksByOfficeAndClientIds.mockResolvedValueOnce(
 				[

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -887,16 +887,7 @@ export class ShiftAdjustmentSuggestionService {
 		absence: StaffAbsenceInput,
 	): Promise<SuggestShiftAdjustmentsOutput> {
 		const adminStaff = await this.getAdminStaff(userId);
-
-		const startedAt = this.now();
-		let timedOut = false;
-		const checkTimeout = () => {
-			if (this.now() - startedAt > this.maxExecutionMs) {
-				timedOut = true;
-				return true;
-			}
-			return false;
-		};
+		const { checkTimeout, isTimedOut } = this.createTimeoutChecker();
 
 		const validatedAbsence = this.validateAbsence(absence);
 
@@ -953,7 +944,7 @@ export class ShiftAdjustmentSuggestionService {
 		}
 
 		return {
-			...(timedOut ? { meta: { timedOut: true } } : {}),
+			...(isTimedOut() ? { meta: { timedOut: true } } : {}),
 			absence: validatedAbsence,
 			affected,
 		};


### PR DESCRIPTION
PR56 が baseRef=`feat/issue-54-pr1a-models` にマージされたため、同ブランチの変更を `develop` に取り込むための PR です。

含まれる主な変更:
- `client_datetime_change` の Service 実装とユニットテスト (UT)

背景:
- マージコミット `c83cf727844bbd3afdf34b5af6856932182c1092` は PR56 によって作られました。

検証:
- この PR の作成後に、PR のコミット一覧または head ブランチが上記コミットを包含していることを確認してください。

(自動作成された PR です — レビュアーに Copilot を追加してください)