### PR TITLE
feat: Phase2 Task1+導線接続+UT補強（staff_absence提案UI初期導線）

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
@@ -18,6 +18,7 @@ const stepDatetimeCandidatesSpy = vi.fn();
 const actionMocks = vi.hoisted(() => ({
 	suggestCandidateStaffForShiftAction: vi.fn(),
 	suggestCandidateStaffForShiftWithNewDatetimeAction: vi.fn(),
+	suggestStaffAbsenceAdjustmentsAction: vi.fn(),
 	assignStaffWithCascadeUnassignAction: vi.fn(),
 	updateDatetimeAndAssignWithCascadeUnassignAction: vi.fn(),
 	validateStaffAvailabilityAction: vi.fn(),
@@ -38,6 +39,11 @@ vi.mock('@/app/actions/shifts', () => ({
 
 vi.mock('@/app/actions/staffs', () => ({
 	listStaffsAction: actionMocks.listStaffsAction,
+}));
+
+vi.mock('@/app/actions/shiftAdjustments', () => ({
+	suggestStaffAbsenceAdjustmentsAction:
+		actionMocks.suggestStaffAbsenceAdjustmentsAction,
 }));
 
 vi.mock('./StepHelperCandidates', () => ({
@@ -231,9 +237,40 @@ beforeEach(() => {
 		error: null,
 		status: 200,
 	});
+	actionMocks.suggestStaffAbsenceAdjustmentsAction.mockResolvedValue({
+		data: {
+			affected: [],
+			absence: {
+				staffId: TEST_IDS.STAFF_1,
+				startDate: new Date('2026-02-22T00:00:00+09:00'),
+				endDate: new Date('2026-02-22T00:00:00+09:00'),
+			},
+		},
+		error: null,
+		status: 200,
+	});
 });
 
 describe('AdjustmentWizardDialog', () => {
+	it('staffAbsenceRequest未指定時は急休提案ボタンを表示しない', () => {
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.queryByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		).not.toBeInTheDocument();
+		expect(
+			actionMocks.suggestStaffAbsenceAdjustmentsAction,
+		).not.toHaveBeenCalled();
+	});
+
 	it('各Stepに requestCandidates / requestAssign を注入する', async () => {
 		const user = userEvent.setup();
 		render(
@@ -779,5 +816,448 @@ describe('AdjustmentWizardDialog', () => {
 		);
 
 		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('staff_absence提案フロー: affected[].suggestions の operations と rationale を表示する', async () => {
+		const user = userEvent.setup();
+		actionMocks.suggestStaffAbsenceAdjustmentsAction.mockResolvedValue({
+			data: {
+				affected: [
+					{
+						shift: {
+							id: TEST_IDS.SCHEDULE_1,
+							client_id: TEST_IDS.CLIENT_1,
+							service_type_id: 'physical-care',
+							staff_id: TEST_IDS.STAFF_1,
+							date: new Date('2026-02-22T00:00:00+09:00'),
+							start_time: { hour: 9, minute: 0 },
+							end_time: { hour: 10, minute: 0 },
+							status: 'scheduled',
+						},
+						suggestions: [
+							{
+								operations: [
+									{
+										type: 'change_staff',
+										shift_id: TEST_IDS.SCHEDULE_1,
+										from_staff_id: TEST_IDS.STAFF_1,
+										to_staff_id: TEST_IDS.STAFF_2,
+									},
+								],
+								rationale: [{ code: 'available', message: '時間重複なし' }],
+							},
+							{
+								operations: [
+									{
+										type: 'update_shift_schedule',
+										shift_id: TEST_IDS.SCHEDULE_1,
+										new_date: new Date('2026-02-22T00:00:00+09:00'),
+										new_start_time: { hour: 11, minute: 0 },
+										new_end_time: { hour: 12, minute: 0 },
+									},
+								],
+								rationale: [
+									{ code: 'reschedule', message: '同日内で調整可能' },
+								],
+							},
+						],
+					},
+				],
+				absence: {
+					staffId: TEST_IDS.STAFF_1,
+					startDate: new Date('2026-02-22T00:00:00+09:00'),
+					endDate: new Date('2026-02-22T00:00:00+09:00'),
+				},
+			},
+			error: null,
+			status: 200,
+		});
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				staffAbsenceRequest={{
+					staffId: TEST_IDS.STAFF_1,
+					startDate: '2026-02-22',
+					endDate: '2026-02-22',
+				}}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		);
+
+		expect(
+			actionMocks.suggestStaffAbsenceAdjustmentsAction,
+		).toHaveBeenCalledWith({
+			staffId: TEST_IDS.STAFF_1,
+			startDate: '2026-02-22',
+			endDate: '2026-02-22',
+		});
+		expect(screen.getByText('影響シフト:')).toBeInTheDocument();
+		expect(screen.getByText(/担当変更:/)).toBeInTheDocument();
+		expect(screen.getByText(/日時変更:/)).toBeInTheDocument();
+		expect(screen.getByText('時間重複なし')).toBeInTheDocument();
+		expect(screen.getByText('同日内で調整可能')).toBeInTheDocument();
+	});
+
+	it('staff_absence提案フロー: 案を選択して確認して閉じられ、更新系actionは呼ばれない', async () => {
+		const user = userEvent.setup();
+		const onClose = vi.fn();
+		actionMocks.suggestStaffAbsenceAdjustmentsAction.mockResolvedValue({
+			data: {
+				affected: [
+					{
+						shift: {
+							id: TEST_IDS.SCHEDULE_1,
+							client_id: TEST_IDS.CLIENT_1,
+							service_type_id: 'physical-care',
+							staff_id: TEST_IDS.STAFF_1,
+							date: new Date('2026-02-22T00:00:00+09:00'),
+							start_time: { hour: 9, minute: 0 },
+							end_time: { hour: 10, minute: 0 },
+							status: 'scheduled',
+						},
+						suggestions: [
+							{
+								operations: [
+									{
+										type: 'change_staff',
+										shift_id: TEST_IDS.SCHEDULE_1,
+										from_staff_id: TEST_IDS.STAFF_1,
+										to_staff_id: TEST_IDS.STAFF_2,
+									},
+								],
+								rationale: [{ code: 'a', message: '案1' }],
+							},
+							{
+								operations: [
+									{
+										type: 'change_staff',
+										shift_id: TEST_IDS.SCHEDULE_1,
+										from_staff_id: TEST_IDS.STAFF_1,
+										to_staff_id: TEST_IDS.STAFF_3,
+									},
+								],
+								rationale: [{ code: 'b', message: '案2' }],
+							},
+						],
+					},
+				],
+				absence: {
+					staffId: TEST_IDS.STAFF_1,
+					startDate: new Date('2026-02-22T00:00:00+09:00'),
+					endDate: new Date('2026-02-22T00:00:00+09:00'),
+				},
+			},
+			error: null,
+			status: 200,
+		});
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={onClose}
+				staffAbsenceRequest={{
+					staffId: TEST_IDS.STAFF_1,
+					startDate: '2026-02-22',
+					endDate: '2026-02-22',
+				}}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		);
+		await user.click(screen.getByRole('radio', { name: /案2/ }));
+		await user.click(screen.getByRole('button', { name: '確認して閉じる' }));
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(
+			actionMocks.assignStaffWithCascadeUnassignAction,
+		).not.toHaveBeenCalled();
+		expect(
+			actionMocks.updateDatetimeAndAssignWithCascadeUnassignAction,
+		).not.toHaveBeenCalled();
+	});
+
+	it('staff_absence提案取得でActionResultエラー(400)の場合はエラーメッセージを表示する', async () => {
+		const user = userEvent.setup();
+		actionMocks.suggestStaffAbsenceAdjustmentsAction.mockResolvedValue({
+			data: null,
+			error: '対象スタッフが見つかりません',
+			status: 400,
+			details: { reason: 'NOT_FOUND' },
+		});
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				staffAbsenceRequest={{
+					staffId: TEST_IDS.STAFF_1,
+					startDate: '2026-02-22',
+					endDate: '2026-02-22',
+				}}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		);
+
+		expect(
+			await screen.findByText('対象スタッフが見つかりません'),
+		).toBeInTheDocument();
+	});
+
+	it('staff_absence提案取得で例外発生時はエラー表示にフォールバックする', async () => {
+		const user = userEvent.setup();
+		actionMocks.suggestStaffAbsenceAdjustmentsAction.mockRejectedValue(
+			new Error('network down'),
+		);
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				staffAbsenceRequest={{
+					staffId: TEST_IDS.STAFF_1,
+					startDate: '2026-02-22',
+					endDate: '2026-02-22',
+				}}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		);
+
+		expect(
+			await screen.findByText('提案の取得に失敗しました'),
+		).toBeInTheDocument();
+		expect(screen.queryByText('提案を取得中...')).not.toBeInTheDocument();
+	});
+
+	it('staff_absence提案取得でActionResultエラー(500)の場合は定型エラーを表示する', async () => {
+		const user = userEvent.setup();
+		actionMocks.suggestStaffAbsenceAdjustmentsAction.mockResolvedValue({
+			data: null,
+			error: 'db connection failed: stacktrace...',
+			status: 500,
+			details: { stack: 'sensitive' },
+		});
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				staffAbsenceRequest={{
+					staffId: TEST_IDS.STAFF_1,
+					startDate: '2026-02-22',
+					endDate: '2026-02-22',
+				}}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		);
+
+		expect(
+			await screen.findByText('提案の取得に失敗しました'),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText('db connection failed: stacktrace...'),
+		).not.toBeInTheDocument();
+	});
+
+	it('staff_absence提案フロー: 複数affectedの各シフトを表示できる', async () => {
+		const user = userEvent.setup();
+		actionMocks.suggestStaffAbsenceAdjustmentsAction.mockResolvedValue({
+			data: {
+				affected: [
+					{
+						shift: {
+							id: TEST_IDS.SCHEDULE_1,
+							client_id: TEST_IDS.CLIENT_1,
+							service_type_id: 'physical-care',
+							staff_id: TEST_IDS.STAFF_1,
+							date: new Date('2026-02-22T00:00:00+09:00'),
+							start_time: { hour: 9, minute: 0 },
+							end_time: { hour: 10, minute: 0 },
+							status: 'scheduled',
+						},
+						suggestions: [
+							{
+								operations: [
+									{
+										type: 'change_staff',
+										shift_id: TEST_IDS.SCHEDULE_1,
+										from_staff_id: TEST_IDS.STAFF_1,
+										to_staff_id: TEST_IDS.STAFF_2,
+									},
+								],
+								rationale: [{ code: 'a', message: 'S1案1' }],
+							},
+						],
+					},
+					{
+						shift: {
+							id: TEST_IDS.SCHEDULE_2,
+							client_id: TEST_IDS.CLIENT_2,
+							service_type_id: 'physical-care',
+							staff_id: TEST_IDS.STAFF_1,
+							date: new Date('2026-02-22T00:00:00+09:00'),
+							start_time: { hour: 11, minute: 0 },
+							end_time: { hour: 12, minute: 0 },
+							status: 'scheduled',
+						},
+						suggestions: [
+							{
+								operations: [
+									{
+										type: 'change_staff',
+										shift_id: TEST_IDS.SCHEDULE_2,
+										from_staff_id: TEST_IDS.STAFF_1,
+										to_staff_id: TEST_IDS.STAFF_3,
+									},
+								],
+								rationale: [{ code: 'b', message: 'S2案1' }],
+							},
+						],
+					},
+				],
+				absence: {
+					staffId: TEST_IDS.STAFF_1,
+					startDate: new Date('2026-02-22T00:00:00+09:00'),
+					endDate: new Date('2026-02-22T00:00:00+09:00'),
+				},
+			},
+			error: null,
+			status: 200,
+		});
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				staffAbsenceRequest={{
+					staffId: TEST_IDS.STAFF_1,
+					startDate: '2026-02-22',
+					endDate: '2026-02-22',
+				}}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		);
+
+		expect(await screen.findByText('S1案1')).toBeInTheDocument();
+		expect(screen.getByText('S2案1')).toBeInTheDocument();
+		expect(screen.getAllByText('影響シフト:')).toHaveLength(2);
+	});
+
+	it('staff_absence提案フロー: 古いリクエストのレスポンスで最新表示を上書きしない', async () => {
+		const user = userEvent.setup();
+		const createAbsenceResponse = (message: string, toStaffId: string) => ({
+			data: {
+				affected: [
+					{
+						shift: {
+							id: TEST_IDS.SCHEDULE_1,
+							client_id: TEST_IDS.CLIENT_1,
+							service_type_id: 'physical-care',
+							staff_id: TEST_IDS.STAFF_1,
+							date: new Date('2026-02-22T00:00:00+09:00'),
+							start_time: { hour: 9, minute: 0 },
+							end_time: { hour: 10, minute: 0 },
+							status: 'scheduled' as const,
+						},
+						suggestions: [
+							{
+								operations: [
+									{
+										type: 'change_staff' as const,
+										shift_id: TEST_IDS.SCHEDULE_1,
+										from_staff_id: TEST_IDS.STAFF_1,
+										to_staff_id: toStaffId,
+									},
+								],
+								rationale: [{ code: 'code', message }],
+							},
+						],
+					},
+				],
+				absence: {
+					staffId: TEST_IDS.STAFF_1,
+					startDate: new Date('2026-02-22T00:00:00+09:00'),
+					endDate: new Date('2026-02-22T00:00:00+09:00'),
+				},
+			},
+			error: null,
+			status: 200 as const,
+		});
+
+		type AbsenceResponse = ReturnType<typeof createAbsenceResponse>;
+		let resolveFirst: ((value: AbsenceResponse) => void) | undefined;
+		const firstPromise = new Promise<AbsenceResponse>((resolve) => {
+			resolveFirst = resolve;
+		});
+
+		actionMocks.suggestStaffAbsenceAdjustmentsAction
+			.mockImplementationOnce(() => firstPromise)
+			.mockResolvedValueOnce(createAbsenceResponse('LATEST', TEST_IDS.STAFF_2));
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				staffAbsenceRequest={{
+					staffId: TEST_IDS.STAFF_1,
+					startDate: '2026-02-22',
+					endDate: '2026-02-22',
+				}}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		);
+		await user.click(screen.getByRole('button', { name: '戻る' }));
+		await user.click(
+			screen.getByRole('button', { name: 'スタッフ急休の提案を確認' }),
+		);
+
+		expect(await screen.findByText('LATEST')).toBeInTheDocument();
+		resolveFirst?.(createAbsenceResponse('OLD', TEST_IDS.STAFF_3));
+
+		await waitFor(() => {
+			expect(screen.queryByText('OLD')).not.toBeInTheDocument();
+		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { suggestStaffAbsenceAdjustmentsAction } from '@/app/actions/shiftAdjustments';
 import {
 	suggestCandidateStaffForShiftAction,
 	suggestCandidateStaffForShiftWithNewDatetimeAction,
@@ -7,6 +8,11 @@ import {
 } from '@/app/actions/shifts';
 import type { ActionResult } from '@/app/actions/utils/actionResult';
 import { errorResult, successResult } from '@/app/actions/utils/actionResult';
+import { useActionResultHandler } from '@/hooks/useActionResultHandler';
+import type {
+	StaffAbsenceActionInput,
+	SuggestShiftAdjustmentsOutput,
+} from '@/models/shiftAdjustmentActionSchemas';
 import { formatJstDateString, getJstHours, getJstMinutes } from '@/utils/date';
 import {
 	type SyntheticEvent,
@@ -30,14 +36,17 @@ type WizardStep =
 	| 'select'
 	| 'helper-candidates'
 	| 'datetime-input'
-	| 'datetime-candidates';
+	| 'datetime-candidates'
+	| 'staff-absence-suggestions';
 
 const SelectStep = ({
 	onSelectHelperCandidates,
 	onSelectDatetime,
+	onSelectStaffAbsence,
 }: {
 	onSelectHelperCandidates: () => void;
 	onSelectDatetime: () => void;
+	onSelectStaffAbsence?: () => void;
 }) => {
 	return (
 		<div className="space-y-3">
@@ -60,6 +69,15 @@ const SelectStep = ({
 				>
 					日時の変更
 				</button>
+				{onSelectStaffAbsence && (
+					<button
+						type="button"
+						className="btn btn-outline sm:col-span-2"
+						onClick={onSelectStaffAbsence}
+					>
+						スタッフ急休の提案を確認
+					</button>
+				)}
 			</div>
 		</div>
 	);
@@ -80,6 +98,7 @@ type AdjustmentWizardDialogProps = {
 	onClose: () => void;
 	onAssigned?: (suggestion: AdjustmentWizardSuggestion) => void;
 	onCascadeReopen?: (shiftIds: string[]) => void;
+	staffAbsenceRequest?: StaffAbsenceActionInput;
 };
 
 type Candidate =
@@ -182,6 +201,27 @@ const successNoPersist = (): ActionResult<{
 	status: 200,
 });
 
+type StaffAbsenceAffectedSuggestion =
+	SuggestShiftAdjustmentsOutput['affected'][number];
+
+const toTimeLabel = (time: { hour: number; minute: number }) =>
+	`${String(time.hour).padStart(2, '0')}:${String(time.minute).padStart(2, '0')}`;
+
+const STAFF_ABSENCE_FETCH_ERROR_MESSAGE = '提案の取得に失敗しました';
+
+const toOperationLabel = (
+	operation: StaffAbsenceAffectedSuggestion['suggestions'][number]['operations'][number],
+) => {
+	switch (operation.type) {
+		case 'change_staff':
+			return `担当変更: ${operation.from_staff_id} → ${operation.to_staff_id}`;
+		case 'update_shift_schedule':
+			return `日時変更: ${formatJstDateString(operation.new_date)} ${toTimeLabel(operation.new_start_time)}-${toTimeLabel(operation.new_end_time)}`;
+		default:
+			return '';
+	}
+};
+
 export const AdjustmentWizardDialog = ({
 	isOpen,
 	shiftId,
@@ -190,6 +230,7 @@ export const AdjustmentWizardDialog = ({
 	onClose,
 	onAssigned,
 	onCascadeReopen,
+	staffAbsenceRequest,
 }: AdjustmentWizardDialogProps) => {
 	const dialogRef = useRef<HTMLDialogElement>(null);
 	const inputIdBase = useId();
@@ -204,6 +245,17 @@ export const AdjustmentWizardDialog = ({
 		newEndTime: initialEndTime,
 	});
 	const selectedSuggestionRef = useRef<AdjustmentWizardSuggestion | null>(null);
+	const [staffAbsenceSuggestions, setStaffAbsenceSuggestions] = useState<
+		SuggestShiftAdjustmentsOutput['affected']
+	>([]);
+	const [staffAbsenceError, setStaffAbsenceError] = useState<string | null>(
+		null,
+	);
+	const [isStaffAbsenceLoading, setIsStaffAbsenceLoading] = useState(false);
+	const [selectedStaffAbsenceSuggestions, setSelectedStaffAbsenceSuggestions] =
+		useState<Record<string, number>>({});
+	const staffAbsenceRequestIdRef = useRef(0);
+	const { handleActionResult } = useActionResultHandler();
 
 	const requestHelperCandidates = useCallback<
 		NonNullable<StepHelperCandidatesProps['requestCandidates']>
@@ -270,6 +322,84 @@ export const AdjustmentWizardDialog = ({
 		[],
 	);
 
+	const resetStaffAbsenceState = useCallback((invalidateRequest = false) => {
+		if (invalidateRequest) {
+			staffAbsenceRequestIdRef.current += 1;
+		}
+		setStaffAbsenceSuggestions([]);
+		setSelectedStaffAbsenceSuggestions({});
+		setStaffAbsenceError(null);
+		setIsStaffAbsenceLoading(false);
+	}, []);
+
+	const handleSelectStaffAbsence = useCallback(async () => {
+		if (!staffAbsenceRequest) {
+			return;
+		}
+
+		const requestId = staffAbsenceRequestIdRef.current + 1;
+		staffAbsenceRequestIdRef.current = requestId;
+
+		setStep('staff-absence-suggestions');
+		setIsStaffAbsenceLoading(true);
+		setStaffAbsenceError(null);
+
+		try {
+			const result =
+				await suggestStaffAbsenceAdjustmentsAction(staffAbsenceRequest);
+			if (staffAbsenceRequestIdRef.current !== requestId) {
+				return;
+			}
+
+			const normalizedResult: ActionResult<SuggestShiftAdjustmentsOutput> =
+				result.error || !result.data
+					? mapActionError<SuggestShiftAdjustmentsOutput>(
+							result.error,
+							result.status,
+							result.details,
+							STAFF_ABSENCE_FETCH_ERROR_MESSAGE,
+						)
+					: result;
+
+			handleActionResult(normalizedResult, {
+				errorMessage:
+					normalizedResult.status >= 500
+						? STAFF_ABSENCE_FETCH_ERROR_MESSAGE
+						: undefined,
+				onSuccess: (data) => {
+					if (!data) {
+						return;
+					}
+					const initialSelections = Object.fromEntries(
+						data.affected.map((affected) => [affected.shift.id, 0]),
+					) as Record<string, number>;
+					setStaffAbsenceSuggestions(data.affected);
+					setSelectedStaffAbsenceSuggestions(initialSelections);
+				},
+				onError: (_error, actionResult) => {
+					setStaffAbsenceSuggestions([]);
+					setSelectedStaffAbsenceSuggestions({});
+					setStaffAbsenceError(
+						actionResult.status >= 500
+							? STAFF_ABSENCE_FETCH_ERROR_MESSAGE
+							: (actionResult.error ?? STAFF_ABSENCE_FETCH_ERROR_MESSAGE),
+					);
+				},
+			});
+		} catch {
+			if (staffAbsenceRequestIdRef.current !== requestId) {
+				return;
+			}
+			setStaffAbsenceSuggestions([]);
+			setSelectedStaffAbsenceSuggestions({});
+			setStaffAbsenceError(STAFF_ABSENCE_FETCH_ERROR_MESSAGE);
+		} finally {
+			if (staffAbsenceRequestIdRef.current === requestId) {
+				setIsStaffAbsenceLoading(false);
+			}
+		}
+	}, [handleActionResult, staffAbsenceRequest]);
+
 	useEffect(() => {
 		if (!isOpen) {
 			return;
@@ -283,13 +413,20 @@ export const AdjustmentWizardDialog = ({
 				newStartTime: initialStartTime,
 				newEndTime: initialEndTime,
 			});
+			resetStaffAbsenceState(true);
 			selectedSuggestionRef.current = null;
 		}, 0);
 
 		return () => {
 			clearTimeout(timer);
 		};
-	}, [initialEndTime, initialStartTime, isOpen, shiftId]);
+	}, [
+		initialEndTime,
+		initialStartTime,
+		isOpen,
+		resetStaffAbsenceState,
+		shiftId,
+	]);
 
 	useEffect(() => {
 		const dialog = dialogRef.current;
@@ -306,12 +443,14 @@ export const AdjustmentWizardDialog = ({
 
 	const handleRequestClose = () => {
 		setStep('select');
+		resetStaffAbsenceState(true);
 		selectedSuggestionRef.current = null;
 		onClose();
 	};
 
 	const handleDialogClose = () => {
 		setStep('select');
+		resetStaffAbsenceState(true);
 		selectedSuggestionRef.current = null;
 		if (isOpen) {
 			onClose();
@@ -321,6 +460,7 @@ export const AdjustmentWizardDialog = ({
 	const handleDialogCancel = (event: SyntheticEvent<HTMLDialogElement>) => {
 		event.preventDefault();
 		setStep('select');
+		resetStaffAbsenceState(true);
 		selectedSuggestionRef.current = null;
 		onClose();
 	};
@@ -343,6 +483,10 @@ export const AdjustmentWizardDialog = ({
 			case 'datetime-candidates':
 				setStep('datetime-input');
 				break;
+			case 'staff-absence-suggestions':
+				resetStaffAbsenceState(true);
+				setStep('select');
+				break;
 			default:
 				break;
 		}
@@ -355,6 +499,9 @@ export const AdjustmentWizardDialog = ({
 					<SelectStep
 						onSelectHelperCandidates={() => setStep('helper-candidates')}
 						onSelectDatetime={() => setStep('datetime-input')}
+						onSelectStaffAbsence={
+							staffAbsenceRequest ? handleSelectStaffAbsence : undefined
+						}
 					/>
 				);
 			case 'helper-candidates':
@@ -389,6 +536,102 @@ export const AdjustmentWizardDialog = ({
 						requestCandidates={requestDatetimeCandidates}
 						requestAssign={requestDatetimeAssign}
 					/>
+				);
+			case 'staff-absence-suggestions':
+				if (isStaffAbsenceLoading) {
+					return <div className="alert alert-info">提案を取得中...</div>;
+				}
+
+				if (staffAbsenceError) {
+					return <div className="alert alert-error">{staffAbsenceError}</div>;
+				}
+
+				if (staffAbsenceSuggestions.length === 0) {
+					return (
+						<div className="alert alert-warning">提案はありませんでした。</div>
+					);
+				}
+
+				return (
+					<div className="space-y-4">
+						{staffAbsenceSuggestions.map((affected) => (
+							<section
+								key={affected.shift.id}
+								className="rounded-lg border border-base-300 p-3"
+							>
+								<p className="text-sm font-semibold">影響シフト:</p>
+								<p className="text-xs text-base-content/70">
+									{formatJstDateString(affected.shift.date)}{' '}
+									{toTimeLabel(affected.shift.start_time)}-
+									{toTimeLabel(affected.shift.end_time)}
+								</p>
+								<div className="mt-3 space-y-3">
+									{affected.suggestions.map((suggestion, index) => {
+										const radioId = `${inputIdBase}-${affected.shift.id}-suggestion-${index}`;
+										return (
+											<label
+												key={radioId}
+												htmlFor={radioId}
+												className="block space-y-2 rounded border border-base-300 p-3"
+											>
+												<div className="flex items-center gap-2">
+													<input
+														id={radioId}
+														type="radio"
+														name={`staff-absence-${affected.shift.id}`}
+														className="radio radio-sm"
+														checked={
+															selectedStaffAbsenceSuggestions[
+																affected.shift.id
+															] === index
+														}
+														onChange={() => {
+															setSelectedStaffAbsenceSuggestions((prev) => ({
+																...prev,
+																[affected.shift.id]: index,
+															}));
+														}}
+													/>
+													<span className="font-medium">案{index + 1}</span>
+												</div>
+												<ul className="list-inside list-disc text-sm">
+													{suggestion.operations.map(
+														(operation, operationIndex) => (
+															<li
+																key={`${radioId}-operation-${operationIndex}`}
+															>
+																{toOperationLabel(operation)}
+															</li>
+														),
+													)}
+												</ul>
+												<ul className="list-inside list-disc text-xs text-base-content/80">
+													{suggestion.rationale.map(
+														(rationale, rationaleIndex) => (
+															<li
+																key={`${radioId}-rationale-${rationaleIndex}`}
+															>
+																{rationale.message}
+															</li>
+														),
+													)}
+												</ul>
+											</label>
+										);
+									})}
+								</div>
+							</section>
+						))}
+						<div className="flex justify-end">
+							<button
+								type="button"
+								className="btn btn-primary"
+								onClick={handleRequestClose}
+							>
+								確認して閉じる
+							</button>
+						</div>
+					</div>
 				);
 			default:
 				return null;

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
@@ -82,6 +82,7 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 		shiftId,
 		initialStartTime,
 		initialEndTime,
+		staffAbsenceRequest,
 		onAssigned,
 		onClose,
 		onCascadeReopen,
@@ -90,6 +91,11 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 		shiftId: string;
 		initialStartTime: Date;
 		initialEndTime: Date;
+		staffAbsenceRequest?: {
+			staffId: string;
+			startDate: Date;
+			endDate: Date;
+		};
 		onClose?: () => void;
 		onAssigned?: (payload: {
 			shiftId: string;
@@ -104,6 +110,13 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 				<p>Wizard Open: {shiftId}</p>
 				<p>Start: {initialStartTime.toISOString()}</p>
 				<p>End: {initialEndTime.toISOString()}</p>
+				{staffAbsenceRequest && (
+					<>
+						<p>Staff absence request: {staffAbsenceRequest.staffId}</p>
+						<p>Absence start: {staffAbsenceRequest.startDate.toISOString()}</p>
+						<p>Absence end: {staffAbsenceRequest.endDate.toISOString()}</p>
+					</>
+				)}
 				<button type="button" onClick={() => onClose?.()}>
 					Wizardを閉じる
 				</button>
@@ -254,5 +267,50 @@ describe('WeeklySchedulePage (Adjustment entry)', () => {
 		expect(
 			screen.queryByText(`Wizard Open: ${TEST_IDS.SCHEDULE_1}`),
 		).not.toBeInTheDocument();
+	});
+
+	it('ChangeStaffDialog経由で開いたWizardに staffAbsenceRequest を渡す', async () => {
+		const user = userEvent.setup();
+
+		render(<WeeklySchedulePage {...defaultProps} />);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+
+		expect(
+			screen.getByText(`Staff absence request: ${TEST_IDS.STAFF_1}`),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Absence start: 2026-01-19T00:00:00.000Z'),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Absence end: 2026-01-19T00:00:00.000Z'),
+		).toBeInTheDocument();
+	});
+
+	it('staffId が null のシフトでは staffAbsenceRequest を渡さない', async () => {
+		const user = userEvent.setup();
+		render(
+			<WeeklySchedulePage
+				{...defaultProps}
+				initialShifts={[
+					{
+						...sampleShifts[0],
+						staffId: null,
+						staffName: null,
+						isUnassigned: true,
+					},
+				]}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+
+		expect(
+			screen.queryByText(/Staff absence request:/),
+		).not.toBeInTheDocument();
+		expect(screen.queryByText(/Absence start:/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Absence end:/)).not.toBeInTheDocument();
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
@@ -2,6 +2,7 @@
 
 import { generateWeeklyShiftsAction } from '@/app/actions/weeklySchedules';
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import type { StaffAbsenceActionInput } from '@/models/shiftAdjustmentActionSchemas';
 import { ServiceTypeLabels } from '@/models/valueObjects/serviceTypeId';
 import { formatJstDateString, getJstDateOnly } from '@/utils/date';
 import { useRouter } from 'next/navigation';
@@ -113,6 +114,20 @@ const getReopenWizardShiftId = (
 		: null;
 };
 
+const createStaffAbsenceRequest = (
+	shift: ShiftDisplayRow | null,
+): StaffAbsenceActionInput | undefined => {
+	if (!shift?.staffId) {
+		return undefined;
+	}
+
+	return {
+		staffId: shift.staffId,
+		startDate: shift.date,
+		endDate: shift.date,
+	};
+};
+
 const renderScheduleContent = ({
 	hasShifts,
 	viewMode,
@@ -208,6 +223,7 @@ export const WeeklySchedulePage = ({
 		useState<string | undefined>();
 
 	const wizardShift = findShiftById(initialShifts, wizardShiftId);
+	const wizardStaffAbsenceRequest = createStaffAbsenceRequest(wizardShift);
 
 	const handleOpenCreateOneOffShiftDialog = (
 		defaultDateStr: string,
@@ -343,6 +359,7 @@ export const WeeklySchedulePage = ({
 					onCascadeReopen={(shiftIds) => {
 						setWizardShiftId(getReopenWizardShiftId(initialShifts, shiftIds));
 					}}
+					staffAbsenceRequest={wizardStaffAbsenceRequest}
 				/>
 			)}
 


### PR DESCRIPTION
## 概要
Phase2の現時点差分として、Task1（staff_absence提案UI）に加えて、WeeklySchedulePage からの導線接続とUT補強を実施しました。

## 変更内容
- `AdjustmentWizardDialog` に `staff-absence-suggestions` ステップを追加
- `suggestStaffAbsenceAdjustmentsAction` を呼び出し、`affected[].suggestions` の operations / rationale を表示
- `WeeklySchedulePage` から Wizard へ `staffAbsenceRequest` を受け渡す導線を追加
- 4ファイルに対するユニットテストを追加・更新し、staff_absence導線と表示挙動を検証

## 設計メモ（Phase2方針）
- 非永続化方針を維持（更新系actionは呼び出さない）
- staff_absence提案UIはPhase2初期導線であり、選択結果の反映は後続Taskで対応

## 動作確認
- 関連UT実行: pass
- 対象ファイルESLint: pass

## 関連Issue
Refs #72
