### PR TITLE
Issue #72 Phase A: 調整ウィザードのUIモック注入経路を追加

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
@@ -306,6 +306,64 @@ describe('AdjustmentWizardDialog', () => {
 		expect(result.data?.cascadeUnassignedShiftIds).toEqual([]);
 	});
 
+	it('Partial mock: helper candidatesのみ差し替え時、assignはnon-persistentフォールバックを使う', async () => {
+		const user = userEvent.setup();
+		const requestHelperCandidates = vi.fn().mockResolvedValue({
+			data: {
+				candidates: [
+					{
+						staffId: TEST_IDS.STAFF_1,
+						staffName: 'モック候補',
+						conflictingShifts: [],
+					},
+				],
+			},
+			error: null,
+			status: 200,
+		});
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				mockApi={{ requestHelperCandidates }}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'ヘルパーの変更' }));
+
+		const helperProps = stepHelperCandidatesSpy.mock.lastCall?.[0] as {
+			requestCandidates: (input: { shiftId: string }) => Promise<unknown>;
+			requestAssign: (input: {
+				shiftId: string;
+				newStaffId: string;
+			}) => Promise<{
+				data: {
+					cascadeUnassignedShiftIds: string[];
+				} | null;
+				error: string | null;
+				status: number;
+			}>;
+		};
+
+		await helperProps.requestCandidates({ shiftId: TEST_IDS.SCHEDULE_1 });
+		const assignResult = await helperProps.requestAssign({
+			shiftId: TEST_IDS.SCHEDULE_1,
+			newStaffId: TEST_IDS.STAFF_1,
+		});
+
+		expect(requestHelperCandidates).toHaveBeenCalledWith({
+			shiftId: TEST_IDS.SCHEDULE_1,
+		});
+		expect(
+			actionMocks.assignStaffWithCascadeUnassignAction,
+		).not.toHaveBeenCalled();
+		expect(assignResult.data?.cascadeUnassignedShiftIds).toEqual([]);
+	});
+
 	it('datetime割当は永続化せずに成功を返す', async () => {
 		const user = userEvent.setup();
 		render(

--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.tsx
@@ -80,6 +80,7 @@ type AdjustmentWizardDialogProps = {
 	onClose: () => void;
 	onAssigned?: (suggestion: AdjustmentWizardSuggestion) => void;
 	onCascadeReopen?: (shiftIds: string[]) => void;
+	mockApi?: AdjustmentWizardMockApi;
 };
 
 type Candidate =
@@ -92,6 +93,26 @@ type Candidate =
 				: never
 			: never
 		: never;
+
+/**
+ * UIモック用途の差し替え口。
+ *
+ * NOTE: 各 assign 系は永続化を伴わない契約です。
+ * 未指定のAPIは既定実装へフォールバックし、assign未指定時は
+ * `cascadeUnassignedShiftIds: []` を返す non-persistent 成功として扱います。
+ */
+export type AdjustmentWizardMockApi = Partial<{
+	requestHelperCandidates: NonNullable<
+		StepHelperCandidatesProps['requestCandidates']
+	>;
+	requestHelperAssign: NonNullable<StepHelperCandidatesProps['requestAssign']>;
+	requestDatetimeCandidates: NonNullable<
+		StepDatetimeCandidatesProps['requestCandidates']
+	>;
+	requestDatetimeAssign: NonNullable<
+		StepDatetimeCandidatesProps['requestAssign']
+	>;
+}>;
 
 const mapActionError = <T,>(
 	error: string | null,
@@ -172,6 +193,10 @@ const buildCandidates = async (
 	return successResult({ candidates });
 };
 
+/**
+ * assignment処理の既定戻り値。
+ * DB更新は行わず、UI遷移のための成功レスポンスのみ返却する。
+ */
 const successNoPersist = (): ActionResult<{
 	cascadeUnassignedShiftIds: string[];
 }> => ({
@@ -190,6 +215,7 @@ export const AdjustmentWizardDialog = ({
 	onClose,
 	onAssigned,
 	onCascadeReopen,
+	mockApi,
 }: AdjustmentWizardDialogProps) => {
 	const dialogRef = useRef<HTMLDialogElement>(null);
 	const inputIdBase = useId();
@@ -208,9 +234,14 @@ export const AdjustmentWizardDialog = ({
 	const requestHelperCandidates = useCallback<
 		NonNullable<StepHelperCandidatesProps['requestCandidates']>
 	>(
-		async ({ shiftId: targetShiftId }) =>
-			buildCandidates(targetShiftId, initialStartTime, initialEndTime),
-		[initialEndTime, initialStartTime],
+		async ({ shiftId: targetShiftId }) => {
+			if (mockApi?.requestHelperCandidates) {
+				return mockApi.requestHelperCandidates({ shiftId: targetShiftId });
+			}
+
+			return buildCandidates(targetShiftId, initialStartTime, initialEndTime);
+		},
+		[initialEndTime, initialStartTime, mockApi],
 	);
 
 	const requestHelperAssign = useCallback<
@@ -223,32 +254,51 @@ export const AdjustmentWizardDialog = ({
 				newStartTime: initialStartTime,
 				newEndTime: initialEndTime,
 			};
+
+			if (mockApi?.requestHelperAssign) {
+				return mockApi.requestHelperAssign({
+					shiftId: targetShiftId,
+					newStaffId,
+				});
+			}
+
 			return successNoPersist();
 		},
-		[initialEndTime, initialStartTime],
+		[initialEndTime, initialStartTime, mockApi],
 	);
 
 	const requestDatetimeCandidates = useCallback<
 		NonNullable<StepDatetimeCandidatesProps['requestCandidates']>
-	>(async ({ shiftId: targetShiftId, newStartTime, newEndTime }) => {
-		const suggestResult =
-			await suggestCandidateStaffForShiftWithNewDatetimeAction({
-				shiftId: targetShiftId,
-				newStartTime,
-				newEndTime,
-			});
+	>(
+		async ({ shiftId: targetShiftId, newStartTime, newEndTime }) => {
+			if (mockApi?.requestDatetimeCandidates) {
+				return mockApi.requestDatetimeCandidates({
+					shiftId: targetShiftId,
+					newStartTime,
+					newEndTime,
+				});
+			}
 
-		if (suggestResult.error || !suggestResult.data) {
-			return mapActionError<{ candidates: Candidate[] }>(
-				suggestResult.error,
-				suggestResult.status,
-				suggestResult.details,
-				'候補スタッフの取得に失敗しました',
-			);
-		}
+			const suggestResult =
+				await suggestCandidateStaffForShiftWithNewDatetimeAction({
+					shiftId: targetShiftId,
+					newStartTime,
+					newEndTime,
+				});
 
-		return successResult({ candidates: suggestResult.data.candidates });
-	}, []);
+			if (suggestResult.error || !suggestResult.data) {
+				return mapActionError<{ candidates: Candidate[] }>(
+					suggestResult.error,
+					suggestResult.status,
+					suggestResult.details,
+					'候補スタッフの取得に失敗しました',
+				);
+			}
+
+			return successResult({ candidates: suggestResult.data.candidates });
+		},
+		[mockApi],
+	);
 
 	const requestDatetimeAssign = useCallback<
 		NonNullable<StepDatetimeCandidatesProps['requestAssign']>
@@ -265,9 +315,19 @@ export const AdjustmentWizardDialog = ({
 				newStartTime,
 				newEndTime,
 			};
+
+			if (mockApi?.requestDatetimeAssign) {
+				return mockApi.requestDatetimeAssign({
+					shiftId: targetShiftId,
+					newStaffId,
+					newStartTime,
+					newEndTime,
+				});
+			}
+
 			return successNoPersist();
 		},
-		[],
+		[mockApi],
 	);
 
 	useEffect(() => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/index.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/index.ts
@@ -1,5 +1,8 @@
 export { AdjustmentWizardDialog } from './AdjustmentWizardDialog';
-export type { AdjustmentWizardSuggestion } from './AdjustmentWizardDialog';
+export type {
+	AdjustmentWizardMockApi,
+	AdjustmentWizardSuggestion,
+} from './AdjustmentWizardDialog';
 export { StepDatetimeCandidates } from './StepDatetimeCandidates';
 export { StepDatetimeInput } from './StepDatetimeInput';
 export { StepHelperCandidates } from './StepHelperCandidates';

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
@@ -5,6 +5,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
+let capturedWizardMockApi:
+	| {
+			requestHelperAssign?: (input: {
+				shiftId: string;
+				newStaffId: string;
+			}) => Promise<unknown>;
+	  }
+	| undefined;
 
 vi.mock('next/navigation', () => ({
 	useRouter: () => ({
@@ -82,6 +90,7 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 		shiftId,
 		initialStartTime,
 		initialEndTime,
+		mockApi,
 		onAssigned,
 		onClose,
 		onCascadeReopen,
@@ -90,6 +99,12 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 		shiftId: string;
 		initialStartTime: Date;
 		initialEndTime: Date;
+		mockApi?: {
+			requestHelperAssign?: (input: {
+				shiftId: string;
+				newStaffId: string;
+			}) => Promise<unknown>;
+		};
 		onClose?: () => void;
 		onAssigned?: (payload: {
 			shiftId: string;
@@ -101,6 +116,10 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 	}) =>
 		isOpen ? (
 			<div>
+				{(() => {
+					capturedWizardMockApi = mockApi;
+					return null;
+				})()}
 				<p>Wizard Open: {shiftId}</p>
 				<p>Start: {initialStartTime.toISOString()}</p>
 				<p>End: {initialEndTime.toISOString()}</p>
@@ -140,6 +159,7 @@ import {
 describe('WeeklySchedulePage (Adjustment entry)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		capturedWizardMockApi = undefined;
 	});
 	const sampleShifts: ShiftDisplayRow[] = [
 		{
@@ -254,5 +274,37 @@ describe('WeeklySchedulePage (Adjustment entry)', () => {
 		expect(
 			screen.queryByText(`Wizard Open: ${TEST_IDS.SCHEDULE_1}`),
 		).not.toBeInTheDocument();
+	});
+
+	it('UIモック経路では adjustmentWizardMockApi を Wizard に引き渡す', async () => {
+		const user = userEvent.setup();
+		const requestHelperAssign = vi.fn().mockResolvedValue({
+			data: { cascadeUnassignedShiftIds: [] },
+			error: null,
+			status: 200,
+		});
+
+		render(
+			<WeeklySchedulePage
+				{...defaultProps}
+				adjustmentWizardMockApi={{
+					requestHelperAssign,
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+
+		expect(capturedWizardMockApi).toBeDefined();
+		await capturedWizardMockApi?.requestHelperAssign?.({
+			shiftId: TEST_IDS.SCHEDULE_1,
+			newStaffId: TEST_IDS.STAFF_2,
+		});
+
+		expect(requestHelperAssign).toHaveBeenCalledWith({
+			shiftId: TEST_IDS.SCHEDULE_1,
+			newStaffId: TEST_IDS.STAFF_2,
+		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.stories.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.stories.tsx
@@ -3,6 +3,7 @@ import { TEST_IDS } from '@/test/helpers/testIds';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { fn } from 'storybook/test';
 import type { ShiftDisplayRow } from '../ShiftTable';
+import type { WeeklySchedulePageProps } from './WeeklySchedulePage';
 import { WeeklySchedulePage } from './WeeklySchedulePage';
 
 const meta: Meta<typeof WeeklySchedulePage> = {
@@ -180,5 +181,125 @@ export const ManyShifts: Story = {
 		],
 		staffOptions: sampleStaffOptions,
 		clientOptions: sampleClientOptions,
+	},
+};
+
+const helperCandidate = {
+	staffId: TEST_IDS.STAFF_2,
+	staffName: '佐々木健太',
+	conflictingShifts: [],
+};
+
+const mockApiWithCandidates: NonNullable<
+	WeeklySchedulePageProps['adjustmentWizardMockApi']
+> = {
+	requestHelperCandidates: async () => ({
+		data: { candidates: [helperCandidate] },
+		error: null,
+		status: 200,
+	}),
+	requestHelperAssign: async () => ({
+		data: { cascadeUnassignedShiftIds: [] },
+		error: null,
+		status: 200,
+	}),
+	requestDatetimeCandidates: async () => ({
+		data: { candidates: [helperCandidate] },
+		error: null,
+		status: 200,
+	}),
+	requestDatetimeAssign: async () => ({
+		data: { cascadeUnassignedShiftIds: [] },
+		error: null,
+		status: 200,
+	}),
+};
+
+const mockApiWithoutCandidates: NonNullable<
+	WeeklySchedulePageProps['adjustmentWizardMockApi']
+> = {
+	...mockApiWithCandidates,
+	requestHelperCandidates: async () => ({
+		data: { candidates: [] },
+		error: null,
+		status: 200,
+	}),
+	requestDatetimeCandidates: async () => ({
+		data: { candidates: [] },
+		error: null,
+		status: 200,
+	}),
+};
+
+const mockApiWithError: NonNullable<
+	WeeklySchedulePageProps['adjustmentWizardMockApi']
+> = {
+	...mockApiWithCandidates,
+	requestHelperCandidates: async () => ({
+		data: null,
+		error: 'Mock: 候補取得でエラー',
+		status: 500,
+	}),
+	requestDatetimeCandidates: async () => ({
+		data: null,
+		error: 'Mock: 候補取得でエラー',
+		status: 500,
+	}),
+};
+
+export const AdjustmentMockCandidates: Story = {
+	name: 'Adjustment Mock / 候補あり',
+	args: {
+		weekStartDate,
+		initialShifts: sampleShifts,
+		staffOptions: sampleStaffOptions,
+		clientOptions: sampleClientOptions,
+		adjustmentWizardMockApi: mockApiWithCandidates,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'「担当者変更 → 調整相談 → ヘルパーの変更」でモック候補（佐々木健太）が表示されます。',
+			},
+		},
+	},
+};
+
+export const AdjustmentMockNoCandidates: Story = {
+	name: 'Adjustment Mock / 候補なし',
+	args: {
+		weekStartDate,
+		initialShifts: sampleShifts,
+		staffOptions: sampleStaffOptions,
+		clientOptions: sampleClientOptions,
+		adjustmentWizardMockApi: mockApiWithoutCandidates,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'同じ導線で「候補ヘルパーが見つかりませんでした。」を確認できます。',
+			},
+		},
+	},
+};
+
+export const AdjustmentMockError: Story = {
+	name: 'Adjustment Mock / エラー',
+	args: {
+		weekStartDate,
+		initialShifts: sampleShifts,
+		staffOptions: sampleStaffOptions,
+		clientOptions: sampleClientOptions,
+		adjustmentWizardMockApi: mockApiWithError,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'同じ導線でエラー時挙動（候補が空表示になり、保存は行わない）を確認できます。',
+			},
+		},
 	},
 };

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.stories.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.stories.tsx
@@ -1,5 +1,7 @@
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import { getMonday } from '@/app/admin/weekly-schedules/helpers';
 import { TEST_IDS } from '@/test/helpers/testIds';
+import { addJstDays } from '@/utils/date';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { fn } from 'storybook/test';
 import type { ShiftDisplayRow } from '../ShiftTable';
@@ -31,7 +33,9 @@ const meta: Meta<typeof WeeklySchedulePage> = {
 export default meta;
 type Story = StoryObj<typeof WeeklySchedulePage>;
 
-const weekStartDate = new Date('2026-01-19T00:00:00');
+const weekStartDate = addJstDays(getMonday(new Date()), 7);
+const createShiftDate = (daysFromWeekStart: number): Date =>
+	addJstDays(weekStartDate, daysFromWeekStart);
 
 const sampleStaffOptions: StaffPickerOption[] = [
 	{
@@ -57,7 +61,7 @@ const sampleStaffOptions: StaffPickerOption[] = [
 const sampleShifts: ShiftDisplayRow[] = [
 	{
 		id: 'shift-1',
-		date: new Date('2026-01-19T00:00:00'),
+		date: createShiftDate(0),
 		startTime: { hour: 9, minute: 0 },
 		endTime: { hour: 10, minute: 0 },
 		clientId: TEST_IDS.CLIENT_1,
@@ -70,7 +74,7 @@ const sampleShifts: ShiftDisplayRow[] = [
 	},
 	{
 		id: 'shift-2',
-		date: new Date('2026-01-19T00:00:00'),
+		date: createShiftDate(0),
 		startTime: { hour: 11, minute: 0 },
 		endTime: { hour: 12, minute: 0 },
 		clientId: TEST_IDS.CLIENT_2,
@@ -83,7 +87,7 @@ const sampleShifts: ShiftDisplayRow[] = [
 	},
 	{
 		id: 'shift-3',
-		date: new Date('2026-01-20T00:00:00'),
+		date: createShiftDate(1),
 		startTime: { hour: 9, minute: 30 },
 		endTime: { hour: 11, minute: 0 },
 		clientId: TEST_IDS.CLIENT_3,
@@ -96,7 +100,7 @@ const sampleShifts: ShiftDisplayRow[] = [
 	},
 	{
 		id: 'shift-4',
-		date: new Date('2026-01-21T00:00:00'),
+		date: createShiftDate(2),
 		startTime: { hour: 14, minute: 0 },
 		endTime: { hour: 15, minute: 30 },
 		clientId: TEST_IDS.CLIENT_4,
@@ -141,7 +145,7 @@ export const ManyShifts: Story = {
 			...sampleShifts,
 			{
 				id: 'shift-5',
-				date: new Date('2026-01-22T00:00:00'),
+				date: createShiftDate(3),
 				startTime: { hour: 10, minute: 0 },
 				endTime: { hour: 11, minute: 30 },
 				clientId: 'client-5',
@@ -154,7 +158,7 @@ export const ManyShifts: Story = {
 			},
 			{
 				id: 'shift-6',
-				date: new Date('2026-01-23T00:00:00'),
+				date: createShiftDate(4),
 				startTime: { hour: 13, minute: 0 },
 				endTime: { hour: 14, minute: 0 },
 				clientId: 'client-6',
@@ -167,7 +171,7 @@ export const ManyShifts: Story = {
 			},
 			{
 				id: 'shift-7',
-				date: new Date('2026-01-24T00:00:00'),
+				date: createShiftDate(5),
 				startTime: { hour: 9, minute: 0 },
 				endTime: { hour: 10, minute: 30 },
 				clientId: 'client-7',

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import {
 	AdjustmentWizardDialog,
+	type AdjustmentWizardMockApi,
 	type AdjustmentWizardSuggestion,
 } from '../AdjustmentWizardDialog';
 import {
@@ -39,6 +40,7 @@ export interface WeeklySchedulePageProps {
 	initialShifts: ShiftDisplayRow[];
 	staffOptions: StaffPickerOption[];
 	clientOptions: { id: string; name: string }[];
+	adjustmentWizardMockApi?: AdjustmentWizardMockApi;
 }
 
 const shiftToDateTime = (
@@ -187,6 +189,7 @@ export const WeeklySchedulePage = ({
 	initialShifts,
 	staffOptions,
 	clientOptions,
+	adjustmentWizardMockApi,
 }: WeeklySchedulePageProps) => {
 	const router = useRouter();
 	const weekStartDateStr = formatJstDateString(weekStartDate);
@@ -343,6 +346,7 @@ export const WeeklySchedulePage = ({
 					onCascadeReopen={(shiftIds) => {
 						setWizardShiftId(getReopenWizardShiftId(initialShifts, shiftIds));
 					}}
+					mockApi={adjustmentWizardMockApi}
 				/>
 			)}
 


### PR DESCRIPTION
## 概要
Issue #72 の再開対応として、Phase A（UIモック先行確認）向けに調整ウィザードの mock API 差し替え経路を実装しました。

Refs #72

## 変更内容
- AdjustmentWizardDialog に mockApi（AdjustmentWizardMockApi）を追加
  - 候補取得/割当処理を必要なものだけ差し替え可能に
  - assign系未指定時は non-persistent成功（cascadeUnassignedShiftIds: []）へフォールバック
- WeeklySchedulePage で adjustmentWizardMockApi props を受け取り、Wizardへ透過的に受け渡し
- Storybook に Phase A の確認用ストーリーを追加
  - 候補あり
  - 候補なし
  - エラー
- テスト追加/更新
  - partial mock 時に assign が non-persistent フォールバックされること
  - WeeklySchedulePage から AdjustmentWizardDialog への mock API 受け渡し
- 追加統合: WeeklySchedulePage.stories.tsx の日付を JST 現在基準で動的化（重複PR #86 の差分を統合）

## レビュー観点
- non-persistent mockApi 契約（assign未指定時フォールバック）の妥当性
- 偽陽性にならないテスト構成（実際に受け渡した mock を呼び出して検証）
- Storybookの日付初期値がローカル日付依存で破綻しないか

## 動作確認
- pnpm vitest --run src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
- pnpm -s typecheck
- pnpm -s test:storybook --run
