### PR TITLE
feat: Phase1 staff_absence 提案API契約を実装

### DIFF
--- a/src/app/actions/shiftAdjustments.test.ts
+++ b/src/app/actions/shiftAdjustments.test.ts
@@ -5,7 +5,10 @@ import {
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
-import { suggestClientDatetimeChangeAdjustmentsAction } from './shiftAdjustments';
+import {
+	suggestClientDatetimeChangeAdjustmentsAction,
+	suggestStaffAbsenceAdjustmentsAction,
+} from './shiftAdjustments';
 
 vi.mock('@/utils/supabase/server');
 vi.mock('@/backend/services/shiftAdjustmentSuggestionService', async () => {
@@ -25,6 +28,7 @@ const mockSupabase = {
 };
 
 const createMockService = () => ({
+	suggestStaffAbsenceAdjustments: vi.fn(),
 	suggestClientDatetimeChangeAdjustments: vi.fn(),
 });
 
@@ -218,5 +222,112 @@ describe('suggestClientDatetimeChangeAdjustmentsAction', () => {
 		expect(result.status).toBe(200);
 		expect(result.error).toBeNull();
 		expect(result.data?.target.suggestions).toEqual([]);
+	});
+});
+
+describe('suggestStaffAbsenceAdjustmentsAction', () => {
+	const validInput = {
+		staffId: TEST_IDS.STAFF_1,
+		startDate: '2026-02-22',
+		endDate: '2026-02-22',
+		memo: '子どもの発熱により急休',
+	};
+
+	it('未認証は401を返す', async () => {
+		mockSupabase.auth.getUser.mockResolvedValue({
+			data: { user: null },
+			error: null,
+		});
+
+		const result = await suggestStaffAbsenceAdjustmentsAction(validInput);
+
+		expect(result).toEqual({ data: null, error: 'Unauthorized', status: 401 });
+		expect(mockService.suggestStaffAbsenceAdjustments).not.toHaveBeenCalled();
+	});
+
+	it('バリデーションエラーは400を返す（staffIdが不正）', async () => {
+		mockAuthUser('user-1');
+
+		const result = await suggestStaffAbsenceAdjustmentsAction({
+			...validInput,
+			staffId: 'invalid-uuid',
+		});
+
+		expect(result.status).toBe(400);
+		expect(result.error).toBe('Validation failed');
+		expect(result.details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					path: ['staffId'],
+					code: 'invalid_format',
+				}),
+			]),
+		);
+		expect(mockService.suggestStaffAbsenceAdjustments).not.toHaveBeenCalled();
+	});
+
+	it('ServiceError(500)はdetailsを返さない', async () => {
+		mockAuthUser('user-1');
+		mockService.suggestStaffAbsenceAdjustments.mockRejectedValue(
+			new ServiceError(500, 'Internal Server Error', { reason: 'sensitive' }),
+		);
+
+		const result = await suggestStaffAbsenceAdjustmentsAction(validInput);
+
+		expect(result.status).toBe(500);
+		expect(result.error).toBe('Internal Server Error');
+		expect(result).not.toHaveProperty('details');
+	});
+
+	it('提案取得に成功し、結果を返す', async () => {
+		mockAuthUser('user-1');
+		mockService.suggestStaffAbsenceAdjustments.mockResolvedValue({
+			absence: {
+				staffId: validInput.staffId,
+				startDate: new Date('2026-02-22T00:00:00+09:00'),
+				endDate: new Date('2026-02-22T00:00:00+09:00'),
+				memo: validInput.memo,
+			},
+			affected: [
+				{
+					shift: {
+						id: TEST_IDS.SCHEDULE_1,
+						client_id: TEST_IDS.CLIENT_1,
+						service_type_id: 'life-support',
+						staff_id: TEST_IDS.STAFF_1,
+						date: new Date('2026-02-22T00:00:00+09:00'),
+						start_time: { hour: 9, minute: 0 },
+						end_time: { hour: 10, minute: 0 },
+						status: 'scheduled',
+					},
+					suggestions: [
+						{
+							operations: [
+								{
+									type: 'change_staff',
+									shift_id: TEST_IDS.SCHEDULE_1,
+									from_staff_id: TEST_IDS.STAFF_1,
+									to_staff_id: TEST_IDS.STAFF_2,
+								},
+							],
+							rationale: [{ code: 'available', message: '時間重複なし' }],
+						},
+					],
+				},
+			],
+		});
+
+		const result = await suggestStaffAbsenceAdjustmentsAction(validInput);
+
+		expect(mockService.suggestStaffAbsenceAdjustments).toHaveBeenCalledWith(
+			'user-1',
+			expect.objectContaining({
+				staffId: validInput.staffId,
+				memo: validInput.memo,
+			}),
+		);
+		expect(result.status).toBe(200);
+		expect(result.error).toBeNull();
+		expect(result.data?.affected).toHaveLength(1);
 	});
 });

