### PR TITLE
Phase3: staff_absence選択結果を担当者変更ダイアログへ反映

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
@@ -909,6 +909,7 @@ describe('AdjustmentWizardDialog', () => {
 	it('staff_absence提案フロー: 案を選択して確認して閉じられ、更新系actionは呼ばれない', async () => {
 		const user = userEvent.setup();
 		const onClose = vi.fn();
+		const onStaffAbsenceSuggestionSelected = vi.fn();
 		actionMocks.suggestStaffAbsenceAdjustmentsAction.mockResolvedValue({
 			data: {
 				affected: [
@@ -966,6 +967,7 @@ describe('AdjustmentWizardDialog', () => {
 				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
 				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
 				onClose={onClose}
+				onStaffAbsenceSuggestionSelected={onStaffAbsenceSuggestionSelected}
 				staffAbsenceRequest={{
 					staffId: TEST_IDS.STAFF_1,
 					startDate: '2026-02-22',
@@ -981,6 +983,19 @@ describe('AdjustmentWizardDialog', () => {
 		await user.click(screen.getByRole('button', { name: '確認して閉じる' }));
 
 		expect(onClose).toHaveBeenCalledTimes(1);
+		expect(onStaffAbsenceSuggestionSelected).toHaveBeenCalledWith(
+			expect.objectContaining({
+				shift: expect.objectContaining({ id: TEST_IDS.SCHEDULE_1 }),
+				suggestion: expect.objectContaining({
+					operations: [
+						expect.objectContaining({
+							type: 'change_staff',
+							to_staff_id: TEST_IDS.STAFF_3,
+						}),
+					],
+				}),
+			}),
+		);
 		expect(
 			actionMocks.assignStaffWithCascadeUnassignAction,
 		).not.toHaveBeenCalled();

--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.tsx
@@ -90,6 +90,11 @@ export type AdjustmentWizardSuggestion = {
 	newEndTime: Date;
 };
 
+export type AdjustmentWizardStaffAbsenceSelection = {
+	shift: SuggestShiftAdjustmentsOutput['affected'][number]['shift'];
+	suggestion: SuggestShiftAdjustmentsOutput['affected'][number]['suggestions'][number];
+};
+
 type AdjustmentWizardDialogProps = {
 	isOpen: boolean;
 	shiftId: string;
@@ -97,6 +102,9 @@ type AdjustmentWizardDialogProps = {
 	initialEndTime: Date;
 	onClose: () => void;
 	onAssigned?: (suggestion: AdjustmentWizardSuggestion) => void;
+	onStaffAbsenceSuggestionSelected?: (
+		selection: AdjustmentWizardStaffAbsenceSelection,
+	) => void;
 	onCascadeReopen?: (shiftIds: string[]) => void;
 	staffAbsenceRequest?: StaffAbsenceActionInput;
 };
@@ -229,6 +237,7 @@ export const AdjustmentWizardDialog = ({
 	initialEndTime,
 	onClose,
 	onAssigned,
+	onStaffAbsenceSuggestionSelected,
 	onCascadeReopen,
 	staffAbsenceRequest,
 }: AdjustmentWizardDialogProps) => {
@@ -472,6 +481,27 @@ export const AdjustmentWizardDialog = ({
 		handleRequestClose();
 	};
 
+	const handleStaffAbsenceComplete = () => {
+		const selectedAffectedShift = staffAbsenceSuggestions.find(
+			(affected) => affected.shift.id === shiftId,
+		);
+
+		if (selectedAffectedShift) {
+			const selectedIndex =
+				selectedStaffAbsenceSuggestions[selectedAffectedShift.shift.id] ?? 0;
+			const selectedSuggestion =
+				selectedAffectedShift.suggestions[selectedIndex];
+			if (selectedSuggestion) {
+				onStaffAbsenceSuggestionSelected?.({
+					shift: selectedAffectedShift.shift,
+					suggestion: selectedSuggestion,
+				});
+			}
+		}
+
+		handleRequestClose();
+	};
+
 	const handleBack = () => {
 		switch (step) {
 			case 'helper-candidates':
@@ -626,7 +656,7 @@ export const AdjustmentWizardDialog = ({
 							<button
 								type="button"
 								className="btn btn-primary"
-								onClick={handleRequestClose}
+								onClick={handleStaffAbsenceComplete}
 							>
 								確認して閉じる
 							</button>

--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/index.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/index.ts
@@ -1,5 +1,8 @@
 export { AdjustmentWizardDialog } from './AdjustmentWizardDialog';
-export type { AdjustmentWizardSuggestion } from './AdjustmentWizardDialog';
+export type {
+	AdjustmentWizardStaffAbsenceSelection,
+	AdjustmentWizardSuggestion,
+} from './AdjustmentWizardDialog';
 export { StepDatetimeCandidates } from './StepDatetimeCandidates';
 export { StepDatetimeInput } from './StepDatetimeInput';
 export { StepHelperCandidates } from './StepHelperCandidates';

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
@@ -84,6 +84,7 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 		initialEndTime,
 		staffAbsenceRequest,
 		onAssigned,
+		onStaffAbsenceSuggestionSelected,
 		onClose,
 		onCascadeReopen,
 	}: {
@@ -102,6 +103,32 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 			newStaffId: string;
 			newStartTime: Date;
 			newEndTime: Date;
+		}) => void;
+		onStaffAbsenceSuggestionSelected?: (payload: {
+			shift: {
+				id: string;
+				date: Date;
+				start_time: { hour: number; minute: number };
+				end_time: { hour: number; minute: number };
+				staff_id: string | null;
+			};
+			suggestion: {
+				operations: Array<
+					| {
+							type: 'change_staff';
+							shift_id: string;
+							from_staff_id: string;
+							to_staff_id: string;
+					  }
+					| {
+							type: 'update_shift_schedule';
+							shift_id: string;
+							new_date: Date;
+							new_start_time: { hour: number; minute: number };
+							new_end_time: { hour: number; minute: number };
+					  }
+				>;
+			};
 		}) => void;
 		onCascadeReopen?: (shiftIds: string[]) => void;
 	}) =>
@@ -133,6 +160,130 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 					}}
 				>
 					候補確定
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						onStaffAbsenceSuggestionSelected?.({
+							shift: {
+								id: shiftId,
+								date: new Date('2026-01-19T00:00:00.000Z'),
+								start_time: { hour: 9, minute: 0 },
+								end_time: { hour: 10, minute: 0 },
+								staff_id: TEST_IDS.STAFF_1,
+							},
+							suggestion: {
+								operations: [
+									{
+										type: 'change_staff',
+										shift_id: shiftId,
+										from_staff_id: TEST_IDS.STAFF_1,
+										to_staff_id: TEST_IDS.STAFF_3,
+									},
+									{
+										type: 'update_shift_schedule',
+										shift_id: shiftId,
+										new_date: new Date('2026-01-19T00:00:00.000Z'),
+										new_start_time: { hour: 11, minute: 0 },
+										new_end_time: { hour: 12, minute: 0 },
+									},
+								],
+							},
+						});
+						onClose?.();
+					}}
+				>
+					急休提案を反映
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						onStaffAbsenceSuggestionSelected?.({
+							shift: {
+								id: shiftId,
+								date: new Date('2026-01-19T00:00:00.000Z'),
+								start_time: { hour: 9, minute: 0 },
+								end_time: { hour: 10, minute: 0 },
+								staff_id: TEST_IDS.STAFF_1,
+							},
+							suggestion: {
+								operations: [
+									{
+										type: 'update_shift_schedule',
+										shift_id: shiftId,
+										new_date: new Date('2026-01-19T00:00:00.000Z'),
+										new_start_time: { hour: 11, minute: 0 },
+										new_end_time: { hour: 12, minute: 0 },
+									},
+								],
+							},
+						});
+						onClose?.();
+					}}
+				>
+					急休提案を反映(updateのみ)
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						onStaffAbsenceSuggestionSelected?.({
+							shift: {
+								id: shiftId,
+								date: new Date('2026-01-19T00:00:00.000Z'),
+								start_time: { hour: 9, minute: 0 },
+								end_time: { hour: 10, minute: 0 },
+								staff_id: TEST_IDS.STAFF_1,
+							},
+							suggestion: {
+								operations: [
+									{
+										type: 'change_staff',
+										shift_id: TEST_IDS.SCHEDULE_2,
+										from_staff_id: TEST_IDS.STAFF_1,
+										to_staff_id: TEST_IDS.STAFF_3,
+									},
+									{
+										type: 'update_shift_schedule',
+										shift_id: TEST_IDS.SCHEDULE_2,
+										new_date: new Date('2026-01-19T00:00:00.000Z'),
+										new_start_time: { hour: 11, minute: 0 },
+										new_end_time: { hour: 12, minute: 0 },
+									},
+								],
+							},
+						});
+						onClose?.();
+					}}
+				>
+					急休提案を反映(shift_id不一致)
+				</button>
+				<button
+					type="button"
+					onClick={() => {
+						onStaffAbsenceSuggestionSelected?.({
+							shift: {
+								id: shiftId,
+								date: new Date('2026-01-19T00:00:00.000Z'),
+								start_time: { hour: 9, minute: 0 },
+								end_time: { hour: 10, minute: 0 },
+								staff_id: null,
+							},
+							suggestion: {
+								operations: [
+									{
+										type: 'update_shift_schedule',
+										shift_id: shiftId,
+										new_date: new Date('2026-01-19T00:00:00.000Z'),
+										new_start_time: { hour: 11, minute: 0 },
+										new_end_time: { hour: 12, minute: 0 },
+									},
+								],
+							},
+						});
+						onClose?.();
+					}}
+				>
+					急休提案を反映(newStaffId欠落)
 				</button>
 				<button
 					type="button"
@@ -247,6 +398,86 @@ describe('WeeklySchedulePage (Adjustment entry)', () => {
 		);
 		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
 
+		expect(screen.queryByText(/Suggested staff:/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Suggested start:/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Suggested end:/)).not.toBeInTheDocument();
+	});
+
+	it('staff_absence 選択結果を ChangeStaffDialog の initialSuggestion に正規化して注入する', async () => {
+		const user = userEvent.setup();
+		render(<WeeklySchedulePage {...defaultProps} />);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+		await user.click(screen.getByRole('button', { name: '急休提案を反映' }));
+
+		expect(mockRefresh).not.toHaveBeenCalled();
+		expect(
+			screen.getByText(`Suggested staff: ${TEST_IDS.STAFF_3}`),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Suggested start: 2026-01-19T02:00:00.000Z'),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Suggested end: 2026-01-19T03:00:00.000Z'),
+		).toBeInTheDocument();
+	});
+
+	it('staff_absence の update のみ提案は shift.staff_id を使って注入する', async () => {
+		const user = userEvent.setup();
+		render(<WeeklySchedulePage {...defaultProps} />);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+		await user.click(
+			screen.getByRole('button', { name: '急休提案を反映(updateのみ)' }),
+		);
+
+		expect(mockRefresh).not.toHaveBeenCalled();
+		expect(
+			screen.getByText(`Suggested staff: ${TEST_IDS.STAFF_1}`),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Suggested start: 2026-01-19T02:00:00.000Z'),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Suggested end: 2026-01-19T03:00:00.000Z'),
+		).toBeInTheDocument();
+	});
+
+	it('staff_absence の operation.shift_id が不一致なら対象shiftの値へフォールバックする', async () => {
+		const user = userEvent.setup();
+		render(<WeeklySchedulePage {...defaultProps} />);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+		await user.click(
+			screen.getByRole('button', { name: '急休提案を反映(shift_id不一致)' }),
+		);
+
+		expect(mockRefresh).not.toHaveBeenCalled();
+		expect(
+			screen.getByText(`Suggested staff: ${TEST_IDS.STAFF_1}`),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Suggested start: 2026-01-19T00:00:00.000Z'),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('Suggested end: 2026-01-19T01:00:00.000Z'),
+		).toBeInTheDocument();
+	});
+
+	it('staff_absence 正規化後に newStaffId を解決できない場合は提案を注入しない', async () => {
+		const user = userEvent.setup();
+		render(<WeeklySchedulePage {...defaultProps} />);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+		await user.click(
+			screen.getByRole('button', { name: '急休提案を反映(newStaffId欠落)' }),
+		);
+
+		expect(mockRefresh).not.toHaveBeenCalled();
 		expect(screen.queryByText(/Suggested staff:/)).not.toBeInTheDocument();
 		expect(screen.queryByText(/Suggested start:/)).not.toBeInTheDocument();
 		expect(screen.queryByText(/Suggested end:/)).not.toBeInTheDocument();

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import {
 	AdjustmentWizardDialog,
+	type AdjustmentWizardStaffAbsenceSelection,
 	type AdjustmentWizardSuggestion,
 } from '../AdjustmentWizardDialog';
 import {
@@ -125,6 +126,91 @@ const createStaffAbsenceRequest = (
 		staffId: shift.staffId,
 		startDate: shift.date,
 		endDate: shift.date,
+	};
+};
+
+type StaffAbsenceOperation =
+	AdjustmentWizardStaffAbsenceSelection['suggestion']['operations'][number];
+
+type ChangeStaffOperation = Extract<
+	StaffAbsenceOperation,
+	{ type: 'change_staff' }
+>;
+
+type UpdateShiftScheduleOperation = Extract<
+	StaffAbsenceOperation,
+	{ type: 'update_shift_schedule' }
+>;
+
+const isChangeStaffOperationForShift =
+	(shiftId: string) =>
+	(operation: StaffAbsenceOperation): operation is ChangeStaffOperation =>
+		operation.type === 'change_staff' && operation.shift_id === shiftId;
+
+const isUpdateShiftScheduleOperationForShift =
+	(shiftId: string) =>
+	(
+		operation: StaffAbsenceOperation,
+	): operation is UpdateShiftScheduleOperation =>
+		operation.type === 'update_shift_schedule' &&
+		operation.shift_id === shiftId;
+
+const findChangeStaffOperation = (
+	selection: AdjustmentWizardStaffAbsenceSelection,
+) =>
+	selection.suggestion.operations.find(
+		isChangeStaffOperationForShift(selection.shift.id),
+	);
+
+const findUpdateShiftScheduleOperation = (
+	selection: AdjustmentWizardStaffAbsenceSelection,
+) =>
+	selection.suggestion.operations.find(
+		isUpdateShiftScheduleOperationForShift(selection.shift.id),
+	);
+
+const resolveStaffAbsenceSuggestionStaffId = (
+	selection: AdjustmentWizardStaffAbsenceSelection,
+) => {
+	const changeStaffOperation = findChangeStaffOperation(selection);
+	return changeStaffOperation?.to_staff_id ?? selection.shift.staff_id ?? null;
+};
+
+const resolveStaffAbsenceSuggestionSchedule = (
+	selection: AdjustmentWizardStaffAbsenceSelection,
+) => {
+	const updateShiftScheduleOperation =
+		findUpdateShiftScheduleOperation(selection);
+	if (!updateShiftScheduleOperation) {
+		return {
+			date: selection.shift.date,
+			startTime: selection.shift.start_time,
+			endTime: selection.shift.end_time,
+		};
+	}
+
+	return {
+		date: updateShiftScheduleOperation.new_date,
+		startTime: updateShiftScheduleOperation.new_start_time,
+		endTime: updateShiftScheduleOperation.new_end_time,
+	};
+};
+
+const normalizeStaffAbsenceSelection = (
+	selection: AdjustmentWizardStaffAbsenceSelection,
+): AdjustmentWizardSuggestion | null => {
+	const newStaffId = resolveStaffAbsenceSuggestionStaffId(selection);
+	if (!newStaffId) {
+		return null;
+	}
+
+	const schedule = resolveStaffAbsenceSuggestionSchedule(selection);
+
+	return {
+		shiftId: selection.shift.id,
+		newStaffId,
+		newStartTime: shiftToDateTime(schedule.date, schedule.startTime),
+		newEndTime: shiftToDateTime(schedule.date, schedule.endTime),
 	};
 };
 
@@ -277,7 +363,9 @@ export const WeeklySchedulePage = ({
 		router.refresh();
 	};
 
-	const handleWizardAssigned = (suggestion: AdjustmentWizardSuggestion) => {
+	const openChangeDialogWithSuggestion = (
+		suggestion: AdjustmentWizardSuggestion,
+	) => {
 		setWizardShiftId(null);
 
 		const targetShift =
@@ -289,6 +377,23 @@ export const WeeklySchedulePage = ({
 
 		setWizardSuggestion(suggestion);
 		setChangeDialogShift(targetShift);
+	};
+
+	const handleWizardAssigned = (suggestion: AdjustmentWizardSuggestion) => {
+		openChangeDialogWithSuggestion(suggestion);
+	};
+
+	const handleStaffAbsenceSuggestionSelected = (
+		selection: AdjustmentWizardStaffAbsenceSelection,
+	) => {
+		const normalizedSuggestion = normalizeStaffAbsenceSelection(selection);
+		if (!normalizedSuggestion) {
+			setWizardShiftId(null);
+			setWizardSuggestion(null);
+			return;
+		}
+
+		openChangeDialogWithSuggestion(normalizedSuggestion);
 	};
 
 	const hasShifts = initialShifts.length > 0;
@@ -356,6 +461,9 @@ export const WeeklySchedulePage = ({
 						setWizardShiftId(null);
 					}}
 					onAssigned={handleWizardAssigned}
+					onStaffAbsenceSuggestionSelected={
+						handleStaffAbsenceSuggestionSelected
+					}
 					onCascadeReopen={(shiftIds) => {
 						setWizardShiftId(getReopenWizardShiftId(initialShifts, shiftIds));
 					}}


### PR DESCRIPTION
## 概要
Phase3（選択結果反映）として、Adjustment Wizard の staff_absence 提案で選択した案を既存の担当者変更フローへ接続しました。非永続化方針を維持しつつ、ChangeStaffDialog の `initialSuggestion` に正規化した値を注入します。

Refs #72

## 変更内容
- Wizard callback追加
  - `AdjustmentWizardDialog` に `onStaffAbsenceSuggestionSelected` を追加
  - 「確認して閉じる」押下時に、対象 shift の選択 suggestion を callback で返却
- WeeklySchedulePageで正規化してinitialSuggestion注入
  - `selection.suggestion.operations` を `AdjustmentWizardSuggestion` へ正規化
  - 正規化した提案を既存 `openChangeDialogWithSuggestion` 経由で `ChangeStaffDialog` に注入
  - 既存フロー互換を維持（`onAssigned` 導線はそのまま）
- shift_id一致チェック
  - `change_staff` / `update_shift_schedule` は `operation.shift_id === selection.shift.id` のものだけ採用
  - 不一致時は対象 shift の元データへフォールバック

## テスト
- 追加UT
  - `AdjustmentWizardDialog.test.tsx`
    - staff_absence 提案の「確認して閉じる」で callback が選択案を返すことを検証
  - `WeeklySchedulePage.adjustment.test.tsx`
    - staff_absence 選択結果を `initialSuggestion` へ正規化注入できること
    - `update_shift_schedule` のみの提案で `shift.staff_id` を利用すること
    - `operation.shift_id` 不一致時に対象 shift 値へフォールバックすること
    - `newStaffId` 解決不可時は注入しないこと

- 実行結果
  - `pnpm -s vitest --project unit --run src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx`
  - 結果: 2 files, 34 tests passed
  - `pnpm -s eslint <変更5ファイル>` も通過

## 影響範囲
- `src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/*`
- `src/app/admin/weekly-schedules/_components/WeeklySchedulePage/*`
