### PR TITLE
fix: Issue #63 バリデーション失敗時ログとShiftAdjustmentDialogのエラー処理改善

### DIFF
--- a/.github/agents/plan.agent.md
+++ b/.github/agents/plan.agent.md
@@ -68,7 +68,7 @@ tools:
     ms-vscode.vscode-websearchforcopilot/websearch,
     todo,
   ]
-model: GPT-5.2 (copilot)
+model: Claude Sonnet 4.6 (copilot)
 ---
 
 与えられたイシューの実装計画を立ててください。

--- a/src/app/actions/shiftAdjustments.test.ts
+++ b/src/app/actions/shiftAdjustments.test.ts
@@ -37,6 +37,7 @@ let mockService: MockService;
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	vi.spyOn(console, 'error').mockImplementation(() => {});
 	mockService = createMockService();
 	mockSupabase.auth.getUser.mockReset();
 	(createSupabaseClient as Mock).mockResolvedValue(mockSupabase);
@@ -84,6 +85,26 @@ describe('suggestShiftAdjustmentsAction', () => {
 
 		expect(result.status).toBe(400);
 		expect(result.error).toBe('Validation failed');
+		expect(console.error).toHaveBeenCalledWith(
+			'suggestShiftAdjustmentsAction validation failed',
+			expect.objectContaining({
+				issues: expect.arrayContaining([
+					expect.objectContaining({
+						path: ['staffId'],
+						code: 'invalid_format',
+					}),
+				]),
+			}),
+		);
+		expect(Array.isArray(result.details)).toBe(true);
+		expect(result.details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					path: ['staffId'],
+					code: 'invalid_format',
+				}),
+			]),
+		);
 		expect(mockService.suggestShiftAdjustments).not.toHaveBeenCalled();
 	});
 
@@ -172,6 +193,26 @@ describe('suggestClientDatetimeChangeAdjustmentsAction', () => {
 
 		expect(result.status).toBe(400);
 		expect(result.error).toBe('Validation failed');
+		expect(console.error).toHaveBeenCalledWith(
+			'suggestClientDatetimeChangeAdjustmentsAction validation failed',
+			expect.objectContaining({
+				issues: expect.arrayContaining([
+					expect.objectContaining({
+						path: ['shiftId'],
+						code: 'invalid_format',
+					}),
+				]),
+			}),
+		);
+		expect(Array.isArray(result.details)).toBe(true);
+		expect(result.details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					path: ['shiftId'],
+					code: 'invalid_format',
+				}),
+			]),
+		);
 		expect(
 			mockService.suggestClientDatetimeChangeAdjustments,
 		).not.toHaveBeenCalled();

--- a/src/app/actions/shiftAdjustments.ts
+++ b/src/app/actions/shiftAdjustments.ts
@@ -24,6 +24,15 @@ import {
 	successResult,
 } from './utils/actionResult';
 
