### PR TITLE
fix: WeeklySchedulePage Storybookの日付をJST現在時刻基準で動的化

### DIFF
--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.stories.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.stories.tsx
@@ -1,5 +1,7 @@
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import { getMonday } from '@/app/admin/weekly-schedules/helpers';
 import { TEST_IDS } from '@/test/helpers/testIds';
+import { addJstDays } from '@/utils/date';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { fn } from 'storybook/test';
 import type { ShiftDisplayRow } from '../ShiftTable';
@@ -30,7 +32,9 @@ const meta: Meta<typeof WeeklySchedulePage> = {
 export default meta;
 type Story = StoryObj<typeof WeeklySchedulePage>;
 
-const weekStartDate = new Date('2026-01-19T00:00:00');
+const weekStartDate = addJstDays(getMonday(new Date()), 7);
+const createShiftDate = (daysFromWeekStart: number): Date =>
+	addJstDays(weekStartDate, daysFromWeekStart);
 
 const sampleStaffOptions: StaffPickerOption[] = [
 	{
@@ -56,7 +60,7 @@ const sampleStaffOptions: StaffPickerOption[] = [
 const sampleShifts: ShiftDisplayRow[] = [
 	{
 		id: 'shift-1',
-		date: new Date('2026-01-19T00:00:00'),
+		date: createShiftDate(0),
 		startTime: { hour: 9, minute: 0 },
 		endTime: { hour: 10, minute: 0 },
 		clientId: TEST_IDS.CLIENT_1,
@@ -69,7 +73,7 @@ const sampleShifts: ShiftDisplayRow[] = [
 	},
 	{
 		id: 'shift-2',
-		date: new Date('2026-01-19T00:00:00'),
+		date: createShiftDate(0),
 		startTime: { hour: 11, minute: 0 },
 		endTime: { hour: 12, minute: 0 },
 		clientId: TEST_IDS.CLIENT_2,
@@ -82,7 +86,7 @@ const sampleShifts: ShiftDisplayRow[] = [
 	},
 	{
 		id: 'shift-3',
-		date: new Date('2026-01-20T00:00:00'),
+		date: createShiftDate(1),
 		startTime: { hour: 9, minute: 30 },
 		endTime: { hour: 11, minute: 0 },
 		clientId: TEST_IDS.CLIENT_3,
@@ -95,7 +99,7 @@ const sampleShifts: ShiftDisplayRow[] = [
 	},
 	{
 		id: 'shift-4',
-		date: new Date('2026-01-21T00:00:00'),
+		date: createShiftDate(2),
 		startTime: { hour: 14, minute: 0 },
 		endTime: { hour: 15, minute: 30 },
 		clientId: TEST_IDS.CLIENT_4,
@@ -140,7 +144,7 @@ export const ManyShifts: Story = {
 			...sampleShifts,
 			{
 				id: 'shift-5',
-				date: new Date('2026-01-22T00:00:00'),
+				date: createShiftDate(3),
 				startTime: { hour: 10, minute: 0 },
 				endTime: { hour: 11, minute: 30 },
 				clientId: 'client-5',
@@ -153,7 +157,7 @@ export const ManyShifts: Story = {
 			},
 			{
 				id: 'shift-6',
-				date: new Date('2026-01-23T00:00:00'),
+				date: createShiftDate(4),
 				startTime: { hour: 13, minute: 0 },
 				endTime: { hour: 14, minute: 0 },
 				clientId: 'client-6',
@@ -166,7 +170,7 @@ export const ManyShifts: Story = {
 			},
 			{
 				id: 'shift-7',
-				date: new Date('2026-01-24T00:00:00'),
+				date: createShiftDate(5),
 				startTime: { hour: 9, minute: 0 },
 				endTime: { hour: 10, minute: 30 },
 				clientId: 'client-7',


### PR DESCRIPTION
## 概要
WeeklySchedulePage の Storybook サンプルデータで固定日付を使っていたため、実行タイミングによっては過去日判定となり「調整相談」ボタンが disabled になる問題がありました。

本PRでは、日付生成を JST現在時刻基準の次週月曜起点 に変更し、ストーリー実行時の過去日判定による誤作動を回避します。

refs #72

## 変更内容
- WeeklySchedulePage.stories.tsx の weekStartDate を固定日付から動的計算へ変更
  - getMonday(new Date()) で当週月曜を取得
  - addJstDays(..., 7) で次週月曜へ
- 各シフト日付を createShiftDate(daysFromWeekStart) で生成するよう統一

## テスト
- pnpm test:storybook --run src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.stories.tsx
- pnpm test --run src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx

## レビュー観点
- JST基準で常に次週月曜始まりになっているか
- 過去日判定により「調整相談」が disabled にならないこと
- 動的日付化に伴うスナップショット差分ノイズが許容範囲か（非ブロッカー）
