### PR TITLE
fix: ShiftAdjustmentDialog再オープン時の状態リセット

### DIFF
--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.tsx
@@ -18,7 +18,7 @@ import {
 	getJstDateOnly,
 	stringToTimeObject,
 } from '@/utils/date';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ShiftDisplayRow } from '../ShiftTable';
 
 type ShiftAdjustmentDialogProps = {
@@ -97,6 +97,24 @@ export const ShiftAdjustmentDialog = ({
 		useState<SuggestShiftAdjustmentsOutput | null>(null);
 	const [clientResultData, setClientResultData] =
 		useState<SuggestClientDatetimeChangeAdjustmentsOutput | null>(null);
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		setAdjustmentType('staff_absence');
+		setStaffId('');
+		setStartDateStr(formatJstDateString(weekStartDate));
+		setEndDateStr(formatJstDateString(weekEndDate));
+		setTargetShiftId('');
+		setNewDateStr(formatJstDateString(weekStartDate));
+		setNewStartTime('09:00');
+		setNewEndTime('10:00');
+		setMemo('');
+		setIsSubmitting(false);
+		setErrorMessage(null);
+		setResultData(null);
+		setClientResultData(null);
+	}, [isOpen, weekStartDate, weekEndDate]);
 
 	const shiftMap = useMemo(() => {
 		const map = new Map<string, ShiftDisplayRow>();


### PR DESCRIPTION
## 概要
PR #61 の指摘（discussion_r2839244892）対応です。

ShiftAdjustmentDialog を閉じて再度開いた際に、前回の入力値・エラー・提案結果が残る問題を修正しました。

## 変更内容
- isOpen が true になったタイミングで state を初期化する useEffect を追加
  - 初期化対象: 欠勤入力（staffId, startDateStr, endDateStr）、日時変更入力（targetShiftId, newDateStr, newStartTime, newEndTime）、memo
  - 画面状態: errorMessage, resultData, clientResultData, adjustmentType, isSubmitting
- 再オープン時の初期化を検証する UT を追加

## テスト
- pnpm lint
- pnpm test:ut --run
