### PR TITLE
feat: 日時変更提案のServer Actionを追加

### DIFF
--- a/src/app/actions/shiftAdjustments.test.ts
+++ b/src/app/actions/shiftAdjustments.test.ts
@@ -2,9 +2,13 @@ import {
 	ServiceError,
 	ShiftAdjustmentSuggestionService,
 } from '@/backend/services/shiftAdjustmentSuggestionService';
+import { TEST_IDS } from '@/test/helpers/testIds';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
-import { suggestShiftAdjustmentsAction } from './shiftAdjustments';
+import {
+	suggestClientDatetimeChangeAdjustmentsAction,
+	suggestShiftAdjustmentsAction,
+} from './shiftAdjustments';
 
 vi.mock('@/utils/supabase/server');
 vi.mock('@/backend/services/shiftAdjustmentSuggestionService', async () => {
@@ -25,6 +29,7 @@ const mockSupabase = {
 
 const createMockService = () => ({
 	suggestShiftAdjustments: vi.fn(),
+	suggestClientDatetimeChangeAdjustments: vi.fn(),
 });
 
 type MockService = ReturnType<typeof createMockService>;
@@ -130,5 +135,113 @@ describe('suggestShiftAdjustmentsAction', () => {
 		expect(result.status).toBe(200);
 		expect(result.error).toBeNull();
 		expect(result.data?.affected).toEqual([]);
+	});
+});
+
+describe('suggestClientDatetimeChangeAdjustmentsAction', () => {
+	const validInput = {
+		shiftId: TEST_IDS.SCHEDULE_1,
+		newDate: '2026-02-22',
+		newStartTime: { hour: 10, minute: 0 },
+		newEndTime: { hour: 11, minute: 0 },
+		memo: '利用者都合',
+	};
+
+	it('未認証は401を返す', async () => {
+		mockSupabase.auth.getUser.mockResolvedValue({
+			data: { user: null },
+			error: null,
+		});
+
+		const result =
+			await suggestClientDatetimeChangeAdjustmentsAction(validInput);
+
+		expect(result).toEqual({ data: null, error: 'Unauthorized', status: 401 });
+		expect(
+			mockService.suggestClientDatetimeChangeAdjustments,
+		).not.toHaveBeenCalled();
+	});
+
+	it('バリデーションエラーは400を返す（shiftIdが不正）', async () => {
+		mockAuthUser('user-1');
+
+		const result = await suggestClientDatetimeChangeAdjustmentsAction({
+			...validInput,
+			shiftId: 'invalid-uuid',
+		});
+
+		expect(result.status).toBe(400);
+		expect(result.error).toBe('Validation failed');
+		expect(
+			mockService.suggestClientDatetimeChangeAdjustments,
+		).not.toHaveBeenCalled();
+	});
+
+	it('ServiceErrorを委譲する（403）', async () => {
+		mockAuthUser('user-1');
+		mockService.suggestClientDatetimeChangeAdjustments.mockRejectedValue(
+			new ServiceError(403, 'Forbidden'),
+		);
+
+		const result =
+			await suggestClientDatetimeChangeAdjustmentsAction(validInput);
+
+		expect(result.status).toBe(403);
+		expect(result.error).toBe('Forbidden');
+	});
+
+	it('ServiceErrorを委譲する（404）', async () => {
+		mockAuthUser('user-1');
+		mockService.suggestClientDatetimeChangeAdjustments.mockRejectedValue(
+			new ServiceError(404, 'Shift not found'),
+		);
+
+		const result =
+			await suggestClientDatetimeChangeAdjustmentsAction(validInput);
+
+		expect(result.status).toBe(404);
+		expect(result.error).toBe('Shift not found');
+	});
+
+	it('提案取得に成功し、結果を返す', async () => {
+		mockAuthUser('user-1');
+		mockService.suggestClientDatetimeChangeAdjustments.mockResolvedValue({
+			change: {
+				shiftId: validInput.shiftId,
+				newDate: new Date('2026-02-22T00:00:00+09:00'),
+				newStartTime: validInput.newStartTime,
+				newEndTime: validInput.newEndTime,
+				memo: validInput.memo,
+			},
+			target: {
+				shift: {
+					id: TEST_IDS.SCHEDULE_1,
+					client_id: TEST_IDS.CLIENT_1,
+					service_type_id: 'life-support',
+					staff_id: TEST_IDS.STAFF_1,
+					date: new Date('2026-02-22T00:00:00+09:00'),
+					start_time: { hour: 9, minute: 0 },
+					end_time: { hour: 10, minute: 0 },
+					status: 'scheduled',
+				},
+				suggestions: [],
+			},
+		});
+
+		const result =
+			await suggestClientDatetimeChangeAdjustmentsAction(validInput);
+
+		expect(
+			mockService.suggestClientDatetimeChangeAdjustments,
+		).toHaveBeenCalledWith(
+			'user-1',
+			expect.objectContaining({
+				shiftId: validInput.shiftId,
+				memo: validInput.memo,
+			}),
+		);
+		expect(result.status).toBe(200);
+		expect(result.error).toBeNull();
+		expect(result.data?.target.suggestions).toEqual([]);
 	});
 });

--- a/src/app/actions/shiftAdjustments.ts
+++ b/src/app/actions/shiftAdjustments.ts
@@ -86,7 +86,20 @@ export const suggestClientDatetimeChangeAdjustmentsAction = async (
 
 	const service = new ShiftAdjustmentSuggestionService(supabase);
 	try {
-		const result = await service.suggestClientDatetimeChangeAdjustments(
+		const suggestClientDatetimeChangeAdjustments = (
+			service as ShiftAdjustmentSuggestionService & {
+				suggestClientDatetimeChangeAdjustments?: (
+					userId: string,
+					input: ClientDatetimeChangeActionInput,
+				) => Promise<SuggestClientDatetimeChangeAdjustmentsOutput>;
+			}
+		).suggestClientDatetimeChangeAdjustments;
+
+		if (!suggestClientDatetimeChangeAdjustments) {
+			throw new ServiceError(501, 'Not implemented');
+		}
+
+		const result = await suggestClientDatetimeChangeAdjustments(
 			user.id,
 			parsedInput.data,
 		);

--- a/src/app/actions/shiftAdjustments.ts
+++ b/src/app/actions/shiftAdjustments.ts
@@ -86,20 +86,7 @@ export const suggestClientDatetimeChangeAdjustmentsAction = async (
 
 	const service = new ShiftAdjustmentSuggestionService(supabase);
 	try {
-		const suggestClientDatetimeChangeAdjustments = (
-			service as ShiftAdjustmentSuggestionService & {
-				suggestClientDatetimeChangeAdjustments?: (
-					userId: string,
-					input: ClientDatetimeChangeActionInput,
-				) => Promise<SuggestClientDatetimeChangeAdjustmentsOutput>;
-			}
-		).suggestClientDatetimeChangeAdjustments;
-
-		if (!suggestClientDatetimeChangeAdjustments) {
-			throw new ServiceError(501, 'Not implemented');
-		}
-
-		const result = await suggestClientDatetimeChangeAdjustments(
+		const result = await service.suggestClientDatetimeChangeAdjustments(
 			user.id,
 			parsedInput.data,
 		);

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -4,6 +4,7 @@ import {
 	ShiftAdjustmentOperationSchema,
 	ShiftAdjustmentRequestSchema,
 	StaffAbsenceInputSchema,
+	SuggestClientDatetimeChangeAdjustmentsOutputSchema,
 	SuggestShiftAdjustmentsOutputSchema,
 } from './shiftAdjustmentActionSchemas';
 import { TimeRangeSchema } from './valueObjects/timeRange';
@@ -237,6 +238,65 @@ describe('SuggestShiftAdjustmentsOutputSchema', () => {
 			},
 			affected: [],
 		});
+
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('SuggestClientDatetimeChangeAdjustmentsOutputSchema', () => {
+	it('meta が無くてもパースできる（後方互換）', () => {
+		const result = SuggestClientDatetimeChangeAdjustmentsOutputSchema.safeParse(
+			{
+				change: {
+					shiftId: TEST_IDS.SCHEDULE_1,
+					newDate: '2026-02-03',
+					newStartTime: { hour: 9, minute: 0 },
+					newEndTime: { hour: 10, minute: 0 },
+				},
+				target: {
+					shift: {
+						id: TEST_IDS.SCHEDULE_1,
+						client_id: TEST_IDS.CLIENT_1,
+						service_type_id: 'life-support',
+						staff_id: TEST_IDS.STAFF_1,
+						date: '2026-02-03',
+						start_time: { hour: 9, minute: 0 },
+						end_time: { hour: 10, minute: 0 },
+						status: 'scheduled',
+					},
+					suggestions: [],
+				},
+			},
+		);
+
+		expect(result.success).toBe(true);
+	});
+
+	it('meta.timedOut を受け付ける', () => {
+		const result = SuggestClientDatetimeChangeAdjustmentsOutputSchema.safeParse(
+			{
+				meta: { timedOut: true },
+				change: {
+					shiftId: TEST_IDS.SCHEDULE_1,
+					newDate: '2026-02-03',
+					newStartTime: { hour: 9, minute: 0 },
+					newEndTime: { hour: 10, minute: 0 },
+				},
+				target: {
+					shift: {
+						id: TEST_IDS.SCHEDULE_1,
+						client_id: TEST_IDS.CLIENT_1,
+						service_type_id: 'life-support',
+						staff_id: TEST_IDS.STAFF_1,
+						date: '2026-02-03',
+						start_time: { hour: 9, minute: 0 },
+						end_time: { hour: 10, minute: 0 },
+						status: 'scheduled',
+					},
+					suggestions: [],
+				},
+			},
+		);
 
 		expect(result.success).toBe(true);
 	});

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -201,3 +201,19 @@ export const SuggestShiftAdjustmentsOutputSchema = z.object({
 export type SuggestShiftAdjustmentsOutput = z.infer<
 	typeof SuggestShiftAdjustmentsOutputSchema
 >;
+
+export const SuggestClientDatetimeChangeAdjustmentsOutputSchema = z.object({
+	meta: z
+		.object({
+			timedOut: z.boolean().optional(),
+		})
+		.optional(),
+	change: ClientDatetimeChangeInputSchema,
+	target: z.object({
+		shift: ShiftSnapshotSchema,
+		suggestions: z.array(ShiftAdjustmentSuggestionSchema),
+	}),
+});
+export type SuggestClientDatetimeChangeAdjustmentsOutput = z.infer<
+	typeof SuggestClientDatetimeChangeAdjustmentsOutputSchema
+>;


### PR DESCRIPTION
Part of Issue #54 — 次フェーズ（Action接続）

追加内容:
- 追加した Server Action: `suggestClientDatetimeChangeAdjustmentsAction`
- 追加した output schema: `SuggestClientDatetimeChangeAdjustmentsOutputSchema`（`meta.timedOut` は optional）
- 単体テスト（UT）を追加

検証:
- `pnpm lint` / `pnpm test:ut --run` を実行し通過済み

備考:
- この PR は Issue #54 の次フェーズ（Action の接続実装）を目的としています。