--- a/src/app/actions/shiftAdjustments.ts
+++ b/src/app/actions/shiftAdjustments.ts
@@ -6,11 +6,15 @@ import {
 } from '@/backend/services/shiftAdjustmentSuggestionService';
 import type {
 	ClientDatetimeChangeActionInput,
+	StaffAbsenceActionInput,
 	SuggestClientDatetimeChangeAdjustmentsOutput,
+	SuggestShiftAdjustmentsOutput,
 } from '@/models/shiftAdjustmentActionSchemas';
 import {
 	ClientDatetimeChangeInputSchema,
+	StaffAbsenceInputSchema,
 	SuggestClientDatetimeChangeAdjustmentsOutputSchema,
+	SuggestShiftAdjustmentsOutputSchema,
 } from '@/models/shiftAdjustmentActionSchemas';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import {
@@ -52,6 +56,36 @@ const handleServiceError = <T>(error: unknown): ActionResult<T> => {
 	}
 	logServerError(error);
 	throw error;
+};
+
+/**
+ * スタッフ急休に対する「代替案（提案）」を取得する（MVP-1）
+ */
+export const suggestStaffAbsenceAdjustmentsAction = async (
+	input: StaffAbsenceActionInput,
+): Promise<ActionResult<SuggestShiftAdjustmentsOutput>> => {
+	const { supabase, user, error } = await getAuthUser();
+	if (error || !user) return errorResult('Unauthorized', 401);
+
+	const parsedInput = StaffAbsenceInputSchema.safeParse(input);
+	if (!parsedInput.success) {
+		const issues = toSanitizedIssues(parsedInput.error.issues);
+		console.error('suggestStaffAbsenceAdjustmentsAction validation failed', {
+			issues,
+		});
+		return errorResult('Validation failed', 400, issues);
+	}
+
+	const service = new ShiftAdjustmentSuggestionService(supabase);
+	try {
+		const result = await service.suggestStaffAbsenceAdjustments(
+			user.id,
+			parsedInput.data,
+		);
+		return successResult(SuggestShiftAdjustmentsOutputSchema.parse(result));
+	} catch (err) {
+		return handleServiceError<SuggestShiftAdjustmentsOutput>(err);
+	}
 };
 
 /**

--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -724,6 +724,41 @@ describe('ShiftAdjustmentSuggestionService', () => {
 			).rejects.toMatchObject({ status: 403, message: 'Forbidden' });
 		});
 
+		it('欠勤シフト取得とスタッフ一覧取得を並列で開始する', async () => {
+			const userId = createTestId();
+			let resolveAbsentShifts: ((value: Shift[]) => void) | undefined;
+			const absentShifts = new Promise<Shift[]>((resolve) => {
+				resolveAbsentShifts = resolve;
+			});
+
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+				createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+			);
+			mockShiftRepo.list.mockImplementationOnce(async () => absentShifts);
+			mockStaffRepo.listByOffice.mockResolvedValueOnce([]);
+
+			const resultPromise = service.suggestStaffAbsenceAdjustments(userId, {
+				staffId: TEST_IDS.STAFF_2,
+				startDate: new Date('2026-02-25T00:00:00+09:00'),
+				endDate: new Date('2026-02-25T00:00:00+09:00'),
+			});
+
+			for (let i = 0; i < 5; i += 1) {
+				await Promise.resolve();
+			}
+
+			expect(mockShiftRepo.list).toHaveBeenCalledTimes(1);
+			expect(mockStaffRepo.listByOffice).toHaveBeenCalledWith(
+				TEST_IDS.OFFICE_1,
+			);
+
+			resolveAbsentShifts?.([]);
+
+			await expect(resultPromise).resolves.toMatchObject({
+				affected: [],
+			});
+		});
+
 		it('対象スタッフのシフトに対して1〜3案を返す（優先順位反映）', async () => {
 			const userId = createTestId();
 			const absentStaffId = TEST_IDS.STAFF_2;

--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -83,6 +83,7 @@ const buildShiftListKey = (filters: ShiftListFilters = {}): string => {
 	// undefined は省略されるので、filters の組み合わせで一意なキーになる
 	return JSON.stringify({
 		officeId: filters.officeId,
+		staffId: filters.staffId,
 		clientId: filters.clientId,
 		status: filters.status,
 		startDate: filters.startDate,
@@ -683,6 +684,273 @@ describe('ShiftAdjustmentSuggestionService', () => {
 			);
 
 			expect(result.meta?.timedOut).toBe(true);
+		});
+	});
+
+	describe('staff_absence', () => {
+		it('不正な欠勤入力は400で失敗する（fail-fast）', async () => {
+			const userId = createTestId();
+
+			await expect(
+				service.suggestStaffAbsenceAdjustments(userId, {
+					staffId: TEST_IDS.STAFF_2,
+					startDate: new Date('2026-02-26T00:00:00+09:00'),
+					endDate: new Date('2026-02-25T00:00:00+09:00'),
+				}),
+			).rejects.toMatchObject({
+				status: 400,
+				message: 'Validation error',
+			});
+			expect(mockStaffRepo.findByAuthUserId).not.toHaveBeenCalled();
+		});
+
+		it('非adminは403を返す', async () => {
+			const userId = createTestId();
+
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+				createAdminStaff({
+					id: createTestId(),
+					auth_user_id: userId,
+					role: 'helper',
+				}),
+			);
+
+			await expect(
+				service.suggestStaffAbsenceAdjustments(userId, {
+					staffId: TEST_IDS.STAFF_2,
+					startDate: new Date('2026-02-25T00:00:00+09:00'),
+					endDate: new Date('2026-02-25T00:00:00+09:00'),
+				}),
+			).rejects.toMatchObject({ status: 403, message: 'Forbidden' });
+		});
+
+		it('対象スタッフのシフトに対して1〜3案を返す（優先順位反映）', async () => {
+			const userId = createTestId();
+			const absentStaffId = TEST_IDS.STAFF_2;
+			const candidateNoHistoryId = createTestId();
+			const candidateHistoryId = createTestId();
+			const candidateKeywordId = createTestId();
+
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+				createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+			);
+			mockStaffRepo.listByOffice.mockResolvedValueOnce([
+				createStaffWithServiceTypes({
+					id: absentStaffId,
+					name: '休暇スタッフ',
+					role: 'helper',
+					service_type_ids: ['life-support'],
+				}),
+				createStaffWithServiceTypes({
+					id: candidateNoHistoryId,
+					name: '候補A',
+					role: 'helper',
+					service_type_ids: ['life-support'],
+					note: '通常対応',
+				}),
+				createStaffWithServiceTypes({
+					id: candidateHistoryId,
+					name: '候補B',
+					role: 'helper',
+					service_type_ids: ['life-support'],
+					note: '通常対応',
+				}),
+				createStaffWithServiceTypes({
+					id: candidateKeywordId,
+					name: '候補C',
+					role: 'helper',
+					service_type_ids: ['life-support'],
+					note: '発熱対応可',
+				}),
+			]);
+
+			const absenceShift = createShift({
+				id: TEST_IDS.SCHEDULE_1,
+				client_id: TEST_IDS.CLIENT_1,
+				staff_id: absentStaffId,
+				service_type_id: 'life-support',
+				date: new Date('2026-02-25T00:00:00+09:00'),
+				time: { start: { hour: 10, minute: 0 }, end: { hour: 11, minute: 0 } },
+				status: 'scheduled',
+			});
+
+			const recentHistoryShift = createShift({
+				id: TEST_IDS.SCHEDULE_2,
+				client_id: TEST_IDS.CLIENT_1,
+				staff_id: candidateHistoryId,
+				date: new Date('2026-02-10T00:00:00+09:00'),
+				time: { start: { hour: 9, minute: 0 }, end: { hour: 10, minute: 0 } },
+				status: 'scheduled',
+			});
+
+			const candidateBusyShift = createShift({
+				id: createTestId(),
+				client_id: TEST_IDS.CLIENT_2,
+				staff_id: candidateNoHistoryId,
+				date: new Date('2026-02-25T00:00:00+09:00'),
+				time: { start: { hour: 12, minute: 0 }, end: { hour: 13, minute: 0 } },
+				status: 'scheduled',
+			});
+
+			mockShiftRepo.list.mockImplementation(async (filters = {}) => {
+				if (filters.staffId === absentStaffId) {
+					return [absenceShift];
+				}
+				if (
+					filters.clientId === TEST_IDS.CLIENT_1 &&
+					filters.startDate?.toISOString() ===
+						new Date('2025-11-27T00:00:00+09:00').toISOString()
+				) {
+					return [absenceShift, recentHistoryShift];
+				}
+				if (
+					filters.startDate?.toISOString() ===
+						new Date('2026-02-25T00:00:00+09:00').toISOString() &&
+					!filters.clientId
+				) {
+					return [absenceShift, candidateBusyShift];
+				}
+				return [];
+			});
+
+			const result = await service.suggestStaffAbsenceAdjustments(userId, {
+				staffId: absentStaffId,
+				startDate: new Date('2026-02-25T00:00:00+09:00'),
+				endDate: new Date('2026-02-25T00:00:00+09:00'),
+				memo: '発熱',
+			});
+
+			const historyCalls = mockShiftRepo.list.mock.calls.filter(([filters]) => {
+				return (
+					filters?.clientId === TEST_IDS.CLIENT_1 &&
+					filters?.startDate?.toISOString() ===
+						new Date('2025-11-27T00:00:00+09:00').toISOString()
+				);
+			});
+
+			expect(result.affected).toHaveLength(1);
+			expect(historyCalls).toHaveLength(1);
+			const suggestions = result.affected[0]?.suggestions ?? [];
+			expect(suggestions.length).toBeGreaterThanOrEqual(1);
+			expect(suggestions.length).toBeLessThanOrEqual(3);
+			expect(suggestions[0]?.operations[0]).toMatchObject({
+				type: 'change_staff',
+				shift_id: absenceShift.id,
+				from_staff_id: absentStaffId,
+				to_staff_id: candidateHistoryId,
+			});
+			expect(suggestions[1]?.operations[0]).toMatchObject({
+				type: 'change_staff',
+				shift_id: absenceShift.id,
+				from_staff_id: absentStaffId,
+				to_staff_id: candidateKeywordId,
+			});
+			expect(suggestions[1]?.rationale).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ code: 'available' }),
+					expect.objectContaining({ code: 'past_assignment_90d' }),
+					expect.objectContaining({ code: 'memo_keyword_match' }),
+				]),
+			);
+		});
+
+		it('同一date/clientの複数欠勤シフトで absent/sameDate/history の取得を分離してキャッシュする', async () => {
+			const userId = createTestId();
+			const absentStaffId = TEST_IDS.STAFF_2;
+			const candidateId = createTestId();
+
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+				createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+			);
+			mockStaffRepo.listByOffice.mockResolvedValueOnce([
+				createStaffWithServiceTypes({
+					id: absentStaffId,
+					name: '休暇スタッフ',
+					role: 'helper',
+					service_type_ids: ['life-support'],
+				}),
+				createStaffWithServiceTypes({
+					id: candidateId,
+					name: '候補A',
+					role: 'helper',
+					service_type_ids: ['life-support'],
+				}),
+			]);
+
+			const absenceShiftDateWithTime = new Date('2026-02-25T12:34:00+09:00');
+			const absenceShift1 = createShift({
+				id: TEST_IDS.SCHEDULE_1,
+				client_id: TEST_IDS.CLIENT_1,
+				staff_id: absentStaffId,
+				date: absenceShiftDateWithTime,
+				time: { start: { hour: 10, minute: 0 }, end: { hour: 11, minute: 0 } },
+				status: 'scheduled',
+			});
+			const absenceShift2 = createShift({
+				id: TEST_IDS.SCHEDULE_2,
+				client_id: TEST_IDS.CLIENT_1,
+				staff_id: absentStaffId,
+				date: absenceShiftDateWithTime,
+				time: { start: { hour: 14, minute: 0 }, end: { hour: 15, minute: 0 } },
+				status: 'scheduled',
+			});
+			const historyShift = createShift({
+				id: createTestId(),
+				client_id: TEST_IDS.CLIENT_1,
+				staff_id: candidateId,
+				date: new Date('2026-02-10T00:00:00+09:00'),
+				time: { start: { hour: 9, minute: 0 }, end: { hour: 10, minute: 0 } },
+				status: 'scheduled',
+			});
+
+			const absenceDate = new Date('2026-02-25T00:00:00+09:00');
+			const historyStartDate = new Date('2025-11-27T00:00:00+09:00');
+			const absentShiftsKey = buildShiftListKey({
+				officeId: TEST_IDS.OFFICE_1,
+				staffId: absentStaffId,
+				status: 'scheduled',
+				startDate: absenceDate,
+				endDate: absenceDate,
+			});
+			const sameDateKey = buildShiftListKey({
+				officeId: TEST_IDS.OFFICE_1,
+				status: 'scheduled',
+				startDate: absenceDate,
+				endDate: absenceDate,
+			});
+			const historyKey = buildShiftListKey({
+				officeId: TEST_IDS.OFFICE_1,
+				status: 'scheduled',
+				startDate: historyStartDate,
+				endDate: absenceDate,
+				clientId: TEST_IDS.CLIENT_1,
+			});
+
+			mockShiftRepo.list.mockImplementation(
+				createShiftListMock({
+					[absentShiftsKey]: [absenceShift1, absenceShift2],
+					[sameDateKey]: [absenceShift1, absenceShift2],
+					[historyKey]: [historyShift],
+				}),
+			);
+
+			const result = await service.suggestStaffAbsenceAdjustments(userId, {
+				staffId: absentStaffId,
+				startDate: absenceDate,
+				endDate: absenceDate,
+			});
+
+			const calledKeys = mockShiftRepo.list.mock.calls.map(([filters]) =>
+				buildShiftListKey(filters ?? {}),
+			);
+			const absentCalls = calledKeys.filter((key) => key === absentShiftsKey);
+			const sameDateCalls = calledKeys.filter((key) => key === sameDateKey);
+			const historyCalls = calledKeys.filter((key) => key === historyKey);
+
+			expect(result.affected).toHaveLength(2);
+			expect(absentCalls).toHaveLength(1);
+			expect(sameDateCalls).toHaveLength(1);
+			expect(historyCalls).toHaveLength(1);
 		});
 	});
 });

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -11,6 +11,8 @@ import {
 	ShiftSnapshot,
 	StaffAbsenceInput,
 	StaffAbsenceInputSchema,
+	SuggestClientDatetimeChangeAdjustmentsOutput,
+	SuggestShiftAdjustmentsOutput,
 } from '@/models/shiftAdjustmentActionSchemas';
 import { ServiceTypeId } from '@/models/valueObjects/serviceTypeId';
 import { getJstDateOnly, setJstTime } from '@/utils/date';
@@ -34,28 +36,6 @@ interface ShiftAdjustmentSuggestionServiceOptions {
 	maxExecutionMs?: number;
 	now?: () => number;
 }
-
-export type SuggestStaffAbsenceAdjustmentsOutput = {
-	meta?: {
-		timedOut?: boolean;
-	};
-	absence: StaffAbsenceInput;
-	affected: Array<{
-		shift: ShiftSnapshot;
-		suggestions: ShiftAdjustmentSuggestion[];
-	}>;
-};
-
-export type SuggestClientDatetimeChangeAdjustmentsOutput = {
-	meta?: {
-		timedOut?: boolean;
-	};
-	change: ClientDatetimeChangeInput;
-	target: {
-		shift: ShiftSnapshot;
-		suggestions: ShiftAdjustmentSuggestion[];
-	};
-};
 
 const isOverlapping = (
 	a: { start: Date; end: Date },
@@ -644,19 +624,20 @@ export class ShiftAdjustmentSuggestionService {
 	async suggestStaffAbsenceAdjustments(
 		userId: string,
 		absence: StaffAbsenceInput,
-	): Promise<SuggestStaffAbsenceAdjustmentsOutput> {
+	): Promise<SuggestShiftAdjustmentsOutput> {
 		const validatedAbsence = this.validateStaffAbsence(absence);
 		const adminStaff = await this.getAdminStaff(userId);
 		const officeId = adminStaff.office_id;
-		const absentShifts = await this.shiftRepository.list({
-			officeId,
-			staffId: validatedAbsence.staffId,
-			status: 'scheduled',
-			startDate: validatedAbsence.startDate,
-			endDate: validatedAbsence.endDate,
-		});
-
-		const staffs = await this.staffRepository.listByOffice(officeId);
+		const [absentShifts, staffs] = await Promise.all([
+			this.shiftRepository.list({
+				officeId,
+				staffId: validatedAbsence.staffId,
+				status: 'scheduled',
+				startDate: validatedAbsence.startDate,
+				endDate: validatedAbsence.endDate,
+			}),
+			this.staffRepository.listByOffice(officeId),
+		]);
 		const candidates = this.buildCandidates({
 			staffs,
 			absentStaffId: validatedAbsence.staffId,

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -9,6 +9,8 @@ import {
 	ShiftAdjustmentRationaleItem,
 	ShiftAdjustmentSuggestion,
 	ShiftSnapshot,
+	StaffAbsenceInput,
+	StaffAbsenceInputSchema,
 } from '@/models/shiftAdjustmentActionSchemas';
 import { ServiceTypeId } from '@/models/valueObjects/serviceTypeId';
 import { getJstDateOnly, setJstTime } from '@/utils/date';
@@ -32,6 +34,17 @@ interface ShiftAdjustmentSuggestionServiceOptions {
 	maxExecutionMs?: number;
 	now?: () => number;
 }
+
+export type SuggestStaffAbsenceAdjustmentsOutput = {
+	meta?: {
+		timedOut?: boolean;
+	};
+	absence: StaffAbsenceInput;
+	affected: Array<{
+		shift: ShiftSnapshot;
+		suggestions: ShiftAdjustmentSuggestion[];
+	}>;
+};
 
 export type SuggestClientDatetimeChangeAdjustmentsOutput = {
 	meta?: {
@@ -576,6 +589,191 @@ export class ShiftAdjustmentSuggestionService {
 			if (params.suggestions.length >= 3) return;
 		}
 	};
+
+	private validateStaffAbsence = (
+		absence: StaffAbsenceInput,
+	): StaffAbsenceInput => {
+		const parsedAbsence = StaffAbsenceInputSchema.safeParse(absence);
+		if (!parsedAbsence.success) {
+			throw new ServiceError(
+				400,
+				'Validation error',
+				parsedAbsence.error.issues,
+			);
+		}
+
+		return parsedAbsence.data;
+	};
+
+	private normalizeMemoKeywords = (memo?: string): string[] => {
+		if (!memo) return [];
+		return memo
+			.split(/[\s、,。]+/)
+			.map((word) => word.trim().toLowerCase())
+			.filter((word) => word.length >= 2)
+			.slice(0, 5);
+	};
+
+	private countPastAssignmentsIn90DaysByStaff = async (params: {
+		officeId: string;
+		clientId: string;
+		baseDate: Date;
+	}): Promise<Map<string, number>> => {
+		const startDate = new Date(params.baseDate);
+		startDate.setDate(startDate.getDate() - 90);
+		const shifts = await this.shiftRepository.list({
+			officeId: params.officeId,
+			status: 'scheduled',
+			startDate,
+			endDate: params.baseDate,
+			clientId: params.clientId,
+		});
+
+		const countByStaff = new Map<string, number>();
+		for (const shift of shifts) {
+			if (!shift.staff_id) continue;
+			countByStaff.set(
+				shift.staff_id,
+				(countByStaff.get(shift.staff_id) ?? 0) + 1,
+			);
+		}
+
+		return countByStaff;
+	};
+
+	async suggestStaffAbsenceAdjustments(
+		userId: string,
+		absence: StaffAbsenceInput,
+	): Promise<SuggestStaffAbsenceAdjustmentsOutput> {
+		const validatedAbsence = this.validateStaffAbsence(absence);
+		const adminStaff = await this.getAdminStaff(userId);
+		const officeId = adminStaff.office_id;
+		const absentShifts = await this.shiftRepository.list({
+			officeId,
+			staffId: validatedAbsence.staffId,
+			status: 'scheduled',
+			startDate: validatedAbsence.startDate,
+			endDate: validatedAbsence.endDate,
+		});
+
+		const staffs = await this.staffRepository.listByOffice(officeId);
+		const candidates = this.buildCandidates({
+			staffs,
+			absentStaffId: validatedAbsence.staffId,
+		});
+		const memoKeywords = this.normalizeMemoKeywords(validatedAbsence.memo);
+		const shiftsOnDateCache = new Map<string, Promise<ScheduledShift[]>>();
+		const pastAssignmentsCache = new Map<
+			string,
+			Promise<Map<string, number>>
+		>();
+
+		const affected = await Promise.all(
+			absentShifts.map(async (shift) => {
+				const shiftDate = getJstDateOnly(shift.date);
+				const dateKey = shiftDate.toISOString();
+				const shiftsOnDatePromise =
+					shiftsOnDateCache.get(dateKey) ??
+					this.shiftRepository.list({
+						officeId,
+						status: 'scheduled',
+						startDate: shiftDate,
+						endDate: shiftDate,
+					});
+				shiftsOnDateCache.set(dateKey, shiftsOnDatePromise);
+				const shiftsOnDate = await shiftsOnDatePromise;
+				const shiftsByStaff = this.buildShiftsByStaff(
+					shiftsOnDate.filter((s) => s.id !== shift.id),
+				);
+				const targetRange = this.getShiftDateTimes(shift);
+
+				const pastAssignmentsKey = `${shift.client_id}|${dateKey}`;
+				const pastAssignmentsPromise =
+					pastAssignmentsCache.get(pastAssignmentsKey) ??
+					this.countPastAssignmentsIn90DaysByStaff({
+						officeId,
+						clientId: shift.client_id,
+						baseDate: shiftDate,
+					});
+				pastAssignmentsCache.set(pastAssignmentsKey, pastAssignmentsPromise);
+				const pastAssignmentsByStaff = await pastAssignmentsPromise;
+
+				const scored = candidates
+					.filter((candidate) =>
+						candidate.service_type_ids.includes(shift.service_type_id),
+					)
+					.map((candidate) => {
+						const available = !this.hasConflictForRange({
+							shiftsByStaff,
+							staffId: candidate.id,
+							range: targetRange,
+						});
+						const pastAssignments =
+							pastAssignmentsByStaff.get(candidate.id) ?? 0;
+						const note = candidate.note?.toLowerCase() ?? '';
+						const keywordMatched = memoKeywords.some((keyword) =>
+							note.includes(keyword),
+						);
+						return {
+							candidate,
+							available,
+							pastAssignments,
+							keywordMatched,
+						};
+					});
+
+				const suggestions = scored
+					.filter((item) => item.available)
+					.sort((a, b) => {
+						if (a.pastAssignments !== b.pastAssignments) {
+							return b.pastAssignments - a.pastAssignments;
+						}
+						if (a.keywordMatched !== b.keywordMatched) {
+							return a.keywordMatched ? -1 : 1;
+						}
+						return a.candidate.name.localeCompare(b.candidate.name, 'ja');
+					})
+					.slice(0, 3)
+					.map(({ candidate, pastAssignments, keywordMatched }) => {
+						const rationale: ShiftAdjustmentRationaleItem[] = [
+							{ code: 'available', message: '時間重複なし' },
+							{
+								code: 'past_assignment_90d',
+								message: `過去90日担当回数: ${pastAssignments}`,
+							},
+							{
+								code: keywordMatched
+									? 'memo_keyword_match'
+									: 'memo_keyword_unmatched',
+								message: keywordMatched
+									? '備考キーワード一致'
+									: '備考キーワード一致なし',
+							},
+						];
+						return this.buildSuggestion({
+							operations: [
+								this.buildChangeStaffOperation({
+									shiftId: shift.id,
+									fromStaffId: validatedAbsence.staffId,
+									toStaffId: candidate.id,
+								}),
+							],
+							rationale,
+						});
+					});
+
+				return {
+					shift: toShiftSnapshot(shift),
+					suggestions,
+				};
+			}),
+		);
+
+		return {
+			absence: validatedAbsence,
+			affected: affected.filter((item) => item.suggestions.length > 0),
+		};
+	}
 
 	async suggestClientDatetimeChangeAdjustments(
 		userId: string,

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -243,6 +243,33 @@ describe('SuggestShiftAdjustmentsOutputSchema', () => {
 	});
 });
 
+it('suggestions が 0 件は NG（1〜3案）', () => {
+	const result = SuggestShiftAdjustmentsOutputSchema.safeParse({
+		absence: {
+			staffId: TEST_IDS.STAFF_1,
+			startDate: '2026-02-01',
+			endDate: '2026-02-01',
+		},
+		affected: [
+			{
+				shift: {
+					id: TEST_IDS.SCHEDULE_1,
+					client_id: TEST_IDS.CLIENT_1,
+					service_type_id: 'life-support',
+					staff_id: TEST_IDS.STAFF_1,
+					date: '2026-02-01',
+					start_time: { hour: 9, minute: 0 },
+					end_time: { hour: 10, minute: 0 },
+					status: 'scheduled',
+				},
+				suggestions: [],
+			},
+		],
+	});
+
+	expect(result.success).toBe(false);
+});
+
 describe('SuggestClientDatetimeChangeAdjustmentsOutputSchema', () => {
 	it('meta が無くてもパースできる（後方互換）', () => {
 		const result = SuggestClientDatetimeChangeAdjustmentsOutputSchema.safeParse(

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -241,33 +241,33 @@ describe('SuggestShiftAdjustmentsOutputSchema', () => {
 
 		expect(result.success).toBe(true);
 	});
-});
 
-it('suggestions が 0 件は NG（1〜3案）', () => {
-	const result = SuggestShiftAdjustmentsOutputSchema.safeParse({
-		absence: {
-			staffId: TEST_IDS.STAFF_1,
-			startDate: '2026-02-01',
-			endDate: '2026-02-01',
-		},
-		affected: [
-			{
-				shift: {
-					id: TEST_IDS.SCHEDULE_1,
-					client_id: TEST_IDS.CLIENT_1,
-					service_type_id: 'life-support',
-					staff_id: TEST_IDS.STAFF_1,
-					date: '2026-02-01',
-					start_time: { hour: 9, minute: 0 },
-					end_time: { hour: 10, minute: 0 },
-					status: 'scheduled',
-				},
-				suggestions: [],
+	it('suggestions が 0 件は NG（1〜3案）', () => {
+		const result = SuggestShiftAdjustmentsOutputSchema.safeParse({
+			absence: {
+				staffId: TEST_IDS.STAFF_1,
+				startDate: '2026-02-01',
+				endDate: '2026-02-01',
 			},
-		],
-	});
+			affected: [
+				{
+					shift: {
+						id: TEST_IDS.SCHEDULE_1,
+						client_id: TEST_IDS.CLIENT_1,
+						service_type_id: 'life-support',
+						staff_id: TEST_IDS.STAFF_1,
+						date: '2026-02-01',
+						start_time: { hour: 9, minute: 0 },
+						end_time: { hour: 10, minute: 0 },
+						status: 'scheduled',
+					},
+					suggestions: [],
+				},
+			],
+		});
 
-	expect(result.success).toBe(false);
+		expect(result.success).toBe(false);
+	});
 });
 
 describe('SuggestClientDatetimeChangeAdjustmentsOutputSchema', () => {

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -182,7 +182,7 @@ export type ShiftAdjustmentSuggestion = z.infer<
 
 export const ShiftAdjustmentShiftSuggestionSchema = z.object({
 	shift: ShiftSnapshotSchema,
-	suggestions: z.array(ShiftAdjustmentSuggestionSchema).max(3),
+	suggestions: z.array(ShiftAdjustmentSuggestionSchema).min(1).max(3),
 });
 export type ShiftAdjustmentShiftSuggestion = z.infer<
 	typeof ShiftAdjustmentShiftSuggestionSchema


### PR DESCRIPTION
## 概要
Phase1（staff_absence 提案API契約）を実装しました。
MVP-1方針に合わせて、**説明生成のみ**を行い、DB自動更新は行いません。

Refs #72

## 変更内容
- `shiftAdjustmentActionSchemas` において、1シフトあたりの提案件数を **1〜3件** に制約
- `suggestStaffAbsenceAdjustmentsAction` を追加
  - 認証チェック
  - 入力バリデーション（400）
  - ServiceError のハンドリング（5xx時detailsマスク）
- `ShiftAdjustmentSuggestionService` に `suggestStaffAbsenceAdjustments` を追加
  - fail-fast バリデーション
  - 対象スタッフ欠勤期間の影響シフト抽出
  - 同日シフト・過去90日担当回数のキャッシュで N+1 を抑制
  - 提案優先順位（過去担当回数 / メモキーワード一致 / 名前順）で上位3件を返却

## テスト
- `src/models/shiftAdjustmentActionSchemas.test.ts`
  - suggestions 0件をNGにする契約テストを追加
- `src/backend/services/shiftAdjustmentSuggestionService.test.ts`
  - fail-fast（400）
  - 非admin（403）
  - 優先順位反映
  - absent/sameDate/history 取得キャッシュ検証
- `src/app/actions/shiftAdjustments.test.ts`
  - 未認証（401）
  - 入力不正（400）
  - 5xx detailsマスク
  - 正常系

## 補足
- 非ブロッカーとして、`staff_absence` 側の timeout 制御の統一はフォローアップ候補です。