+const toSanitizedIssues = (
+	issues: Array<{ path: PropertyKey[]; code: string; message: string }>,
+) =>
+	issues.map((issue) => ({
+		path: issue.path,
+		code: issue.code,
+		message: issue.message,
+	}));
+
 const getAuthUser = async () => {
 	const supabase = await createSupabaseClient();
 	const {
@@ -55,7 +64,11 @@ export const suggestShiftAdjustmentsAction = async (
 
 	const parsedInput = StaffAbsenceInputSchema.safeParse(input);
 	if (!parsedInput.success) {
-		return errorResult('Validation failed', 400, parsedInput.error.flatten());
+		const issues = toSanitizedIssues(parsedInput.error.issues);
+		console.error('suggestShiftAdjustmentsAction validation failed', {
+			issues,
+		});
+		return errorResult('Validation failed', 400, issues);
 	}
 
 	const service = new ShiftAdjustmentSuggestionService(supabase);
@@ -81,7 +94,12 @@ export const suggestClientDatetimeChangeAdjustmentsAction = async (
 
 	const parsedInput = ClientDatetimeChangeInputSchema.safeParse(input);
 	if (!parsedInput.success) {
-		return errorResult('Validation failed', 400, parsedInput.error.flatten());
+		const issues = toSanitizedIssues(parsedInput.error.issues);
+		console.error(
+			'suggestClientDatetimeChangeAdjustmentsAction validation failed',
+			{ issues },
+		);
+		return errorResult('Validation failed', 400, issues);
 	}
 
 	const service = new ShiftAdjustmentSuggestionService(supabase);

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ClientDatetimeChangeForm.tsx
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ClientDatetimeChangeForm.tsx
@@ -1,0 +1,103 @@
+import { formatJstDateString } from '@/utils/date';
+import type { ShiftDisplayRow } from '../ShiftTable';
+
+type ClientDatetimeChangeFormProps = {
+	targetShiftId: string;
+	targetableShifts: ShiftDisplayRow[];
+	newDateStr: string;
+	newStartTime: string;
+	newEndTime: string;
+	isSubmitting: boolean;
+	onTargetShiftChange: (value: string) => void;
+	onNewDateChange: (value: string) => void;
+	onNewStartTimeChange: (value: string) => void;
+	onNewEndTimeChange: (value: string) => void;
+};
+
+export const ClientDatetimeChangeForm = ({
+	targetShiftId,
+	targetableShifts,
+	newDateStr,
+	newStartTime,
+	newEndTime,
+	isSubmitting,
+	onTargetShiftChange,
+	onNewDateChange,
+	onNewStartTimeChange,
+	onNewEndTimeChange,
+}: ClientDatetimeChangeFormProps) => {
+	return (
+		<div className="space-y-3">
+			<div>
+				<label className="label" htmlFor="shift-adjust-target-shift">
+					<span className="label-text font-medium">1) 対象シフト</span>
+				</label>
+				<select
+					id="shift-adjust-target-shift"
+					className="select-bordered select w-full"
+					value={targetShiftId}
+					onChange={(e) => onTargetShiftChange(e.target.value)}
+					disabled={isSubmitting}
+				>
+					<option value="" disabled>
+						対象シフトを選択
+					</option>
+					{targetableShifts.map((shift) => (
+						<option key={shift.id} value={shift.id}>
+							{`${formatJstDateString(shift.date)} ${shift.startTime.hour
+								.toString()
+								.padStart(2, '0')}:${shift.startTime.minute
+								.toString()
+								.padStart(2, '0')}〜${shift.endTime.hour
+								.toString()
+								.padStart(2, '0')}:${shift.endTime.minute
+								.toString()
+								.padStart(2, '0')} ${shift.clientName}`}
+						</option>
+					))}
+				</select>
+			</div>
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+				<div>
+					<label className="label" htmlFor="shift-adjust-new-date">
+						<span className="label-text font-medium">2) 新しい日付</span>
+					</label>
+					<input
+						id="shift-adjust-new-date"
+						type="date"
+						className="input-bordered input w-full"
+						value={newDateStr}
+						onChange={(e) => onNewDateChange(e.target.value)}
+						disabled={isSubmitting}
+					/>
+				</div>
+				<div>
+					<label className="label" htmlFor="shift-adjust-new-start-time">
+						<span className="label-text font-medium">新しい開始時刻</span>
+					</label>
+					<input
+						id="shift-adjust-new-start-time"
+						type="time"
+						className="input-bordered input w-full"
+						value={newStartTime}
+						onChange={(e) => onNewStartTimeChange(e.target.value)}
+						disabled={isSubmitting}
+					/>
+				</div>
+				<div>
+					<label className="label" htmlFor="shift-adjust-new-end-time">
+						<span className="label-text font-medium">新しい終了時刻</span>
+					</label>
+					<input
+						id="shift-adjust-new-end-time"
+						type="time"
+						className="input-bordered input w-full"
+						value={newEndTime}
+						onChange={(e) => onNewEndTimeChange(e.target.value)}
+						disabled={isSubmitting}
+					/>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.test.tsx
@@ -416,7 +416,7 @@ describe('ShiftAdjustmentDialog', () => {
 		).toBeInTheDocument();
 	});
 
-	it('action が例外を投げた場合でも画面が落ちず、エラーを表示する', async () => {
+	it('action が例外を投げた場合でも画面が落ちず、toastで固定エラーを表示する', async () => {
 		const user = userEvent.setup();
 		vi.mocked(suggestShiftAdjustmentsAction).mockRejectedValueOnce(
 			new Error('Network failure'),
@@ -439,12 +439,13 @@ describe('ShiftAdjustmentDialog', () => {
 		await user.click(screen.getByRole('button', { name: '提案を取得' }));
 
 		await waitFor(() => {
-			expect(
-				screen.getByText(
-					'提案の取得に失敗しました。通信状況を確認して再度お試しください。',
-				),
-			).toBeInTheDocument();
+			expect(toast.error).toHaveBeenCalledWith('処理できませんでした。');
 		});
+		expect(
+			screen.queryByText(
+				'提案の取得に失敗しました。通信状況を確認して再度お試しください。',
+			),
+		).not.toBeInTheDocument();
 		expect(screen.getByRole('dialog')).toBeInTheDocument();
 	});
 

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.test.tsx
@@ -4,13 +4,26 @@ import {
 } from '@/app/actions/shiftAdjustments';
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
 import { TEST_IDS } from '@/test/helpers/testIds';
+import {
+	addJstDays,
+	formatJstDateString,
+	getJstDateOnly,
+	parseJstDateString,
+} from '@/utils/date';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'react-toastify';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ShiftDisplayRow } from '../ShiftTable';
 import { ShiftAdjustmentDialog } from './ShiftAdjustmentDialog';
 
 vi.mock('@/app/actions/shiftAdjustments');
+vi.mock('react-toastify', () => ({
+	toast: {
+		error: vi.fn(),
+		success: vi.fn(),
+	},
+}));
 
 const mockStaffOptions: StaffPickerOption[] = [
 	{
@@ -71,6 +84,7 @@ const sampleShifts: ShiftDisplayRow[] = [
 describe('ShiftAdjustmentDialog', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.spyOn(console, 'error').mockImplementation(() => {});
 		vi.mocked(suggestShiftAdjustmentsAction).mockResolvedValue({
 			data: {
 				absence: {
@@ -260,11 +274,88 @@ describe('ShiftAdjustmentDialog', () => {
 		).not.toBeInTheDocument();
 	});
 
-	it('エラー時は最小のエラーメッセージを表示する', async () => {
+	it('初期表示で欠勤の日付デフォルトは today / today', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-03-10T09:00:00+09:00'));
+		try {
+			render(
+				<ShiftAdjustmentDialog
+					isOpen={true}
+					weekStartDate={new Date('2026-02-22T00:00:00+09:00')}
+					staffOptions={mockStaffOptions}
+					shifts={sampleShifts}
+					onClose={vi.fn()}
+				/>,
+			);
+
+			expect(screen.getByLabelText('開始日')).toHaveValue('2026-03-10');
+			expect(screen.getByLabelText('終了日')).toHaveValue('2026-03-10');
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('欠勤の日付入力に14日以内の min/max が付与される', async () => {
+		const user = userEvent.setup();
+		render(
+			<ShiftAdjustmentDialog
+				isOpen={true}
+				weekStartDate={new Date('2026-02-22T00:00:00+09:00')}
+				staffOptions={mockStaffOptions}
+				shifts={sampleShifts}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		const startInput = screen.getByLabelText('開始日');
+		const endInput = screen.getByLabelText('終了日');
+		const today = formatJstDateString(getJstDateOnly(new Date()));
+		const todayMinus13 = formatJstDateString(
+			addJstDays(parseJstDateString(today), -13),
+		);
+		const todayPlus13 = formatJstDateString(
+			addJstDays(parseJstDateString(today), 13),
+		);
+
+		expect(startInput).toHaveAttribute('min', todayMinus13);
+		expect(startInput).toHaveAttribute('max', today);
+		expect(endInput).toHaveAttribute('min', today);
+		expect(endInput).toHaveAttribute('max', todayPlus13);
+
+		const startDate = formatJstDateString(
+			addJstDays(parseJstDateString(today), -3),
+		);
+		const endDate = formatJstDateString(
+			addJstDays(parseJstDateString(today), 2),
+		);
+
+		await user.clear(startInput);
+		await user.type(startInput, startDate);
+
+		expect(startInput).toHaveValue(startDate);
+		expect(endInput).toHaveAttribute('min', startDate);
+		expect(endInput).toHaveAttribute(
+			'max',
+			formatJstDateString(addJstDays(parseJstDateString(startDate), 13)),
+		);
+
+		await user.clear(endInput);
+		await user.type(endInput, endDate);
+
+		expect(endInput).toHaveValue(endDate);
+		expect(startInput).toHaveAttribute(
+			'min',
+			formatJstDateString(addJstDays(parseJstDateString(endDate), -13)),
+		);
+		expect(startInput).toHaveAttribute('max', endDate);
+	});
+
+	it('action error 時は toast と console.error を出す（詳細はUIに出さない）', async () => {
 		const user = userEvent.setup();
 		vi.mocked(suggestShiftAdjustmentsAction).mockResolvedValueOnce({
 			data: null,
 			error: 'Staff not found',
+			details: [{ path: ['staffId'], code: 'custom', message: 'not found' }],
 			status: 404,
 		});
 
@@ -285,8 +376,16 @@ describe('ShiftAdjustmentDialog', () => {
 		await user.click(screen.getByRole('button', { name: '提案を取得' }));
 
 		await waitFor(() => {
-			expect(screen.getByText('Staff not found')).toBeInTheDocument();
+			expect(toast.error).toHaveBeenCalledWith('処理できませんでした。');
 		});
+		expect(console.error).toHaveBeenCalledWith(
+			'Failed to suggest shift adjustments',
+			expect.objectContaining({
+				error: 'Staff not found',
+				details: [{ path: ['staffId'], code: 'custom', message: 'not found' }],
+			}),
+		);
+		expect(screen.queryByText('Staff not found')).not.toBeInTheDocument();
 	});
 
 	it('欠勤で開始日が終了日より後ならsubmitせずエラーを表示する', async () => {
@@ -493,6 +592,7 @@ describe('ShiftAdjustmentDialog', () => {
 
 	it('ダイアログを再オープンすると入力・エラー・提案結果が初期化される', async () => {
 		const user = userEvent.setup();
+		const todayDateStr = formatJstDateString(getJstDateOnly(new Date()));
 		const weekStartDate = new Date('2026-02-22T00:00:00+09:00');
 		const { rerender } = render(
 			<ShiftAdjustmentDialog
@@ -555,8 +655,8 @@ describe('ShiftAdjustmentDialog', () => {
 
 		expect(screen.getByRole('radio', { name: 'スタッフ欠勤' })).toBeChecked();
 		expect(screen.getByLabelText('欠勤スタッフ')).toHaveValue('');
-		expect(screen.getByLabelText('開始日')).toHaveValue('2026-02-22');
-		expect(screen.getByLabelText('終了日')).toHaveValue('2026-02-28');
+		expect(screen.getByLabelText('開始日')).toHaveValue(todayDateStr);
+		expect(screen.getByLabelText('終了日')).toHaveValue(todayDateStr);
 		expect(screen.getByLabelText('メモ（任意）')).toHaveValue('');
 		expect(
 			screen.queryByText('開始時刻は終了時刻より前を指定してください。'),

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.tsx
@@ -30,16 +30,127 @@ type ShiftAdjustmentDialogProps = {
 	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
 };
 
-/* eslint-disable complexity */
-export const ShiftAdjustmentDialog = ({
-	isOpen,
+type ShiftAdjustmentDialogContentProps = Omit<
+	ShiftAdjustmentDialogProps,
+	'isOpen'
+>;
+
+type AdjustmentTypeSpecificFormProps = {
+	adjustmentType: 'staff_absence' | 'client_datetime_change';
+	helperStaffOptions: StaffPickerOption[];
+	staffId: string;
+	startDateStr: string;
+	endDateStr: string;
+	startDateMin: string;
+	startDateMax: string;
+	endDateMin: string;
+	endDateMax: string;
+	targetShiftId: string;
+	targetableShifts: ShiftDisplayRow[];
+	newDateStr: string;
+	newStartTime: string;
+	newEndTime: string;
+	isSubmitting: boolean;
+	onStaffIdChange: (value: string) => void;
+	onStartDateChange: (value: string) => void;
+	onEndDateChange: (value: string) => void;
+	onTargetShiftChange: (value: string) => void;
+	onNewDateChange: (value: string) => void;
+	onNewStartTimeChange: (value: string) => void;
+	onNewEndTimeChange: (value: string) => void;
+};
+
+const AdjustmentTypeSpecificForm = ({
+	adjustmentType,
+	helperStaffOptions,
+	staffId,
+	startDateStr,
+	endDateStr,
+	startDateMin,
+	startDateMax,
+	endDateMin,
+	endDateMax,
+	targetShiftId,
+	targetableShifts,
+	newDateStr,
+	newStartTime,
+	newEndTime,
+	isSubmitting,
+	onStaffIdChange,
+	onStartDateChange,
+	onEndDateChange,
+	onTargetShiftChange,
+	onNewDateChange,
+	onNewStartTimeChange,
+	onNewEndTimeChange,
+}: AdjustmentTypeSpecificFormProps) =>
+	adjustmentType === 'staff_absence' ? (
+		<StaffAbsenceForm
+			helperStaffOptions={helperStaffOptions}
+			staffId={staffId}
+			startDateStr={startDateStr}
+			endDateStr={endDateStr}
+			startDateMin={startDateMin}
+			startDateMax={startDateMax}
+			endDateMin={endDateMin}
+			endDateMax={endDateMax}
+			isSubmitting={isSubmitting}
+			onStaffIdChange={onStaffIdChange}
+			onStartDateChange={onStartDateChange}
+			onEndDateChange={onEndDateChange}
+		/>
+	) : (
+		<ClientDatetimeChangeForm
+			targetShiftId={targetShiftId}
+			targetableShifts={targetableShifts}
+			newDateStr={newDateStr}
+			newStartTime={newStartTime}
+			newEndTime={newEndTime}
+			isSubmitting={isSubmitting}
+			onTargetShiftChange={onTargetShiftChange}
+			onNewDateChange={onNewDateChange}
+			onNewStartTimeChange={onNewStartTimeChange}
+			onNewEndTimeChange={onNewEndTimeChange}
+		/>
+	);
+
+const getSubmitDisabled = (params: {
+	adjustmentType: 'staff_absence' | 'client_datetime_change';
+	staffId: string;
+	startDateStr: string;
+	endDateStr: string;
+	targetShiftId: string;
+	newDateStr: string;
+	newStartTime: string;
+	newEndTime: string;
+	isSubmitting: boolean;
+}) => {
+	if (params.adjustmentType === 'staff_absence') {
+		return (
+			!params.staffId ||
+			!params.startDateStr ||
+			!params.endDateStr ||
+			params.isSubmitting
+		);
+	}
+
+	return (
+		!params.targetShiftId ||
+		!params.newDateStr ||
+		!params.newStartTime ||
+		!params.newEndTime ||
+		params.isSubmitting
+	);
+};
+
+const ShiftAdjustmentDialogContent = ({
 	weekStartDate,
 	staffOptions,
 	shifts,
 	onClose,
 	requestSuggestions,
 	requestClientDatetimeChangeSuggestions,
-}: ShiftAdjustmentDialogProps) => {
+}: ShiftAdjustmentDialogContentProps) => {
 	const {
 		adjustmentType,
 		helperStaffOptions,
@@ -74,7 +185,6 @@ export const ShiftAdjustmentDialog = ({
 		handleSubmit,
 		handleAdjustmentTypeChange,
 	} = useShiftAdjustmentDialog({
-		isOpen,
 		weekStartDate,
 		staffOptions,
 		shifts,
@@ -82,7 +192,17 @@ export const ShiftAdjustmentDialog = ({
 		requestClientDatetimeChangeSuggestions,
 	});
 
-	if (!isOpen) return null;
+	const submitDisabled = getSubmitDisabled({
+		adjustmentType,
+		staffId,
+		startDateStr,
+		endDateStr,
+		targetShiftId,
+		newDateStr,
+		newStartTime,
+		newEndTime,
+		isSubmitting,
+	});
 
 	return (
 		<div
@@ -133,35 +253,30 @@ export const ShiftAdjustmentDialog = ({
 						/>
 					</div>
 
-					{adjustmentType === 'staff_absence' ? (
-						<StaffAbsenceForm
-							helperStaffOptions={helperStaffOptions}
-							staffId={staffId}
-							startDateStr={startDateStr}
-							endDateStr={endDateStr}
-							startDateMin={startDateMin}
-							startDateMax={startDateMax}
-							endDateMin={endDateMin}
-							endDateMax={endDateMax}
-							isSubmitting={isSubmitting}
-							onStaffIdChange={setStaffId}
-							onStartDateChange={setStartDateStr}
-							onEndDateChange={setEndDateStr}
-						/>
-					) : (
-						<ClientDatetimeChangeForm
-							targetShiftId={targetShiftId}
-							targetableShifts={targetableShifts}
-							newDateStr={newDateStr}
-							newStartTime={newStartTime}
-							newEndTime={newEndTime}
-							isSubmitting={isSubmitting}
-							onTargetShiftChange={setTargetShiftId}
-							onNewDateChange={setNewDateStr}
-							onNewStartTimeChange={setNewStartTime}
-							onNewEndTimeChange={setNewEndTime}
-						/>
-					)}
+					<AdjustmentTypeSpecificForm
+						adjustmentType={adjustmentType}
+						helperStaffOptions={helperStaffOptions}
+						staffId={staffId}
+						startDateStr={startDateStr}
+						endDateStr={endDateStr}
+						startDateMin={startDateMin}
+						startDateMax={startDateMax}
+						endDateMin={endDateMin}
+						endDateMax={endDateMax}
+						targetShiftId={targetShiftId}
+						targetableShifts={targetableShifts}
+						newDateStr={newDateStr}
+						newStartTime={newStartTime}
+						newEndTime={newEndTime}
+						isSubmitting={isSubmitting}
+						onStaffIdChange={setStaffId}
+						onStartDateChange={setStartDateStr}
+						onEndDateChange={setEndDateStr}
+						onTargetShiftChange={setTargetShiftId}
+						onNewDateChange={setNewDateStr}
+						onNewStartTimeChange={setNewStartTime}
+						onNewEndTimeChange={setNewEndTime}
+					/>
 
 					<div>
 						<label className="label" htmlFor="shift-adjust-memo">
@@ -209,15 +324,7 @@ export const ShiftAdjustmentDialog = ({
 						type="button"
 						className="btn btn-primary"
 						onClick={handleSubmit}
-						disabled={
-							adjustmentType === 'staff_absence'
-								? !staffId || !startDateStr || !endDateStr || isSubmitting
-								: !targetShiftId ||
-									!newDateStr ||
-									!newStartTime ||
-									!newEndTime ||
-									isSubmitting
-						}
+						disabled={submitDisabled}
 					>
 						{isSubmitting ? '取得中...' : '提案を取得'}
 					</button>
@@ -226,4 +333,29 @@ export const ShiftAdjustmentDialog = ({
 		</div>
 	);
 };
-/* eslint-enable complexity */
+
+export const ShiftAdjustmentDialog = ({
+	isOpen,
+	weekStartDate,
+	staffOptions,
+	shifts,
+	onClose,
+	requestSuggestions,
+	requestClientDatetimeChangeSuggestions,
+}: ShiftAdjustmentDialogProps) => {
+	if (!isOpen) return null;
+
+	return (
+		<ShiftAdjustmentDialogContent
+			key={weekStartDate.toISOString()}
+			weekStartDate={weekStartDate}
+			staffOptions={staffOptions}
+			shifts={shifts}
+			onClose={onClose}
+			requestSuggestions={requestSuggestions}
+			requestClientDatetimeChangeSuggestions={
+				requestClientDatetimeChangeSuggestions
+			}
+		/>
+	);
+};

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/ShiftAdjustmentDialog.tsx
@@ -1,28 +1,17 @@
 'use client';
 
-import {
-	suggestClientDatetimeChangeAdjustmentsAction,
-	suggestShiftAdjustmentsAction,
-} from '@/app/actions/shiftAdjustments';
 import type { ActionResult } from '@/app/actions/utils/actionResult';
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
-import { useActionResultHandler } from '@/hooks/useActionResultHandler';
 import type {
 	ClientDatetimeChangeActionInput,
-	ShiftAdjustmentOperation,
-	ShiftAdjustmentShiftSuggestion,
 	SuggestClientDatetimeChangeAdjustmentsOutput,
 	SuggestShiftAdjustmentsOutput,
 } from '@/models/shiftAdjustmentActionSchemas';
-import {
-	addJstDays,
-	formatJstDateString,
-	getJstDateOnly,
-	parseJstDateString,
-	stringToTimeObject,
-} from '@/utils/date';
-import { useEffect, useMemo, useState } from 'react';
 import type { ShiftDisplayRow } from '../ShiftTable';
+import { ClientDatetimeChangeForm } from './ClientDatetimeChangeForm';
+import { StaffAbsenceForm } from './StaffAbsenceForm';
+import { SuggestionResults } from './SuggestionResults';
+import { useShiftAdjustmentDialog } from './useShiftAdjustmentDialog';
 
 type ShiftAdjustmentDialogProps = {
 	isOpen: boolean;
@@ -41,35 +30,6 @@ type ShiftAdjustmentDialogProps = {
 	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
 };
 
-const resolveShiftTitle = (
-	shift: ShiftDisplayRow | undefined,
-	fallback: { id: string; date: Date; start: string; end: string },
-) => {
-	if (!shift) {
-		return `シフト ${fallback.id}（${fallback.start}〜${fallback.end}）`;
-	}
-	return `${shift.clientName}（${shift.startTime.hour
-		.toString()
-		.padStart(2, '0')}:${shift.startTime.minute
-		.toString()
-		.padStart(2, '0')}〜${shift.endTime.hour
-		.toString()
-		.padStart(2, '0')}:${shift.endTime.minute.toString().padStart(2, '0')}）`;
-};
-
-const toDateInputString = (
-	value: string,
-	offsetDays: number,
-	fallback: string,
-) => {
-	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-		return fallback;
-	}
-	return formatJstDateString(addJstDays(parseJstDateString(value), offsetDays));
-};
-
-const ACTION_ERROR_MESSAGE = '処理できませんでした。';
-
 /* eslint-disable complexity */
 export const ShiftAdjustmentDialog = ({
 	isOpen,
@@ -80,330 +40,47 @@ export const ShiftAdjustmentDialog = ({
 	requestSuggestions,
 	requestClientDatetimeChangeSuggestions,
 }: ShiftAdjustmentDialogProps) => {
-	const [adjustmentType, setAdjustmentType] = useState<
-		'staff_absence' | 'client_datetime_change'
-	>('staff_absence');
-	const helperStaffOptions = useMemo(
-		() => staffOptions.filter((s) => s.role === 'helper'),
-		[staffOptions],
-	);
-	const { handleActionResult } = useActionResultHandler();
-	const todayDateStr = useMemo(
-		() => formatJstDateString(getJstDateOnly(new Date())),
-		[isOpen],
-	);
-
-	const [staffId, setStaffId] = useState('');
-	const [startDateStr, setStartDateStr] = useState(todayDateStr);
-	const [endDateStr, setEndDateStr] = useState(todayDateStr);
-	const [targetShiftId, setTargetShiftId] = useState('');
-	const [newDateStr, setNewDateStr] = useState(
-		formatJstDateString(weekStartDate),
-	);
-	const [newStartTime, setNewStartTime] = useState('09:00');
-	const [newEndTime, setNewEndTime] = useState('10:00');
-	const [memo, setMemo] = useState('');
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [errorMessage, setErrorMessage] = useState<string | null>(null);
-	const [resultData, setResultData] =
-		useState<SuggestShiftAdjustmentsOutput | null>(null);
-	const [clientResultData, setClientResultData] =
-		useState<SuggestClientDatetimeChangeAdjustmentsOutput | null>(null);
-
-	useEffect(() => {
-		if (!isOpen) return;
-
-		setAdjustmentType('staff_absence');
-		setStaffId('');
-		setStartDateStr(todayDateStr);
-		setEndDateStr(todayDateStr);
-		setTargetShiftId('');
-		setNewDateStr(formatJstDateString(weekStartDate));
-		setNewStartTime('09:00');
-		setNewEndTime('10:00');
-		setMemo('');
-		setIsSubmitting(false);
-		setErrorMessage(null);
-		setResultData(null);
-		setClientResultData(null);
-	}, [isOpen, todayDateStr, weekStartDate]);
-
-	const startDateMin = useMemo(
-		() => toDateInputString(endDateStr, -13, todayDateStr),
-		[endDateStr, todayDateStr],
-	);
-	const startDateMax = endDateStr;
-	const endDateMin = startDateStr;
-	const endDateMax = useMemo(
-		() => toDateInputString(startDateStr, 13, todayDateStr),
-		[startDateStr, todayDateStr],
-	);
-
-	const shiftMap = useMemo(() => {
-		const map = new Map<string, ShiftDisplayRow>();
-		for (const s of shifts) map.set(s.id, s);
-		return map;
-	}, [shifts]);
-
-	const staffNameMap = useMemo(() => {
-		const map = new Map<string, string>();
-		for (const s of helperStaffOptions) map.set(s.id, s.name);
-		return map;
-	}, [helperStaffOptions]);
-
-	const selectedStaffName = staffNameMap.get(staffId);
-
-	const targetableShifts = useMemo(() => {
-		const weekStart = getJstDateOnly(weekStartDate).getTime();
-		const weekEnd = weekStart + 6 * 86400000;
-		return shifts.filter((shift) => {
-			const dateTime = getJstDateOnly(shift.date).getTime();
-			return (
-				shift.status === 'scheduled' &&
-				!shift.isUnassigned &&
-				shift.staffId !== null &&
-				dateTime >= weekStart &&
-				dateTime <= weekEnd
-			);
-		});
-	}, [shifts, weekStartDate]);
-
-	const handleStaffAbsenceSubmit = async () => {
-		setErrorMessage(null);
-		setResultData(null);
-		setClientResultData(null);
-		if (startDateStr > endDateStr) {
-			setErrorMessage('開始日は終了日以前を指定してください。');
-			return;
-		}
-		setIsSubmitting(true);
-		try {
-			const action = requestSuggestions ?? suggestShiftAdjustmentsAction;
-			const res = await action({
-				staffId,
-				startDate: startDateStr,
-				endDate: endDateStr,
-				memo: memo.trim() ? memo.trim() : undefined,
-			});
-			if (
-				!handleActionResult(res, {
-					errorMessage: ACTION_ERROR_MESSAGE,
-					onError: () => {
-						console.error('Failed to suggest shift adjustments', {
-							error: res.error,
-							details: res.details,
-						});
-					},
-				})
-			) {
-				setErrorMessage(ACTION_ERROR_MESSAGE);
-				return;
-			}
-			setResultData(res.data);
-			setClientResultData(null);
-		} catch (error) {
-			console.error('Unexpected error while suggesting shift adjustments', {
-				error,
-			});
-			handleActionResult(
-				{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
-				{ errorMessage: ACTION_ERROR_MESSAGE },
-			);
-			setErrorMessage(
-				'提案の取得に失敗しました。通信状況を確認して再度お試しください。',
-			);
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
-
-	const handleClientDatetimeChangeSubmit = async () => {
-		setErrorMessage(null);
-		setResultData(null);
-		setClientResultData(null);
-		const parsedStartTime = stringToTimeObject(newStartTime);
-		const parsedEndTime = stringToTimeObject(newEndTime);
-		if (!parsedStartTime || !parsedEndTime) {
-			setErrorMessage('時刻の形式が不正です。HH:mm 形式で入力してください。');
-			return;
-		}
-		const startTotalMinutes =
-			parsedStartTime.hour * 60 + parsedStartTime.minute;
-		const endTotalMinutes = parsedEndTime.hour * 60 + parsedEndTime.minute;
-		if (startTotalMinutes >= endTotalMinutes) {
-			setErrorMessage('開始時刻は終了時刻より前を指定してください。');
-			return;
-		}
-		setIsSubmitting(true);
-		try {
-			const action =
-				requestClientDatetimeChangeSuggestions ??
-				suggestClientDatetimeChangeAdjustmentsAction;
-			const res = await action({
-				shiftId: targetShiftId,
-				newDate: newDateStr,
-				newStartTime: parsedStartTime,
-				newEndTime: parsedEndTime,
-				memo: memo.trim() ? memo.trim() : undefined,
-			});
-			if (
-				!handleActionResult(res, {
-					errorMessage: ACTION_ERROR_MESSAGE,
-					onError: () => {
-						console.error(
-							'Failed to suggest client datetime change adjustments',
-							{
-								error: res.error,
-								details: res.details,
-							},
-						);
-					},
-				})
-			) {
-				setErrorMessage(ACTION_ERROR_MESSAGE);
-				return;
-			}
-			setClientResultData(res.data);
-			setResultData(null);
-		} catch (error) {
-			console.error(
-				'Unexpected error while suggesting client datetime change adjustments',
-				{ error },
-			);
-			handleActionResult(
-				{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
-				{ errorMessage: ACTION_ERROR_MESSAGE },
-			);
-			setErrorMessage(
-				'提案の取得に失敗しました。通信状況を確認して再度お試しください。',
-			);
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
-
-	const handleSubmit = async () => {
-		if (adjustmentType === 'staff_absence') {
-			await handleStaffAbsenceSubmit();
-			return;
-		}
-		await handleClientDatetimeChangeSubmit();
-	};
-
-	const renderAffected = (affected: ShiftAdjustmentShiftSuggestion) => {
-		const shift = affected.shift;
-		const shiftRow = shiftMap.get(shift.id);
-		const start = `${shift.start_time.hour
-			.toString()
-			.padStart(2, '0')}:${shift.start_time.minute
-			.toString()
-			.padStart(2, '0')}`;
-		const end = `${shift.end_time.hour
-			.toString()
-			.padStart(2, '0')}:${shift.end_time.minute.toString().padStart(2, '0')}`;
-
-		return (
-			<div key={shift.id} className="card card-border">
-				<div className="card-body gap-2">
-					<div className="flex flex-wrap items-center justify-between gap-2">
-						<h3 className="card-title text-base">
-							{resolveShiftTitle(shiftRow, {
-								id: shift.id,
-								date: shift.date,
-								start,
-								end,
-							})}
-						</h3>
-						<span className="text-sm text-base-content/70">
-							{formatJstDateString(shift.date)}
-						</span>
-					</div>
-
-					{affected.suggestions.length === 0 ? (
-						<div className="alert alert-warning">
-							このシフトに対する候補が見つかりませんでした。
-						</div>
-					) : (
-						<ul className="list">
-							{affected.suggestions.map((s, idx) => {
-								const describeOperation = (op: ShiftAdjustmentOperation) => {
-									const row = shiftMap.get(op.shift_id);
-									const startStr = row
-										? `${row.startTime.hour.toString().padStart(2, '0')}:${row.startTime.minute
-												.toString()
-												.padStart(2, '0')}`
-										: '--:--';
-									const endStr = row
-										? `${row.endTime.hour.toString().padStart(2, '0')}:${row.endTime.minute
-												.toString()
-												.padStart(2, '0')}`
-										: '--:--';
-									const shiftTitle = resolveShiftTitle(row, {
-										id: op.shift_id,
-										date: row?.date ?? shift.date,
-										start: startStr,
-										end: endStr,
-									});
-
-									if (op.type === 'change_staff') {
-										const toName =
-											staffNameMap.get(op.to_staff_id) ?? op.to_staff_id;
-										return {
-											shiftId: op.shift_id,
-											summary:
-												op.shift_id === shift.id
-													? `${toName} に変更`
-													: `${shiftTitle} を ${toName} に変更`,
-										};
-									}
-
-									const newDateStr = formatJstDateString(op.new_date);
-									const newStart = `${op.new_start_time.hour.toString().padStart(2, '0')}:${op.new_start_time.minute
-										.toString()
-										.padStart(2, '0')}`;
-									const newEnd = `${op.new_end_time.hour.toString().padStart(2, '0')}:${op.new_end_time.minute
-										.toString()
-										.padStart(2, '0')}`;
-									return {
-										shiftId: op.shift_id,
-										summary:
-											op.shift_id === shift.id
-												? `日時を ${newDateStr} ${newStart}〜${newEnd} に変更`
-												: `${shiftTitle} の日時を ${newDateStr} ${newStart}〜${newEnd} に変更`,
-									};
-								};
-
-								const firstOp = s.operations[0]!;
-								const secondOp = s.operations[1];
-								const first = describeOperation(firstOp);
-								const second = secondOp ? describeOperation(secondOp) : null;
-								const rationaleText = s.rationale
-									.map((r) => r.message)
-									.join(' / ');
-								return (
-									<li key={`${shift.id}-${idx}`} className="list-row">
-										<div className="text-sm">
-											<div className="font-medium">
-												案{idx + 1}: {first.summary}
-											</div>
-											{second ? (
-												<div className="text-base-content/70">
-													2手目: {second.summary}
-												</div>
-											) : null}
-											<div className="text-base-content/70">
-												{rationaleText}
-											</div>
-										</div>
-									</li>
-								);
-							})}
-						</ul>
-					)}
-				</div>
-			</div>
-		);
-	};
+	const {
+		adjustmentType,
+		helperStaffOptions,
+		staffId,
+		startDateStr,
+		endDateStr,
+		targetShiftId,
+		newDateStr,
+		newStartTime,
+		newEndTime,
+		memo,
+		isSubmitting,
+		errorMessage,
+		resultData,
+		clientResultData,
+		startDateMin,
+		startDateMax,
+		endDateMin,
+		endDateMax,
+		selectedStaffName,
+		targetableShifts,
+		shiftMap,
+		staffNameMap,
+		setStaffId,
+		setStartDateStr,
+		setEndDateStr,
+		setTargetShiftId,
+		setNewDateStr,
+		setNewStartTime,
+		setNewEndTime,
+		setMemo,
+		handleSubmit,
+		handleAdjustmentTypeChange,
+	} = useShiftAdjustmentDialog({
+		isOpen,
+		weekStartDate,
+		staffOptions,
+		shifts,
+		requestSuggestions,
+		requestClientDatetimeChangeSuggestions,
+	});
 
 	if (!isOpen) return null;
 
@@ -440,12 +117,7 @@ export const ShiftAdjustmentDialog = ({
 							className="btn join-item"
 							aria-label="スタッフ欠勤"
 							checked={adjustmentType === 'staff_absence'}
-							onChange={() => {
-								setAdjustmentType('staff_absence');
-								setResultData(null);
-								setClientResultData(null);
-								setErrorMessage(null);
-							}}
+							onChange={() => handleAdjustmentTypeChange('staff_absence')}
 							disabled={isSubmitting}
 						/>
 						<input
@@ -454,152 +126,41 @@ export const ShiftAdjustmentDialog = ({
 							className="btn join-item"
 							aria-label="利用者都合の日時変更"
 							checked={adjustmentType === 'client_datetime_change'}
-							onChange={() => {
-								setAdjustmentType('client_datetime_change');
-								setResultData(null);
-								setClientResultData(null);
-								setErrorMessage(null);
-							}}
+							onChange={() =>
+								handleAdjustmentTypeChange('client_datetime_change')
+							}
 							disabled={isSubmitting}
 						/>
 					</div>
 
 					{adjustmentType === 'staff_absence' ? (
-						<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-							<div className="sm:col-span-1">
-								<label className="label" htmlFor="shift-adjust-staff">
-									<span className="label-text font-medium">欠勤スタッフ</span>
-								</label>
-								<select
-									id="shift-adjust-staff"
-									className="select-bordered select w-full"
-									value={staffId}
-									onChange={(e) => setStaffId(e.target.value)}
-									disabled={isSubmitting}
-								>
-									<option value="" disabled>
-										スタッフを選択
-									</option>
-									{helperStaffOptions.map((s) => (
-										<option key={s.id} value={s.id}>
-											{s.name}
-										</option>
-									))}
-								</select>
-							</div>
-							<div>
-								<label className="label" htmlFor="shift-adjust-start">
-									<span className="label-text font-medium">開始日</span>
-								</label>
-								<input
-									id="shift-adjust-start"
-									type="date"
-									className="input-bordered input w-full"
-									value={startDateStr}
-									min={startDateMin}
-									max={startDateMax}
-									onChange={(e) => setStartDateStr(e.target.value)}
-									disabled={isSubmitting}
-								/>
-							</div>
-							<div>
-								<label className="label" htmlFor="shift-adjust-end">
-									<span className="label-text font-medium">終了日</span>
-								</label>
-								<input
-									id="shift-adjust-end"
-									type="date"
-									className="input-bordered input w-full"
-									value={endDateStr}
-									min={endDateMin}
-									max={endDateMax}
-									onChange={(e) => setEndDateStr(e.target.value)}
-									disabled={isSubmitting}
-								/>
-							</div>
-						</div>
+						<StaffAbsenceForm
+							helperStaffOptions={helperStaffOptions}
+							staffId={staffId}
+							startDateStr={startDateStr}
+							endDateStr={endDateStr}
+							startDateMin={startDateMin}
+							startDateMax={startDateMax}
+							endDateMin={endDateMin}
+							endDateMax={endDateMax}
+							isSubmitting={isSubmitting}
+							onStaffIdChange={setStaffId}
+							onStartDateChange={setStartDateStr}
+							onEndDateChange={setEndDateStr}
+						/>
 					) : (
-						<div className="space-y-3">
-							<div>
-								<label className="label" htmlFor="shift-adjust-target-shift">
-									<span className="label-text font-medium">1) 対象シフト</span>
-								</label>
-								<select
-									id="shift-adjust-target-shift"
-									className="select-bordered select w-full"
-									value={targetShiftId}
-									onChange={(e) => setTargetShiftId(e.target.value)}
-									disabled={isSubmitting}
-								>
-									<option value="" disabled>
-										対象シフトを選択
-									</option>
-									{targetableShifts.map((shift) => (
-										<option key={shift.id} value={shift.id}>
-											{`${formatJstDateString(shift.date)} ${shift.startTime.hour
-												.toString()
-												.padStart(2, '0')}:${shift.startTime.minute
-												.toString()
-												.padStart(2, '0')}〜${shift.endTime.hour
-												.toString()
-												.padStart(2, '0')}:${shift.endTime.minute
-												.toString()
-												.padStart(2, '0')} ${shift.clientName}`}
-										</option>
-									))}
-								</select>
-							</div>
-							<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-								<div>
-									<label className="label" htmlFor="shift-adjust-new-date">
-										<span className="label-text font-medium">
-											2) 新しい日付
-										</span>
-									</label>
-									<input
-										id="shift-adjust-new-date"
-										type="date"
-										className="input-bordered input w-full"
-										value={newDateStr}
-										onChange={(e) => setNewDateStr(e.target.value)}
-										disabled={isSubmitting}
-									/>
-								</div>
-								<div>
-									<label
-										className="label"
-										htmlFor="shift-adjust-new-start-time"
-									>
-										<span className="label-text font-medium">
-											新しい開始時刻
-										</span>
-									</label>
-									<input
-										id="shift-adjust-new-start-time"
-										type="time"
-										className="input-bordered input w-full"
-										value={newStartTime}
-										onChange={(e) => setNewStartTime(e.target.value)}
-										disabled={isSubmitting}
-									/>
-								</div>
-								<div>
-									<label className="label" htmlFor="shift-adjust-new-end-time">
-										<span className="label-text font-medium">
-											新しい終了時刻
-										</span>
-									</label>
-									<input
-										id="shift-adjust-new-end-time"
-										type="time"
-										className="input-bordered input w-full"
-										value={newEndTime}
-										onChange={(e) => setNewEndTime(e.target.value)}
-										disabled={isSubmitting}
-									/>
-								</div>
-							</div>
-						</div>
+						<ClientDatetimeChangeForm
+							targetShiftId={targetShiftId}
+							targetableShifts={targetableShifts}
+							newDateStr={newDateStr}
+							newStartTime={newStartTime}
+							newEndTime={newEndTime}
+							isSubmitting={isSubmitting}
+							onTargetShiftChange={setTargetShiftId}
+							onNewDateChange={setNewDateStr}
+							onNewStartTimeChange={setNewStartTime}
+							onNewEndTimeChange={setNewEndTime}
+						/>
 					)}
 
 					<div>
@@ -626,43 +187,13 @@ export const ShiftAdjustmentDialog = ({
 						<div className="alert alert-error">{errorMessage}</div>
 					)}
 
-					{adjustmentType === 'staff_absence' && resultData && (
-						<div className="space-y-3">
-							<div className="divider">提案結果</div>
-							{resultData.meta?.timedOut ? (
-								<div className="alert alert-warning">
-									一部の提案探索が時間上限に達したため、結果は部分的な可能性があります。
-								</div>
-							) : null}
-							{resultData.affected.length === 0 ? (
-								<div className="alert alert-success">
-									対象期間に該当するシフトがありません。
-								</div>
-							) : (
-								<div className="grid grid-cols-1 gap-3">
-									{resultData.affected.map(renderAffected)}
-								</div>
-							)}
-							<div className="alert alert-soft">
-								提案は自動適用されません。必要に応じて、各シフトの「担当者変更」から反映してください。
-							</div>
-						</div>
-					)}
-
-					{adjustmentType === 'client_datetime_change' && clientResultData && (
-						<div className="space-y-3">
-							<div className="divider">提案結果</div>
-							{clientResultData.meta?.timedOut ? (
-								<div className="alert alert-warning">
-									一部の提案探索が時間上限に達したため、結果は部分的な可能性があります。
-								</div>
-							) : null}
-							{renderAffected(clientResultData.target)}
-							<div className="alert alert-soft">
-								提案は自動適用されません。内容を確認して必要に応じて手動反映してください。
-							</div>
-						</div>
-					)}
+					<SuggestionResults
+						adjustmentType={adjustmentType}
+						resultData={resultData}
+						clientResultData={clientResultData}
+						shiftMap={shiftMap}
+						staffNameMap={staffNameMap}
+					/>
 				</div>
 
 				<div className="modal-action">

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/StaffAbsenceForm.tsx
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/StaffAbsenceForm.tsx
@@ -1,0 +1,87 @@
+import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+
+type StaffAbsenceFormProps = {
+	helperStaffOptions: StaffPickerOption[];
+	staffId: string;
+	startDateStr: string;
+	endDateStr: string;
+	startDateMin: string;
+	startDateMax: string;
+	endDateMin: string;
+	endDateMax: string;
+	isSubmitting: boolean;
+	onStaffIdChange: (value: string) => void;
+	onStartDateChange: (value: string) => void;
+	onEndDateChange: (value: string) => void;
+};
+
+export const StaffAbsenceForm = ({
+	helperStaffOptions,
+	staffId,
+	startDateStr,
+	endDateStr,
+	startDateMin,
+	startDateMax,
+	endDateMin,
+	endDateMax,
+	isSubmitting,
+	onStaffIdChange,
+	onStartDateChange,
+	onEndDateChange,
+}: StaffAbsenceFormProps) => {
+	return (
+		<div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+			<div className="sm:col-span-1">
+				<label className="label" htmlFor="shift-adjust-staff">
+					<span className="label-text font-medium">欠勤スタッフ</span>
+				</label>
+				<select
+					id="shift-adjust-staff"
+					className="select-bordered select w-full"
+					value={staffId}
+					onChange={(e) => onStaffIdChange(e.target.value)}
+					disabled={isSubmitting}
+				>
+					<option value="" disabled>
+						スタッフを選択
+					</option>
+					{helperStaffOptions.map((staff) => (
+						<option key={staff.id} value={staff.id}>
+							{staff.name}
+						</option>
+					))}
+				</select>
+			</div>
+			<div>
+				<label className="label" htmlFor="shift-adjust-start">
+					<span className="label-text font-medium">開始日</span>
+				</label>
+				<input
+					id="shift-adjust-start"
+					type="date"
+					className="input-bordered input w-full"
+					value={startDateStr}
+					min={startDateMin}
+					max={startDateMax}
+					onChange={(e) => onStartDateChange(e.target.value)}
+					disabled={isSubmitting}
+				/>
+			</div>
+			<div>
+				<label className="label" htmlFor="shift-adjust-end">
+					<span className="label-text font-medium">終了日</span>
+				</label>
+				<input
+					id="shift-adjust-end"
+					type="date"
+					className="input-bordered input w-full"
+					value={endDateStr}
+					min={endDateMin}
+					max={endDateMax}
+					onChange={(e) => onEndDateChange(e.target.value)}
+					disabled={isSubmitting}
+				/>
+			</div>
+		</div>
+	);
+};

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/SuggestionResults.tsx
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/SuggestionResults.tsx
@@ -1,0 +1,201 @@
+import type {
+	ShiftAdjustmentOperation,
+	ShiftAdjustmentShiftSuggestion,
+	SuggestClientDatetimeChangeAdjustmentsOutput,
+	SuggestShiftAdjustmentsOutput,
+} from '@/models/shiftAdjustmentActionSchemas';
+import { formatJstDateString } from '@/utils/date';
+import type { ShiftDisplayRow } from '../ShiftTable';
+
+type SuggestionResultsProps = {
+	adjustmentType: 'staff_absence' | 'client_datetime_change';
+	resultData: SuggestShiftAdjustmentsOutput | null;
+	clientResultData: SuggestClientDatetimeChangeAdjustmentsOutput | null;
+	shiftMap: Map<string, ShiftDisplayRow>;
+	staffNameMap: Map<string, string>;
+};
+
+const resolveShiftTitle = (
+	shift: ShiftDisplayRow | undefined,
+	fallback: { id: string; date: Date; start: string; end: string },
+) => {
+	if (!shift) {
+		return `シフト ${fallback.id}（${fallback.start}〜${fallback.end}）`;
+	}
+	return `${shift.clientName}（${shift.startTime.hour.toString().padStart(2, '0')}:${shift.startTime.minute
+		.toString()
+		.padStart(2, '0')}〜${shift.endTime.hour
+		.toString()
+		.padStart(2, '0')}:${shift.endTime.minute.toString().padStart(2, '0')}）`;
+};
+
+export const SuggestionResults = ({
+	adjustmentType,
+	resultData,
+	clientResultData,
+	shiftMap,
+	staffNameMap,
+}: SuggestionResultsProps) => {
+	const renderAffected = (affected: ShiftAdjustmentShiftSuggestion) => {
+		const shift = affected.shift;
+		const shiftRow = shiftMap.get(shift.id);
+		const start = `${shift.start_time.hour.toString().padStart(2, '0')}:${shift.start_time.minute
+			.toString()
+			.padStart(2, '0')}`;
+		const end = `${shift.end_time.hour.toString().padStart(2, '0')}:${shift.end_time.minute
+			.toString()
+			.padStart(2, '0')}`;
+
+		return (
+			<div key={shift.id} className="card card-border">
+				<div className="card-body gap-2">
+					<div className="flex flex-wrap items-center justify-between gap-2">
+						<h3 className="card-title text-base">
+							{resolveShiftTitle(shiftRow, {
+								id: shift.id,
+								date: shift.date,
+								start,
+								end,
+							})}
+						</h3>
+						<span className="text-sm text-base-content/70">
+							{formatJstDateString(shift.date)}
+						</span>
+					</div>
+
+					{affected.suggestions.length === 0 ? (
+						<div className="alert alert-warning">
+							このシフトに対する候補が見つかりませんでした。
+						</div>
+					) : (
+						<ul className="list">
+							{affected.suggestions.map((suggestion, idx) => {
+								const describeOperation = (op: ShiftAdjustmentOperation) => {
+									const row = shiftMap.get(op.shift_id);
+									const startStr = row
+										? `${row.startTime.hour
+												.toString()
+												.padStart(2, '0')}:${row.startTime.minute
+												.toString()
+												.padStart(2, '0')}`
+										: '--:--';
+									const endStr = row
+										? `${row.endTime.hour.toString().padStart(2, '0')}:${row.endTime.minute
+												.toString()
+												.padStart(2, '0')}`
+										: '--:--';
+									const shiftTitle = resolveShiftTitle(row, {
+										id: op.shift_id,
+										date: row?.date ?? shift.date,
+										start: startStr,
+										end: endStr,
+									});
+
+									if (op.type === 'change_staff') {
+										const toName =
+											staffNameMap.get(op.to_staff_id) ?? op.to_staff_id;
+										return {
+											shiftId: op.shift_id,
+											summary:
+												op.shift_id === shift.id
+													? `${toName} に変更`
+													: `${shiftTitle} を ${toName} に変更`,
+										};
+									}
+
+									const newDateStr = formatJstDateString(op.new_date);
+									const newStart = `${op.new_start_time.hour
+										.toString()
+										.padStart(2, '0')}:${op.new_start_time.minute
+										.toString()
+										.padStart(2, '0')}`;
+									const newEnd = `${op.new_end_time.hour
+										.toString()
+										.padStart(2, '0')}:${op.new_end_time.minute
+										.toString()
+										.padStart(2, '0')}`;
+									return {
+										shiftId: op.shift_id,
+										summary:
+											op.shift_id === shift.id
+												? `日時を ${newDateStr} ${newStart}〜${newEnd} に変更`
+												: `${shiftTitle} の日時を ${newDateStr} ${newStart}〜${newEnd} に変更`,
+									};
+								};
+
+								const firstOp = suggestion.operations[0]!;
+								const secondOp = suggestion.operations[1];
+								const first = describeOperation(firstOp);
+								const second = secondOp ? describeOperation(secondOp) : null;
+								const rationaleText = suggestion.rationale
+									.map((r) => r.message)
+									.join(' / ');
+								return (
+									<li key={`${shift.id}-${idx}`} className="list-row">
+										<div className="text-sm">
+											<div className="font-medium">
+												案{idx + 1}: {first.summary}
+											</div>
+											{second ? (
+												<div className="text-base-content/70">
+													2手目: {second.summary}
+												</div>
+											) : null}
+											<div className="text-base-content/70">
+												{rationaleText}
+											</div>
+										</div>
+									</li>
+								);
+							})}
+						</ul>
+					)}
+				</div>
+			</div>
+		);
+	};
+
+	if (adjustmentType === 'staff_absence' && resultData) {
+		return (
+			<div className="space-y-3">
+				<div className="divider">提案結果</div>
+				{resultData.meta?.timedOut ? (
+					<div className="alert alert-warning">
+						一部の提案探索が時間上限に達したため、結果は部分的な可能性があります。
+					</div>
+				) : null}
+				{resultData.affected.length === 0 ? (
+					<div className="alert alert-success">
+						対象期間に該当するシフトがありません。
+					</div>
+				) : (
+					<div className="grid grid-cols-1 gap-3">
+						{resultData.affected.map(renderAffected)}
+					</div>
+				)}
+				<div className="alert alert-soft">
+					提案は自動適用されません。必要に応じて、各シフトの「担当者変更」から反映してください。
+				</div>
+			</div>
+		);
+	}
+
+	if (adjustmentType === 'client_datetime_change' && clientResultData) {
+		return (
+			<div className="space-y-3">
+				<div className="divider">提案結果</div>
+				{clientResultData.meta?.timedOut ? (
+					<div className="alert alert-warning">
+						一部の提案探索が時間上限に達したため、結果は部分的な可能性があります。
+					</div>
+				) : null}
+				{renderAffected(clientResultData.target)}
+				<div className="alert alert-soft">
+					提案は自動適用されません。内容を確認して必要に応じて手動反映してください。
+				</div>
+			</div>
+		);
+	}
+
+	return null;
+};

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/shiftAdjustmentDialogHelpers.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/shiftAdjustmentDialogHelpers.ts
@@ -1,0 +1,70 @@
+import {
+	addJstDays,
+	formatJstDateString,
+	parseJstDateString,
+	stringToTimeObject,
+} from '@/utils/date';
+
+export type AdjustmentType = 'staff_absence' | 'client_datetime_change';
+
+export const ACTION_ERROR_MESSAGE = '処理できませんでした。';
+
+export const NETWORK_ERROR_MESSAGE =
+	'提案の取得に失敗しました。通信状況を確認して再度お試しください。';
+
+export const DEFAULT_START_TIME = '09:00';
+
+export const DEFAULT_END_TIME = '10:00';
+
+export const toDateInputString = (
+	value: string,
+	offsetDays: number,
+	fallback: string,
+) => {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		return fallback;
+	}
+	return formatJstDateString(addJstDays(parseJstDateString(value), offsetDays));
+};
+
+export const toOptionalMemo = (memo: string) => {
+	const trimmedMemo = memo.trim();
+	return trimmedMemo ? trimmedMemo : undefined;
+};
+
+export const validateStaffAbsenceRange = (
+	startDateStr: string,
+	endDateStr: string,
+) => {
+	if (startDateStr > endDateStr) {
+		return '開始日は終了日以前を指定してください。';
+	}
+	return null;
+};
+
+export const validateClientDatetimeChangeTimes = (
+	newStartTime: string,
+	newEndTime: string,
+) => {
+	const parsedStartTime = stringToTimeObject(newStartTime);
+	const parsedEndTime = stringToTimeObject(newEndTime);
+	if (!parsedStartTime || !parsedEndTime) {
+		return {
+			isValid: false as const,
+			errorMessage: '時刻の形式が不正です。HH:mm 形式で入力してください。',
+		};
+	}
+	const startTotalMinutes = parsedStartTime.hour * 60 + parsedStartTime.minute;
+	const endTotalMinutes = parsedEndTime.hour * 60 + parsedEndTime.minute;
+	if (startTotalMinutes >= endTotalMinutes) {
+		return {
+			isValid: false as const,
+			errorMessage: '開始時刻は終了時刻より前を指定してください。',
+		};
+	}
+	return {
+		isValid: true as const,
+		parsedStartTime,
+		parsedEndTime,
+	};
+};

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialog.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialog.ts
@@ -17,7 +17,6 @@ import { useShiftAdjustmentDialogState } from './useShiftAdjustmentDialogState';
 import { useShiftAdjustmentDialogSubmit } from './useShiftAdjustmentDialogSubmit';
 
 type UseShiftAdjustmentDialogParams = {
-	isOpen: boolean;
 	weekStartDate: Date;
 	staffOptions: StaffPickerOption[];
 	shifts: ShiftDisplayRow[];
@@ -33,7 +32,6 @@ type UseShiftAdjustmentDialogParams = {
 };
 
 export const useShiftAdjustmentDialog = ({
-	isOpen,
 	weekStartDate,
 	staffOptions,
 	shifts,
@@ -41,7 +39,6 @@ export const useShiftAdjustmentDialog = ({
 	requestClientDatetimeChangeSuggestions,
 }: UseShiftAdjustmentDialogParams) => {
 	const state = useShiftAdjustmentDialogState({
-		isOpen,
 		weekStartDate,
 	});
 

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialog.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialog.ts
@@ -1,0 +1,309 @@
+import {
+	suggestClientDatetimeChangeAdjustmentsAction,
+	suggestShiftAdjustmentsAction,
+} from '@/app/actions/shiftAdjustments';
+import type { ActionResult } from '@/app/actions/utils/actionResult';
+import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import { useActionResultHandler } from '@/hooks/useActionResultHandler';
+import type {
+	ClientDatetimeChangeActionInput,
+	SuggestClientDatetimeChangeAdjustmentsOutput,
+	SuggestShiftAdjustmentsOutput,
+} from '@/models/shiftAdjustmentActionSchemas';
+import {
+	addJstDays,
+	formatJstDateString,
+	getJstDateOnly,
+	parseJstDateString,
+	stringToTimeObject,
+} from '@/utils/date';
+import { useEffect, useMemo, useState } from 'react';
+import type { ShiftDisplayRow } from '../ShiftTable';
+
+type AdjustmentType = 'staff_absence' | 'client_datetime_change';
+
+type UseShiftAdjustmentDialogParams = {
+	isOpen: boolean;
+	weekStartDate: Date;
+	staffOptions: StaffPickerOption[];
+	shifts: ShiftDisplayRow[];
+	requestSuggestions?: (input: {
+		staffId: string;
+		startDate: string;
+		endDate: string;
+		memo?: string;
+	}) => Promise<ActionResult<SuggestShiftAdjustmentsOutput>>;
+	requestClientDatetimeChangeSuggestions?: (
+		input: ClientDatetimeChangeActionInput,
+	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
+};
+
+const toDateInputString = (
+	value: string,
+	offsetDays: number,
+	fallback: string,
+) => {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		return fallback;
+	}
+	return formatJstDateString(addJstDays(parseJstDateString(value), offsetDays));
+};
+
+const ACTION_ERROR_MESSAGE = '処理できませんでした。';
+
+export const useShiftAdjustmentDialog = ({
+	isOpen,
+	weekStartDate,
+	staffOptions,
+	shifts,
+	requestSuggestions,
+	requestClientDatetimeChangeSuggestions,
+}: UseShiftAdjustmentDialogParams) => {
+	const [adjustmentType, setAdjustmentType] =
+		useState<AdjustmentType>('staff_absence');
+	const helperStaffOptions = useMemo(
+		() => staffOptions.filter((s) => s.role === 'helper'),
+		[staffOptions],
+	);
+	const { handleActionResult } = useActionResultHandler();
+	const todayDateStr = formatJstDateString(getJstDateOnly(new Date()));
+
+	const [staffId, setStaffId] = useState('');
+	const [startDateStr, setStartDateStr] = useState(todayDateStr);
+	const [endDateStr, setEndDateStr] = useState(todayDateStr);
+	const [targetShiftId, setTargetShiftId] = useState('');
+	const [newDateStr, setNewDateStr] = useState(
+		formatJstDateString(weekStartDate),
+	);
+	const [newStartTime, setNewStartTime] = useState('09:00');
+	const [newEndTime, setNewEndTime] = useState('10:00');
+	const [memo, setMemo] = useState('');
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const [resultData, setResultData] =
+		useState<SuggestShiftAdjustmentsOutput | null>(null);
+	const [clientResultData, setClientResultData] =
+		useState<SuggestClientDatetimeChangeAdjustmentsOutput | null>(null);
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		setAdjustmentType('staff_absence');
+		setStaffId('');
+		setStartDateStr(todayDateStr);
+		setEndDateStr(todayDateStr);
+		setTargetShiftId('');
+		setNewDateStr(formatJstDateString(weekStartDate));
+		setNewStartTime('09:00');
+		setNewEndTime('10:00');
+		setMemo('');
+		setIsSubmitting(false);
+		setErrorMessage(null);
+		setResultData(null);
+		setClientResultData(null);
+	}, [isOpen, todayDateStr, weekStartDate]);
+
+	const startDateMin = useMemo(
+		() => toDateInputString(endDateStr, -13, todayDateStr),
+		[endDateStr, todayDateStr],
+	);
+	const startDateMax = endDateStr;
+	const endDateMin = startDateStr;
+	const endDateMax = useMemo(
+		() => toDateInputString(startDateStr, 13, todayDateStr),
+		[startDateStr, todayDateStr],
+	);
+
+	const shiftMap = useMemo(() => {
+		const map = new Map<string, ShiftDisplayRow>();
+		for (const shift of shifts) map.set(shift.id, shift);
+		return map;
+	}, [shifts]);
+
+	const staffNameMap = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const staff of helperStaffOptions) map.set(staff.id, staff.name);
+		return map;
+	}, [helperStaffOptions]);
+
+	const selectedStaffName = staffNameMap.get(staffId);
+
+	const targetableShifts = useMemo(() => {
+		const weekStart = getJstDateOnly(weekStartDate).getTime();
+		const weekEnd = weekStart + 6 * 86400000;
+		return shifts.filter((shift) => {
+			const dateTime = getJstDateOnly(shift.date).getTime();
+			return (
+				shift.status === 'scheduled' &&
+				!shift.isUnassigned &&
+				shift.staffId !== null &&
+				dateTime >= weekStart &&
+				dateTime <= weekEnd
+			);
+		});
+	}, [shifts, weekStartDate]);
+
+	const clearResultsAndError = () => {
+		setResultData(null);
+		setClientResultData(null);
+		setErrorMessage(null);
+	};
+
+	const handleStaffAbsenceSubmit = async () => {
+		clearResultsAndError();
+		if (startDateStr > endDateStr) {
+			setErrorMessage('開始日は終了日以前を指定してください。');
+			return;
+		}
+		setIsSubmitting(true);
+		try {
+			const action = requestSuggestions ?? suggestShiftAdjustmentsAction;
+			const res = await action({
+				staffId,
+				startDate: startDateStr,
+				endDate: endDateStr,
+				memo: memo.trim() ? memo.trim() : undefined,
+			});
+			if (
+				!handleActionResult(res, {
+					errorMessage: ACTION_ERROR_MESSAGE,
+					onError: () => {
+						console.error('Failed to suggest shift adjustments', {
+							error: res.error,
+							details: res.details,
+						});
+					},
+				})
+			) {
+				setErrorMessage(ACTION_ERROR_MESSAGE);
+				return;
+			}
+			setResultData(res.data);
+			setClientResultData(null);
+		} catch (error) {
+			console.error('Unexpected error while suggesting shift adjustments', {
+				error,
+			});
+			handleActionResult(
+				{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
+				{ errorMessage: ACTION_ERROR_MESSAGE },
+			);
+			setErrorMessage(
+				'提案の取得に失敗しました。通信状況を確認して再度お試しください。',
+			);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleClientDatetimeChangeSubmit = async () => {
+		clearResultsAndError();
+		const parsedStartTime = stringToTimeObject(newStartTime);
+		const parsedEndTime = stringToTimeObject(newEndTime);
+		if (!parsedStartTime || !parsedEndTime) {
+			setErrorMessage('時刻の形式が不正です。HH:mm 形式で入力してください。');
+			return;
+		}
+		const startTotalMinutes =
+			parsedStartTime.hour * 60 + parsedStartTime.minute;
+		const endTotalMinutes = parsedEndTime.hour * 60 + parsedEndTime.minute;
+		if (startTotalMinutes >= endTotalMinutes) {
+			setErrorMessage('開始時刻は終了時刻より前を指定してください。');
+			return;
+		}
+		setIsSubmitting(true);
+		try {
+			const action =
+				requestClientDatetimeChangeSuggestions ??
+				suggestClientDatetimeChangeAdjustmentsAction;
+			const res = await action({
+				shiftId: targetShiftId,
+				newDate: newDateStr,
+				newStartTime: parsedStartTime,
+				newEndTime: parsedEndTime,
+				memo: memo.trim() ? memo.trim() : undefined,
+			});
+			if (
+				!handleActionResult(res, {
+					errorMessage: ACTION_ERROR_MESSAGE,
+					onError: () => {
+						console.error(
+							'Failed to suggest client datetime change adjustments',
+							{
+								error: res.error,
+								details: res.details,
+							},
+						);
+					},
+				})
+			) {
+				setErrorMessage(ACTION_ERROR_MESSAGE);
+				return;
+			}
+			setClientResultData(res.data);
+			setResultData(null);
+		} catch (error) {
+			console.error(
+				'Unexpected error while suggesting client datetime change adjustments',
+				{ error },
+			);
+			handleActionResult(
+				{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
+				{ errorMessage: ACTION_ERROR_MESSAGE },
+			);
+			setErrorMessage(
+				'提案の取得に失敗しました。通信状況を確認して再度お試しください。',
+			);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleSubmit = async () => {
+		if (adjustmentType === 'staff_absence') {
+			await handleStaffAbsenceSubmit();
+			return;
+		}
+		await handleClientDatetimeChangeSubmit();
+	};
+
+	const handleAdjustmentTypeChange = (nextType: AdjustmentType) => {
+		setAdjustmentType(nextType);
+		clearResultsAndError();
+	};
+
+	return {
+		adjustmentType,
+		helperStaffOptions,
+		staffId,
+		startDateStr,
+		endDateStr,
+		targetShiftId,
+		newDateStr,
+		newStartTime,
+		newEndTime,
+		memo,
+		isSubmitting,
+		errorMessage,
+		resultData,
+		clientResultData,
+		startDateMin,
+		startDateMax,
+		endDateMin,
+		endDateMax,
+		selectedStaffName,
+		targetableShifts,
+		shiftMap,
+		staffNameMap,
+		setStaffId,
+		setStartDateStr,
+		setEndDateStr,
+		setTargetShiftId,
+		setNewDateStr,
+		setNewStartTime,
+		setNewEndTime,
+		setMemo,
+		handleSubmit,
+		handleAdjustmentTypeChange,
+	};
+};

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialog.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialog.ts
@@ -1,7 +1,3 @@
-import {
-	suggestClientDatetimeChangeAdjustmentsAction,
-	suggestShiftAdjustmentsAction,
-} from '@/app/actions/shiftAdjustments';
 import type { ActionResult } from '@/app/actions/utils/actionResult';
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
 import { useActionResultHandler } from '@/hooks/useActionResultHandler';
@@ -10,17 +6,15 @@ import type {
 	SuggestClientDatetimeChangeAdjustmentsOutput,
 	SuggestShiftAdjustmentsOutput,
 } from '@/models/shiftAdjustmentActionSchemas';
-import {
-	addJstDays,
-	formatJstDateString,
-	getJstDateOnly,
-	parseJstDateString,
-	stringToTimeObject,
-} from '@/utils/date';
-import { useEffect, useMemo, useState } from 'react';
 import type { ShiftDisplayRow } from '../ShiftTable';
-
-type AdjustmentType = 'staff_absence' | 'client_datetime_change';
+import { useShiftAdjustmentDialogDerived } from './useShiftAdjustmentDialogDerived';
+import {
+	buildDialogResult,
+	buildSubmitParams,
+	createDialogAdjustmentTypeChangeHandler,
+} from './useShiftAdjustmentDialogInternals';
+import { useShiftAdjustmentDialogState } from './useShiftAdjustmentDialogState';
+import { useShiftAdjustmentDialogSubmit } from './useShiftAdjustmentDialogSubmit';
 
 type UseShiftAdjustmentDialogParams = {
 	isOpen: boolean;
@@ -38,19 +32,6 @@ type UseShiftAdjustmentDialogParams = {
 	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
 };
 
-const toDateInputString = (
-	value: string,
-	offsetDays: number,
-	fallback: string,
-) => {
-	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-		return fallback;
-	}
-	return formatJstDateString(addJstDays(parseJstDateString(value), offsetDays));
-};
-
-const ACTION_ERROR_MESSAGE = '処理できませんでした。';
-
 export const useShiftAdjustmentDialog = ({
 	isOpen,
 	weekStartDate,
@@ -59,251 +40,42 @@ export const useShiftAdjustmentDialog = ({
 	requestSuggestions,
 	requestClientDatetimeChangeSuggestions,
 }: UseShiftAdjustmentDialogParams) => {
-	const [adjustmentType, setAdjustmentType] =
-		useState<AdjustmentType>('staff_absence');
-	const helperStaffOptions = useMemo(
-		() => staffOptions.filter((s) => s.role === 'helper'),
-		[staffOptions],
-	);
+	const state = useShiftAdjustmentDialogState({
+		isOpen,
+		weekStartDate,
+	});
+
+	const derived = useShiftAdjustmentDialogDerived({
+		staffOptions,
+		shifts,
+		weekStartDate,
+		staffId: state.staffId,
+		startDateStr: state.startDateStr,
+		endDateStr: state.endDateStr,
+		todayDateStr: state.todayDateStr,
+	});
+
 	const { handleActionResult } = useActionResultHandler();
-	const todayDateStr = formatJstDateString(getJstDateOnly(new Date()));
+	const { handleSubmit, handleAdjustmentTypeChange } =
+		useShiftAdjustmentDialogSubmit(
+			buildSubmitParams({
+				state,
+				requestSuggestions,
+				requestClientDatetimeChangeSuggestions,
+				handleActionResult,
+			}),
+		);
 
-	const [staffId, setStaffId] = useState('');
-	const [startDateStr, setStartDateStr] = useState(todayDateStr);
-	const [endDateStr, setEndDateStr] = useState(todayDateStr);
-	const [targetShiftId, setTargetShiftId] = useState('');
-	const [newDateStr, setNewDateStr] = useState(
-		formatJstDateString(weekStartDate),
-	);
-	const [newStartTime, setNewStartTime] = useState('09:00');
-	const [newEndTime, setNewEndTime] = useState('10:00');
-	const [memo, setMemo] = useState('');
-	const [isSubmitting, setIsSubmitting] = useState(false);
-	const [errorMessage, setErrorMessage] = useState<string | null>(null);
-	const [resultData, setResultData] =
-		useState<SuggestShiftAdjustmentsOutput | null>(null);
-	const [clientResultData, setClientResultData] =
-		useState<SuggestClientDatetimeChangeAdjustmentsOutput | null>(null);
+	const handleDialogAdjustmentTypeChange =
+		createDialogAdjustmentTypeChangeHandler(
+			state.setAdjustmentType,
+			handleAdjustmentTypeChange,
+		);
 
-	useEffect(() => {
-		if (!isOpen) return;
-
-		setAdjustmentType('staff_absence');
-		setStaffId('');
-		setStartDateStr(todayDateStr);
-		setEndDateStr(todayDateStr);
-		setTargetShiftId('');
-		setNewDateStr(formatJstDateString(weekStartDate));
-		setNewStartTime('09:00');
-		setNewEndTime('10:00');
-		setMemo('');
-		setIsSubmitting(false);
-		setErrorMessage(null);
-		setResultData(null);
-		setClientResultData(null);
-	}, [isOpen, todayDateStr, weekStartDate]);
-
-	const startDateMin = useMemo(
-		() => toDateInputString(endDateStr, -13, todayDateStr),
-		[endDateStr, todayDateStr],
-	);
-	const startDateMax = endDateStr;
-	const endDateMin = startDateStr;
-	const endDateMax = useMemo(
-		() => toDateInputString(startDateStr, 13, todayDateStr),
-		[startDateStr, todayDateStr],
-	);
-
-	const shiftMap = useMemo(() => {
-		const map = new Map<string, ShiftDisplayRow>();
-		for (const shift of shifts) map.set(shift.id, shift);
-		return map;
-	}, [shifts]);
-
-	const staffNameMap = useMemo(() => {
-		const map = new Map<string, string>();
-		for (const staff of helperStaffOptions) map.set(staff.id, staff.name);
-		return map;
-	}, [helperStaffOptions]);
-
-	const selectedStaffName = staffNameMap.get(staffId);
-
-	const targetableShifts = useMemo(() => {
-		const weekStart = getJstDateOnly(weekStartDate).getTime();
-		const weekEnd = weekStart + 6 * 86400000;
-		return shifts.filter((shift) => {
-			const dateTime = getJstDateOnly(shift.date).getTime();
-			return (
-				shift.status === 'scheduled' &&
-				!shift.isUnassigned &&
-				shift.staffId !== null &&
-				dateTime >= weekStart &&
-				dateTime <= weekEnd
-			);
-		});
-	}, [shifts, weekStartDate]);
-
-	const clearResultsAndError = () => {
-		setResultData(null);
-		setClientResultData(null);
-		setErrorMessage(null);
-	};
-
-	const handleStaffAbsenceSubmit = async () => {
-		clearResultsAndError();
-		if (startDateStr > endDateStr) {
-			setErrorMessage('開始日は終了日以前を指定してください。');
-			return;
-		}
-		setIsSubmitting(true);
-		try {
-			const action = requestSuggestions ?? suggestShiftAdjustmentsAction;
-			const res = await action({
-				staffId,
-				startDate: startDateStr,
-				endDate: endDateStr,
-				memo: memo.trim() ? memo.trim() : undefined,
-			});
-			if (
-				!handleActionResult(res, {
-					errorMessage: ACTION_ERROR_MESSAGE,
-					onError: () => {
-						console.error('Failed to suggest shift adjustments', {
-							error: res.error,
-							details: res.details,
-						});
-					},
-				})
-			) {
-				setErrorMessage(ACTION_ERROR_MESSAGE);
-				return;
-			}
-			setResultData(res.data);
-			setClientResultData(null);
-		} catch (error) {
-			console.error('Unexpected error while suggesting shift adjustments', {
-				error,
-			});
-			handleActionResult(
-				{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
-				{ errorMessage: ACTION_ERROR_MESSAGE },
-			);
-			setErrorMessage(
-				'提案の取得に失敗しました。通信状況を確認して再度お試しください。',
-			);
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
-
-	const handleClientDatetimeChangeSubmit = async () => {
-		clearResultsAndError();
-		const parsedStartTime = stringToTimeObject(newStartTime);
-		const parsedEndTime = stringToTimeObject(newEndTime);
-		if (!parsedStartTime || !parsedEndTime) {
-			setErrorMessage('時刻の形式が不正です。HH:mm 形式で入力してください。');
-			return;
-		}
-		const startTotalMinutes =
-			parsedStartTime.hour * 60 + parsedStartTime.minute;
-		const endTotalMinutes = parsedEndTime.hour * 60 + parsedEndTime.minute;
-		if (startTotalMinutes >= endTotalMinutes) {
-			setErrorMessage('開始時刻は終了時刻より前を指定してください。');
-			return;
-		}
-		setIsSubmitting(true);
-		try {
-			const action =
-				requestClientDatetimeChangeSuggestions ??
-				suggestClientDatetimeChangeAdjustmentsAction;
-			const res = await action({
-				shiftId: targetShiftId,
-				newDate: newDateStr,
-				newStartTime: parsedStartTime,
-				newEndTime: parsedEndTime,
-				memo: memo.trim() ? memo.trim() : undefined,
-			});
-			if (
-				!handleActionResult(res, {
-					errorMessage: ACTION_ERROR_MESSAGE,
-					onError: () => {
-						console.error(
-							'Failed to suggest client datetime change adjustments',
-							{
-								error: res.error,
-								details: res.details,
-							},
-						);
-					},
-				})
-			) {
-				setErrorMessage(ACTION_ERROR_MESSAGE);
-				return;
-			}
-			setClientResultData(res.data);
-			setResultData(null);
-		} catch (error) {
-			console.error(
-				'Unexpected error while suggesting client datetime change adjustments',
-				{ error },
-			);
-			handleActionResult(
-				{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
-				{ errorMessage: ACTION_ERROR_MESSAGE },
-			);
-			setErrorMessage(
-				'提案の取得に失敗しました。通信状況を確認して再度お試しください。',
-			);
-		} finally {
-			setIsSubmitting(false);
-		}
-	};
-
-	const handleSubmit = async () => {
-		if (adjustmentType === 'staff_absence') {
-			await handleStaffAbsenceSubmit();
-			return;
-		}
-		await handleClientDatetimeChangeSubmit();
-	};
-
-	const handleAdjustmentTypeChange = (nextType: AdjustmentType) => {
-		setAdjustmentType(nextType);
-		clearResultsAndError();
-	};
-
-	return {
-		adjustmentType,
-		helperStaffOptions,
-		staffId,
-		startDateStr,
-		endDateStr,
-		targetShiftId,
-		newDateStr,
-		newStartTime,
-		newEndTime,
-		memo,
-		isSubmitting,
-		errorMessage,
-		resultData,
-		clientResultData,
-		startDateMin,
-		startDateMax,
-		endDateMin,
-		endDateMax,
-		selectedStaffName,
-		targetableShifts,
-		shiftMap,
-		staffNameMap,
-		setStaffId,
-		setStartDateStr,
-		setEndDateStr,
-		setTargetShiftId,
-		setNewDateStr,
-		setNewStartTime,
-		setNewEndTime,
-		setMemo,
+	return buildDialogResult({
+		state,
+		derived,
 		handleSubmit,
-		handleAdjustmentTypeChange,
-	};
+		handleDialogAdjustmentTypeChange,
+	});
 };

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogDerived.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogDerived.ts
@@ -1,0 +1,82 @@
+import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import { getJstDateOnly } from '@/utils/date';
+import { useMemo } from 'react';
+import type { ShiftDisplayRow } from '../ShiftTable';
+import { toDateInputString } from './shiftAdjustmentDialogHelpers';
+
+type UseShiftAdjustmentDialogDerivedParams = {
+	staffOptions: StaffPickerOption[];
+	shifts: ShiftDisplayRow[];
+	weekStartDate: Date;
+	staffId: string;
+	startDateStr: string;
+	endDateStr: string;
+	todayDateStr: string;
+};
+
+export const useShiftAdjustmentDialogDerived = ({
+	staffOptions,
+	shifts,
+	weekStartDate,
+	staffId,
+	startDateStr,
+	endDateStr,
+	todayDateStr,
+}: UseShiftAdjustmentDialogDerivedParams) => {
+	const helperStaffOptions = useMemo(
+		() => staffOptions.filter((staff) => staff.role === 'helper'),
+		[staffOptions],
+	);
+
+	const startDateMin = useMemo(
+		() => toDateInputString(endDateStr, -13, todayDateStr),
+		[endDateStr, todayDateStr],
+	);
+	const startDateMax = endDateStr;
+	const endDateMin = startDateStr;
+	const endDateMax = useMemo(
+		() => toDateInputString(startDateStr, 13, todayDateStr),
+		[startDateStr, todayDateStr],
+	);
+
+	const shiftMap = useMemo(() => {
+		const map = new Map<string, ShiftDisplayRow>();
+		for (const shift of shifts) map.set(shift.id, shift);
+		return map;
+	}, [shifts]);
+
+	const staffNameMap = useMemo(() => {
+		const map = new Map<string, string>();
+		for (const staff of helperStaffOptions) map.set(staff.id, staff.name);
+		return map;
+	}, [helperStaffOptions]);
+
+	const selectedStaffName = staffNameMap.get(staffId);
+
+	const targetableShifts = useMemo(() => {
+		const weekStart = getJstDateOnly(weekStartDate).getTime();
+		const weekEnd = weekStart + 6 * 86400000;
+		return shifts.filter((shift) => {
+			const dateTime = getJstDateOnly(shift.date).getTime();
+			return (
+				shift.status === 'scheduled' &&
+				!shift.isUnassigned &&
+				shift.staffId !== null &&
+				dateTime >= weekStart &&
+				dateTime <= weekEnd
+			);
+		});
+	}, [shifts, weekStartDate]);
+
+	return {
+		helperStaffOptions,
+		startDateMin,
+		startDateMax,
+		endDateMin,
+		endDateMax,
+		shiftMap,
+		staffNameMap,
+		selectedStaffName,
+		targetableShifts,
+	};
+};

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogInternals.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogInternals.ts
@@ -1,6 +1,9 @@
 import type { ActionResult } from '@/app/actions/utils/actionResult';
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
-import type { HandleActionResult } from '@/hooks/useActionResultHandler';
+import type {
+	HandleActionResult,
+	HandleActionResultOptions,
+} from '@/hooks/useActionResultHandler';
 import type {
 	ClientDatetimeChangeActionInput,
 	SuggestClientDatetimeChangeAdjustmentsOutput,
@@ -66,6 +69,11 @@ type BuildSubmitParamsArgs = {
 	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
 	handleActionResult: HandleActionResult;
 };
+
+export type ShiftAdjustmentHandleActionResultOptions<T> = NonNullable<
+	Parameters<HandleActionResult>[1]
+> &
+	HandleActionResultOptions<T>;
 
 export const buildSubmitParams = ({
 	state,

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogInternals.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogInternals.ts
@@ -1,5 +1,6 @@
 import type { ActionResult } from '@/app/actions/utils/actionResult';
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import type { HandleActionResult } from '@/hooks/useActionResultHandler';
 import type {
 	ClientDatetimeChangeActionInput,
 	SuggestClientDatetimeChangeAdjustmentsOutput,
@@ -63,15 +64,7 @@ type BuildSubmitParamsArgs = {
 	requestClientDatetimeChangeSuggestions?: (
 		input: ClientDatetimeChangeActionInput,
 	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
-	handleActionResult: (
-		result: ActionResult<unknown>,
-		options?: {
-			successMessage?: string;
-			errorMessage?: string;
-			onSuccess?: (data: unknown) => void;
-			onError?: () => void;
-		},
-	) => boolean;
+	handleActionResult: HandleActionResult;
 };
 
 export const buildSubmitParams = ({

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogInternals.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogInternals.ts
@@ -1,0 +1,156 @@
+import type { ActionResult } from '@/app/actions/utils/actionResult';
+import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import type {
+	ClientDatetimeChangeActionInput,
+	SuggestClientDatetimeChangeAdjustmentsOutput,
+	SuggestShiftAdjustmentsOutput,
+} from '@/models/shiftAdjustmentActionSchemas';
+import type { Dispatch, SetStateAction } from 'react';
+import type { ShiftDisplayRow } from '../ShiftTable';
+import type { AdjustmentType } from './shiftAdjustmentDialogHelpers';
+
+type ShiftAdjustmentDialogStateLike = {
+	adjustmentType: AdjustmentType;
+	staffId: string;
+	startDateStr: string;
+	endDateStr: string;
+	targetShiftId: string;
+	newDateStr: string;
+	newStartTime: string;
+	newEndTime: string;
+	memo: string;
+	isSubmitting: boolean;
+	errorMessage: string | null;
+	resultData: SuggestShiftAdjustmentsOutput | null;
+	clientResultData: SuggestClientDatetimeChangeAdjustmentsOutput | null;
+	setAdjustmentType: Dispatch<SetStateAction<AdjustmentType>>;
+	setStaffId: Dispatch<SetStateAction<string>>;
+	setStartDateStr: Dispatch<SetStateAction<string>>;
+	setEndDateStr: Dispatch<SetStateAction<string>>;
+	setTargetShiftId: Dispatch<SetStateAction<string>>;
+	setNewDateStr: Dispatch<SetStateAction<string>>;
+	setNewStartTime: Dispatch<SetStateAction<string>>;
+	setNewEndTime: Dispatch<SetStateAction<string>>;
+	setMemo: Dispatch<SetStateAction<string>>;
+	setIsSubmitting: Dispatch<SetStateAction<boolean>>;
+	setErrorMessage: Dispatch<SetStateAction<string | null>>;
+	setResultData: Dispatch<SetStateAction<SuggestShiftAdjustmentsOutput | null>>;
+	setClientResultData: Dispatch<
+		SetStateAction<SuggestClientDatetimeChangeAdjustmentsOutput | null>
+	>;
+};
+
+type ShiftAdjustmentDialogDerivedLike = {
+	helperStaffOptions: StaffPickerOption[];
+	startDateMin: string;
+	startDateMax: string;
+	endDateMin: string;
+	endDateMax: string;
+	shiftMap: Map<string, ShiftDisplayRow>;
+	staffNameMap: Map<string, string>;
+	selectedStaffName: string | undefined;
+	targetableShifts: ShiftDisplayRow[];
+};
+
+type BuildSubmitParamsArgs = {
+	state: ShiftAdjustmentDialogStateLike;
+	requestSuggestions?: (input: {
+		staffId: string;
+		startDate: string;
+		endDate: string;
+		memo?: string;
+	}) => Promise<ActionResult<SuggestShiftAdjustmentsOutput>>;
+	requestClientDatetimeChangeSuggestions?: (
+		input: ClientDatetimeChangeActionInput,
+	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
+	handleActionResult: (
+		result: ActionResult<unknown>,
+		options?: {
+			successMessage?: string;
+			errorMessage?: string;
+			onSuccess?: (data: unknown) => void;
+			onError?: () => void;
+		},
+	) => boolean;
+};
+
+export const buildSubmitParams = ({
+	state,
+	requestSuggestions,
+	requestClientDatetimeChangeSuggestions,
+	handleActionResult,
+}: BuildSubmitParamsArgs) => ({
+	adjustmentType: state.adjustmentType,
+	staffId: state.staffId,
+	startDateStr: state.startDateStr,
+	endDateStr: state.endDateStr,
+	targetShiftId: state.targetShiftId,
+	newDateStr: state.newDateStr,
+	newStartTime: state.newStartTime,
+	newEndTime: state.newEndTime,
+	memo: state.memo,
+	requestSuggestions,
+	requestClientDatetimeChangeSuggestions,
+	handleActionResult,
+	setIsSubmitting: state.setIsSubmitting,
+	setErrorMessage: state.setErrorMessage,
+	setResultData: state.setResultData,
+	setClientResultData: state.setClientResultData,
+});
+
+export const createDialogAdjustmentTypeChangeHandler =
+	(
+		setAdjustmentType: Dispatch<SetStateAction<AdjustmentType>>,
+		handleAdjustmentTypeChange: () => void,
+	) =>
+	(nextType: AdjustmentType) => {
+		setAdjustmentType(nextType);
+		handleAdjustmentTypeChange();
+	};
+
+type BuildDialogResultArgs = {
+	state: ShiftAdjustmentDialogStateLike;
+	derived: ShiftAdjustmentDialogDerivedLike;
+	handleSubmit: () => Promise<void>;
+	handleDialogAdjustmentTypeChange: (nextType: AdjustmentType) => void;
+};
+
+export const buildDialogResult = ({
+	state,
+	derived,
+	handleSubmit,
+	handleDialogAdjustmentTypeChange,
+}: BuildDialogResultArgs) => ({
+	adjustmentType: state.adjustmentType,
+	helperStaffOptions: derived.helperStaffOptions,
+	staffId: state.staffId,
+	startDateStr: state.startDateStr,
+	endDateStr: state.endDateStr,
+	targetShiftId: state.targetShiftId,
+	newDateStr: state.newDateStr,
+	newStartTime: state.newStartTime,
+	newEndTime: state.newEndTime,
+	memo: state.memo,
+	isSubmitting: state.isSubmitting,
+	errorMessage: state.errorMessage,
+	resultData: state.resultData,
+	clientResultData: state.clientResultData,
+	startDateMin: derived.startDateMin,
+	startDateMax: derived.startDateMax,
+	endDateMin: derived.endDateMin,
+	endDateMax: derived.endDateMax,
+	selectedStaffName: derived.selectedStaffName,
+	targetableShifts: derived.targetableShifts,
+	shiftMap: derived.shiftMap,
+	staffNameMap: derived.staffNameMap,
+	setStaffId: state.setStaffId,
+	setStartDateStr: state.setStartDateStr,
+	setEndDateStr: state.setEndDateStr,
+	setTargetShiftId: state.setTargetShiftId,
+	setNewDateStr: state.setNewDateStr,
+	setNewStartTime: state.setNewStartTime,
+	setNewEndTime: state.setNewEndTime,
+	setMemo: state.setMemo,
+	handleSubmit,
+	handleAdjustmentTypeChange: handleDialogAdjustmentTypeChange,
+});

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogState.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogState.ts
@@ -1,10 +1,9 @@
-/* eslint-disable react-hooks/set-state-in-effect */
 import type {
 	SuggestClientDatetimeChangeAdjustmentsOutput,
 	SuggestShiftAdjustmentsOutput,
 } from '@/models/shiftAdjustmentActionSchemas';
 import { formatJstDateString, getJstDateOnly } from '@/utils/date';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
 	DEFAULT_END_TIME,
 	DEFAULT_START_TIME,
@@ -12,12 +11,10 @@ import {
 } from './shiftAdjustmentDialogHelpers';
 
 type UseShiftAdjustmentDialogStateParams = {
-	isOpen: boolean;
 	weekStartDate: Date;
 };
 
 export const useShiftAdjustmentDialogState = ({
-	isOpen,
 	weekStartDate,
 }: UseShiftAdjustmentDialogStateParams) => {
 	const todayDateStr = formatJstDateString(getJstDateOnly(new Date()));
@@ -40,24 +37,6 @@ export const useShiftAdjustmentDialogState = ({
 		useState<SuggestShiftAdjustmentsOutput | null>(null);
 	const [clientResultData, setClientResultData] =
 		useState<SuggestClientDatetimeChangeAdjustmentsOutput | null>(null);
-
-	useEffect(() => {
-		if (!isOpen) return;
-
-		setAdjustmentType('staff_absence');
-		setStaffId('');
-		setStartDateStr(todayDateStr);
-		setEndDateStr(todayDateStr);
-		setTargetShiftId('');
-		setNewDateStr(formatJstDateString(weekStartDate));
-		setNewStartTime(DEFAULT_START_TIME);
-		setNewEndTime(DEFAULT_END_TIME);
-		setMemo('');
-		setIsSubmitting(false);
-		setErrorMessage(null);
-		setResultData(null);
-		setClientResultData(null);
-	}, [isOpen, todayDateStr, weekStartDate]);
 
 	return {
 		todayDateStr,

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogState.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogState.ts
@@ -1,0 +1,91 @@
+/* eslint-disable react-hooks/set-state-in-effect */
+import type {
+	SuggestClientDatetimeChangeAdjustmentsOutput,
+	SuggestShiftAdjustmentsOutput,
+} from '@/models/shiftAdjustmentActionSchemas';
+import { formatJstDateString, getJstDateOnly } from '@/utils/date';
+import { useEffect, useState } from 'react';
+import {
+	DEFAULT_END_TIME,
+	DEFAULT_START_TIME,
+	type AdjustmentType,
+} from './shiftAdjustmentDialogHelpers';
+
+type UseShiftAdjustmentDialogStateParams = {
+	isOpen: boolean;
+	weekStartDate: Date;
+};
+
+export const useShiftAdjustmentDialogState = ({
+	isOpen,
+	weekStartDate,
+}: UseShiftAdjustmentDialogStateParams) => {
+	const todayDateStr = formatJstDateString(getJstDateOnly(new Date()));
+
+	const [adjustmentType, setAdjustmentType] =
+		useState<AdjustmentType>('staff_absence');
+	const [staffId, setStaffId] = useState('');
+	const [startDateStr, setStartDateStr] = useState(todayDateStr);
+	const [endDateStr, setEndDateStr] = useState(todayDateStr);
+	const [targetShiftId, setTargetShiftId] = useState('');
+	const [newDateStr, setNewDateStr] = useState(
+		formatJstDateString(weekStartDate),
+	);
+	const [newStartTime, setNewStartTime] = useState(DEFAULT_START_TIME);
+	const [newEndTime, setNewEndTime] = useState(DEFAULT_END_TIME);
+	const [memo, setMemo] = useState('');
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
+	const [resultData, setResultData] =
+		useState<SuggestShiftAdjustmentsOutput | null>(null);
+	const [clientResultData, setClientResultData] =
+		useState<SuggestClientDatetimeChangeAdjustmentsOutput | null>(null);
+
+	useEffect(() => {
+		if (!isOpen) return;
+
+		setAdjustmentType('staff_absence');
+		setStaffId('');
+		setStartDateStr(todayDateStr);
+		setEndDateStr(todayDateStr);
+		setTargetShiftId('');
+		setNewDateStr(formatJstDateString(weekStartDate));
+		setNewStartTime(DEFAULT_START_TIME);
+		setNewEndTime(DEFAULT_END_TIME);
+		setMemo('');
+		setIsSubmitting(false);
+		setErrorMessage(null);
+		setResultData(null);
+		setClientResultData(null);
+	}, [isOpen, todayDateStr, weekStartDate]);
+
+	return {
+		todayDateStr,
+		adjustmentType,
+		staffId,
+		startDateStr,
+		endDateStr,
+		targetShiftId,
+		newDateStr,
+		newStartTime,
+		newEndTime,
+		memo,
+		isSubmitting,
+		errorMessage,
+		resultData,
+		clientResultData,
+		setAdjustmentType,
+		setStaffId,
+		setStartDateStr,
+		setEndDateStr,
+		setTargetShiftId,
+		setNewDateStr,
+		setNewStartTime,
+		setNewEndTime,
+		setMemo,
+		setIsSubmitting,
+		setErrorMessage,
+		setResultData,
+		setClientResultData,
+	};
+};

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
@@ -174,20 +174,21 @@ export const useShiftAdjustmentDialogSubmit = ({
 		});
 
 	const handleStaffAbsenceUnexpectedError = (error: unknown) => {
-		console.error('Unexpected error while suggesting shift adjustments', {
+		handleUnexpectedError(
+			'Unexpected error while suggesting shift adjustments',
 			error,
-		});
-		handleActionResult(
-			{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
-			{ errorMessage: ACTION_ERROR_MESSAGE },
 		);
 	};
 
 	const handleClientDatetimeChangeUnexpectedError = (error: unknown) => {
-		console.error(
+		handleUnexpectedError(
 			'Unexpected error while suggesting client datetime change adjustments',
-			{ error },
+			error,
 		);
+	};
+
+	const handleUnexpectedError = (message: string, error: unknown) => {
+		console.error(message, { error });
 		handleActionResult(
 			{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
 			{ errorMessage: ACTION_ERROR_MESSAGE },

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
@@ -17,6 +17,7 @@ import {
 	validateStaffAbsenceRange,
 	type AdjustmentType,
 } from './shiftAdjustmentDialogHelpers';
+import type { ShiftAdjustmentHandleActionResultOptions } from './useShiftAdjustmentDialogInternals';
 
 type UseShiftAdjustmentDialogSubmitParams = {
 	adjustmentType: AdjustmentType;
@@ -142,29 +143,36 @@ export const useShiftAdjustmentDialogSubmit = ({
 
 	const handleStaffAbsenceActionResult = (
 		res: ActionResult<SuggestShiftAdjustmentsOutput>,
-	) =>
-		handleActionResult(res, {
-			errorMessage: ACTION_ERROR_MESSAGE,
-			onError: () => {
-				console.error('Failed to suggest shift adjustments', {
-					error: res.error,
-					details: res.details,
-				});
-			},
-		});
+	) => handleActionResult(res, createStaffAbsenceActionErrorOptions(res));
 
 	const handleClientDatetimeChangeActionResult = (
 		res: ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>,
 	) =>
-		handleActionResult(res, {
-			errorMessage: ACTION_ERROR_MESSAGE,
-			onError: () => {
-				console.error('Failed to suggest client datetime change adjustments', {
-					error: res.error,
-					details: res.details,
-				});
-			},
-		});
+		handleActionResult(res, createClientDatetimeChangeActionErrorOptions(res));
+
+	const createStaffAbsenceActionErrorOptions = (
+		res: ActionResult<SuggestShiftAdjustmentsOutput>,
+	): ShiftAdjustmentHandleActionResultOptions<SuggestShiftAdjustmentsOutput> => ({
+		errorMessage: ACTION_ERROR_MESSAGE,
+		onError: () => {
+			console.error('Failed to suggest shift adjustments', {
+				error: res.error,
+				details: res.details,
+			});
+		},
+	});
+
+	const createClientDatetimeChangeActionErrorOptions = (
+		res: ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>,
+	): ShiftAdjustmentHandleActionResultOptions<SuggestClientDatetimeChangeAdjustmentsOutput> => ({
+		errorMessage: ACTION_ERROR_MESSAGE,
+		onError: () => {
+			console.error('Failed to suggest client datetime change adjustments', {
+				error: res.error,
+				details: res.details,
+			});
+		},
+	});
 
 	const handleStaffAbsenceUnexpectedError = (error: unknown) => {
 		handleUnexpectedError(

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
@@ -11,7 +11,6 @@ import type {
 import type { Dispatch, SetStateAction } from 'react';
 import {
 	ACTION_ERROR_MESSAGE,
-	NETWORK_ERROR_MESSAGE,
 	toOptionalMemo,
 	validateClientDatetimeChangeTimes,
 	validateStaffAbsenceRange,
@@ -95,7 +94,6 @@ export const useShiftAdjustmentDialogSubmit = ({
 				memo: toOptionalMemo(memo),
 			});
 			if (!handleStaffAbsenceActionResult(res)) {
-				setErrorMessage(ACTION_ERROR_MESSAGE);
 				return;
 			}
 			setResultData(res.data);
@@ -130,7 +128,6 @@ export const useShiftAdjustmentDialogSubmit = ({
 				memo: toOptionalMemo(memo),
 			});
 			if (!handleClientDatetimeChangeActionResult(res)) {
-				setErrorMessage(ACTION_ERROR_MESSAGE);
 				return;
 			}
 			setClientResultData(res.data);
@@ -184,7 +181,6 @@ export const useShiftAdjustmentDialogSubmit = ({
 			{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
 			{ errorMessage: ACTION_ERROR_MESSAGE },
 		);
-		setErrorMessage(NETWORK_ERROR_MESSAGE);
 	};
 
 	const handleClientDatetimeChangeUnexpectedError = (error: unknown) => {
@@ -196,7 +192,6 @@ export const useShiftAdjustmentDialogSubmit = ({
 			{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
 			{ errorMessage: ACTION_ERROR_MESSAGE },
 		);
-		setErrorMessage(NETWORK_ERROR_MESSAGE);
 	};
 
 	const handleAdjustmentTypeChange = () => {

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
@@ -3,6 +3,7 @@ import {
 	suggestShiftAdjustmentsAction,
 } from '@/app/actions/shiftAdjustments';
 import type { ActionResult } from '@/app/actions/utils/actionResult';
+import type { HandleActionResult } from '@/hooks/useActionResultHandler';
 import type {
 	ClientDatetimeChangeActionInput,
 	SuggestClientDatetimeChangeAdjustmentsOutput,
@@ -36,15 +37,7 @@ type UseShiftAdjustmentDialogSubmitParams = {
 	requestClientDatetimeChangeSuggestions?: (
 		input: ClientDatetimeChangeActionInput,
 	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
-	handleActionResult: (
-		result: ActionResult<unknown>,
-		options?: {
-			successMessage?: string;
-			errorMessage?: string;
-			onSuccess?: (data: unknown) => void;
-			onError?: () => void;
-		},
-	) => boolean;
+	handleActionResult: HandleActionResult;
 	setIsSubmitting: Dispatch<SetStateAction<boolean>>;
 	setErrorMessage: Dispatch<SetStateAction<string | null>>;
 	setResultData: Dispatch<SetStateAction<SuggestShiftAdjustmentsOutput | null>>;

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
@@ -182,10 +182,11 @@ export const useShiftAdjustmentDialogSubmit = ({
 
 	const handleUnexpectedError = (message: string, error: unknown) => {
 		console.error(message, { error });
-		handleActionResult(
-			{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
-			{ errorMessage: ACTION_ERROR_MESSAGE },
-		);
+		handleActionResult({
+			data: null,
+			error: ACTION_ERROR_MESSAGE,
+			status: 500,
+		});
 	};
 
 	const handleAdjustmentTypeChange = () => {

--- a/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
+++ b/src/app/admin/weekly-schedules/_components/ShiftAdjustmentDialog/useShiftAdjustmentDialogSubmit.ts
@@ -1,0 +1,210 @@
+import {
+	suggestClientDatetimeChangeAdjustmentsAction,
+	suggestShiftAdjustmentsAction,
+} from '@/app/actions/shiftAdjustments';
+import type { ActionResult } from '@/app/actions/utils/actionResult';
+import type {
+	ClientDatetimeChangeActionInput,
+	SuggestClientDatetimeChangeAdjustmentsOutput,
+	SuggestShiftAdjustmentsOutput,
+} from '@/models/shiftAdjustmentActionSchemas';
+import type { Dispatch, SetStateAction } from 'react';
+import {
+	ACTION_ERROR_MESSAGE,
+	NETWORK_ERROR_MESSAGE,
+	toOptionalMemo,
+	validateClientDatetimeChangeTimes,
+	validateStaffAbsenceRange,
+	type AdjustmentType,
+} from './shiftAdjustmentDialogHelpers';
+
+type UseShiftAdjustmentDialogSubmitParams = {
+	adjustmentType: AdjustmentType;
+	staffId: string;
+	startDateStr: string;
+	endDateStr: string;
+	targetShiftId: string;
+	newDateStr: string;
+	newStartTime: string;
+	newEndTime: string;
+	memo: string;
+	requestSuggestions?: (input: {
+		staffId: string;
+		startDate: string;
+		endDate: string;
+		memo?: string;
+	}) => Promise<ActionResult<SuggestShiftAdjustmentsOutput>>;
+	requestClientDatetimeChangeSuggestions?: (
+		input: ClientDatetimeChangeActionInput,
+	) => Promise<ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>>;
+	handleActionResult: (
+		result: ActionResult<unknown>,
+		options?: {
+			successMessage?: string;
+			errorMessage?: string;
+			onSuccess?: (data: unknown) => void;
+			onError?: () => void;
+		},
+	) => boolean;
+	setIsSubmitting: Dispatch<SetStateAction<boolean>>;
+	setErrorMessage: Dispatch<SetStateAction<string | null>>;
+	setResultData: Dispatch<SetStateAction<SuggestShiftAdjustmentsOutput | null>>;
+	setClientResultData: Dispatch<
+		SetStateAction<SuggestClientDatetimeChangeAdjustmentsOutput | null>
+	>;
+};
+
+export const useShiftAdjustmentDialogSubmit = ({
+	adjustmentType,
+	staffId,
+	startDateStr,
+	endDateStr,
+	targetShiftId,
+	newDateStr,
+	newStartTime,
+	newEndTime,
+	memo,
+	requestSuggestions,
+	requestClientDatetimeChangeSuggestions,
+	handleActionResult,
+	setIsSubmitting,
+	setErrorMessage,
+	setResultData,
+	setClientResultData,
+}: UseShiftAdjustmentDialogSubmitParams) => {
+	const clearResultsAndError = () => {
+		setResultData(null);
+		setClientResultData(null);
+		setErrorMessage(null);
+	};
+
+	const handleStaffAbsenceSubmit = async () => {
+		clearResultsAndError();
+		const validationError = validateStaffAbsenceRange(startDateStr, endDateStr);
+		if (validationError) {
+			setErrorMessage(validationError);
+			return;
+		}
+		setIsSubmitting(true);
+		try {
+			const action = requestSuggestions ?? suggestShiftAdjustmentsAction;
+			const res = await action({
+				staffId,
+				startDate: startDateStr,
+				endDate: endDateStr,
+				memo: toOptionalMemo(memo),
+			});
+			if (!handleStaffAbsenceActionResult(res)) {
+				setErrorMessage(ACTION_ERROR_MESSAGE);
+				return;
+			}
+			setResultData(res.data);
+			setClientResultData(null);
+		} catch (error) {
+			handleStaffAbsenceUnexpectedError(error);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleClientDatetimeChangeSubmit = async () => {
+		clearResultsAndError();
+		const parsedResult = validateClientDatetimeChangeTimes(
+			newStartTime,
+			newEndTime,
+		);
+		if (!parsedResult.isValid) {
+			setErrorMessage(parsedResult.errorMessage);
+			return;
+		}
+		setIsSubmitting(true);
+		try {
+			const action =
+				requestClientDatetimeChangeSuggestions ??
+				suggestClientDatetimeChangeAdjustmentsAction;
+			const res = await action({
+				shiftId: targetShiftId,
+				newDate: newDateStr,
+				newStartTime: parsedResult.parsedStartTime,
+				newEndTime: parsedResult.parsedEndTime,
+				memo: toOptionalMemo(memo),
+			});
+			if (!handleClientDatetimeChangeActionResult(res)) {
+				setErrorMessage(ACTION_ERROR_MESSAGE);
+				return;
+			}
+			setClientResultData(res.data);
+			setResultData(null);
+		} catch (error) {
+			handleClientDatetimeChangeUnexpectedError(error);
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleSubmit = async () => {
+		if (adjustmentType === 'staff_absence') {
+			await handleStaffAbsenceSubmit();
+			return;
+		}
+		await handleClientDatetimeChangeSubmit();
+	};
+
+	const handleStaffAbsenceActionResult = (
+		res: ActionResult<SuggestShiftAdjustmentsOutput>,
+	) =>
+		handleActionResult(res, {
+			errorMessage: ACTION_ERROR_MESSAGE,
+			onError: () => {
+				console.error('Failed to suggest shift adjustments', {
+					error: res.error,
+					details: res.details,
+				});
+			},
+		});
+
+	const handleClientDatetimeChangeActionResult = (
+		res: ActionResult<SuggestClientDatetimeChangeAdjustmentsOutput>,
+	) =>
+		handleActionResult(res, {
+			errorMessage: ACTION_ERROR_MESSAGE,
+			onError: () => {
+				console.error('Failed to suggest client datetime change adjustments', {
+					error: res.error,
+					details: res.details,
+				});
+			},
+		});
+
+	const handleStaffAbsenceUnexpectedError = (error: unknown) => {
+		console.error('Unexpected error while suggesting shift adjustments', {
+			error,
+		});
+		handleActionResult(
+			{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
+			{ errorMessage: ACTION_ERROR_MESSAGE },
+		);
+		setErrorMessage(NETWORK_ERROR_MESSAGE);
+	};
+
+	const handleClientDatetimeChangeUnexpectedError = (error: unknown) => {
+		console.error(
+			'Unexpected error while suggesting client datetime change adjustments',
+			{ error },
+		);
+		handleActionResult(
+			{ data: null, error: ACTION_ERROR_MESSAGE, status: 500 },
+			{ errorMessage: ACTION_ERROR_MESSAGE },
+		);
+		setErrorMessage(NETWORK_ERROR_MESSAGE);
+	};
+
+	const handleAdjustmentTypeChange = () => {
+		clearResultsAndError();
+	};
+
+	return {
+		handleSubmit,
+		handleAdjustmentTypeChange,
+	};
+};

--- a/src/hooks/useActionResultHandler.ts
+++ b/src/hooks/useActionResultHandler.ts
@@ -43,4 +43,8 @@ export const useActionResultHandler = () => {
 	return { handleActionResult };
 };
 
+export type HandleActionResult = ReturnType<
+	typeof useActionResultHandler
+>['handleActionResult'];
+
 export type { HandleActionResultOptions };


### PR DESCRIPTION
## 概要
Issue #63 の実装要件に対応しました。

## 対応内容
- server action: safeParse失敗時にpayloadを出さず、issuesのみを console.error 出力
- server action: ActionResult.details に issues を格納
- UI: 欠勤のデフォルト日付を today/today に変更
- UI: 欠勤の日付inputに14日以内の min/max 制約を追加
- UI: action error時に toast 表示 + console.error 出力（詳細は画面非表示）
- UT: action側(console.error/details)、UI側(デフォルト/minmax/toast+console.error)を追加

## テスト
- pnpm lint
- pnpm test:ut --run
