### PR TITLE
Issue #72 Phase1: UIモック注入境界を追加

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
@@ -306,7 +306,7 @@ describe('AdjustmentWizardDialog', () => {
 		expect(result.data?.cascadeUnassignedShiftIds).toEqual([]);
 	});
 
-	it('mockApi.assign が指定されていると helper割当で透過的に呼び出す', async () => {
+	it('mockApi.assignStaffWithCascadeUnassign が指定されていると helper割当で透過的に呼び出す', async () => {
 		const user = userEvent.setup();
 		const mockAssign = vi.fn().mockResolvedValue({
 			data: {
@@ -389,7 +389,7 @@ describe('AdjustmentWizardDialog', () => {
 		expect(result.data?.cascadeUnassignedShiftIds).toEqual([]);
 	});
 
-	it('mockApi.updateDatetimeAssign が指定されていると datetime割当で透過的に呼び出す', async () => {
+	it('mockApi.updateDatetimeAndAssignWithCascadeUnassign が指定されていると datetime割当で透過的に呼び出す', async () => {
 		const user = userEvent.setup();
 		const mockUpdateDatetimeAssign = vi.fn().mockResolvedValue({
 			data: {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx
@@ -306,6 +306,151 @@ describe('AdjustmentWizardDialog', () => {
 		expect(result.data?.cascadeUnassignedShiftIds).toEqual([]);
 	});
 
+	it('mockApi.assign が指定されていると helper割当で透過的に呼び出す', async () => {
+		const user = userEvent.setup();
+		const mockAssign = vi.fn().mockResolvedValue({
+			data: {
+				cascadeUnassignedShiftIds: [TEST_IDS.SCHEDULE_2],
+			},
+			error: null,
+			status: 200,
+		});
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				mockApi={{ assignStaffWithCascadeUnassign: mockAssign }}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'ヘルパーの変更' }));
+
+		const helperProps = stepHelperCandidatesSpy.mock.lastCall?.[0] as {
+			requestAssign: (input: {
+				shiftId: string;
+				newStaffId: string;
+			}) => Promise<{
+				data: {
+					cascadeUnassignedShiftIds: string[];
+				} | null;
+				error: string | null;
+				status: number;
+			}>;
+		};
+
+		const payload = {
+			shiftId: TEST_IDS.SCHEDULE_1,
+			newStaffId: TEST_IDS.STAFF_1,
+		};
+		const result = await helperProps.requestAssign(payload);
+
+		expect(mockAssign).toHaveBeenCalledWith(payload);
+		expect(result.data?.cascadeUnassignedShiftIds).toEqual([
+			TEST_IDS.SCHEDULE_2,
+		]);
+	});
+
+	it('mockApi.assign 未指定時は helper割当で non-persistent の既定成功を返す', async () => {
+		const user = userEvent.setup();
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				mockApi={{}}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'ヘルパーの変更' }));
+
+		const helperProps = stepHelperCandidatesSpy.mock.lastCall?.[0] as {
+			requestAssign: (input: {
+				shiftId: string;
+				newStaffId: string;
+			}) => Promise<{
+				data: {
+					cascadeUnassignedShiftIds: string[];
+				} | null;
+				error: string | null;
+				status: number;
+			}>;
+		};
+
+		const result = await helperProps.requestAssign({
+			shiftId: TEST_IDS.SCHEDULE_1,
+			newStaffId: TEST_IDS.STAFF_1,
+		});
+
+		expect(result.data?.cascadeUnassignedShiftIds).toEqual([]);
+	});
+
+	it('mockApi.updateDatetimeAssign が指定されていると datetime割当で透過的に呼び出す', async () => {
+		const user = userEvent.setup();
+		const mockUpdateDatetimeAssign = vi.fn().mockResolvedValue({
+			data: {
+				updatedShift: {
+					id: TEST_IDS.SCHEDULE_1,
+				},
+				cascadeUnassignedShiftIds: [TEST_IDS.SCHEDULE_2],
+			},
+			error: null,
+			status: 200,
+		});
+
+		render(
+			<AdjustmentWizardDialog
+				isOpen={true}
+				shiftId={TEST_IDS.SCHEDULE_1}
+				initialStartTime={new Date('2026-02-22T09:00:00+09:00')}
+				initialEndTime={new Date('2026-02-22T10:00:00+09:00')}
+				onClose={vi.fn()}
+				mockApi={{
+					updateDatetimeAndAssignWithCascadeUnassign: mockUpdateDatetimeAssign,
+				}}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: '日時の変更' }));
+		await user.click(screen.getByRole('button', { name: '候補を表示' }));
+
+		const datetimeProps = stepDatetimeCandidatesSpy.mock.lastCall?.[0] as {
+			requestAssign: (input: {
+				shiftId: string;
+				newStaffId: string;
+				newStartTime: Date;
+				newEndTime: Date;
+			}) => Promise<{
+				data: {
+					updatedShift: { id: string };
+					cascadeUnassignedShiftIds: string[];
+				} | null;
+				error: string | null;
+				status: number;
+			}>;
+		};
+
+		const payload = {
+			shiftId: TEST_IDS.SCHEDULE_1,
+			newStaffId: TEST_IDS.STAFF_1,
+			newStartTime: new Date('2026-02-22T09:00:00+09:00'),
+			newEndTime: new Date('2026-02-22T10:00:00+09:00'),
+		};
+		const result = await datetimeProps.requestAssign(payload);
+
+		expect(mockUpdateDatetimeAssign).toHaveBeenCalledWith(payload);
+		expect(
+			actionMocks.updateDatetimeAndAssignWithCascadeUnassignAction,
+		).not.toHaveBeenCalled();
+		expect(result.data?.cascadeUnassignedShiftIds).toEqual([
+			TEST_IDS.SCHEDULE_2,
+		]);
+	});
+
 	it('datetime割当は永続化せずに成功を返す', async () => {
 		const user = userEvent.setup();
 		render(

--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.tsx
@@ -72,6 +72,15 @@ export type AdjustmentWizardSuggestion = {
 	newEndTime: Date;
 };
 
+export type AdjustmentWizardMockApi = {
+	assignStaffWithCascadeUnassign: NonNullable<
+		StepHelperCandidatesProps['requestAssign']
+	>;
+	updateDatetimeAndAssignWithCascadeUnassign: NonNullable<
+		StepDatetimeCandidatesProps['requestAssign']
+	>;
+};
+
 type AdjustmentWizardDialogProps = {
 	isOpen: boolean;
 	shiftId: string;
@@ -80,6 +89,7 @@ type AdjustmentWizardDialogProps = {
 	onClose: () => void;
 	onAssigned?: (suggestion: AdjustmentWizardSuggestion) => void;
 	onCascadeReopen?: (shiftIds: string[]) => void;
+	mockApi?: Partial<AdjustmentWizardMockApi>;
 };
 
 type Candidate =
@@ -190,6 +200,7 @@ export const AdjustmentWizardDialog = ({
 	onClose,
 	onAssigned,
 	onCascadeReopen,
+	mockApi,
 }: AdjustmentWizardDialogProps) => {
 	const dialogRef = useRef<HTMLDialogElement>(null);
 	const inputIdBase = useId();
@@ -223,9 +234,15 @@ export const AdjustmentWizardDialog = ({
 				newStartTime: initialStartTime,
 				newEndTime: initialEndTime,
 			};
+			if (mockApi?.assignStaffWithCascadeUnassign) {
+				return mockApi.assignStaffWithCascadeUnassign({
+					shiftId: targetShiftId,
+					newStaffId,
+				});
+			}
 			return successNoPersist();
 		},
-		[initialEndTime, initialStartTime],
+		[initialEndTime, initialStartTime, mockApi],
 	);
 
 	const requestDatetimeCandidates = useCallback<
@@ -265,9 +282,17 @@ export const AdjustmentWizardDialog = ({
 				newStartTime,
 				newEndTime,
 			};
+			if (mockApi?.updateDatetimeAndAssignWithCascadeUnassign) {
+				return mockApi.updateDatetimeAndAssignWithCascadeUnassign({
+					shiftId: targetShiftId,
+					newStaffId,
+					newStartTime,
+					newEndTime,
+				});
+			}
 			return successNoPersist();
 		},
-		[],
+		[mockApi],
 	);
 
 	useEffect(() => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/index.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/index.ts
@@ -1,5 +1,8 @@
 export { AdjustmentWizardDialog } from './AdjustmentWizardDialog';
-export type { AdjustmentWizardSuggestion } from './AdjustmentWizardDialog';
+export type {
+	AdjustmentWizardMockApi,
+	AdjustmentWizardSuggestion,
+} from './AdjustmentWizardDialog';
 export { StepDatetimeCandidates } from './StepDatetimeCandidates';
 export { StepDatetimeInput } from './StepDatetimeInput';
 export { StepHelperCandidates } from './StepHelperCandidates';

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
@@ -266,7 +266,7 @@ describe('WeeklySchedulePage (Adjustment entry)', () => {
 		expect(screen.queryByText(/Suggested end:/)).not.toBeInTheDocument();
 	});
 
-	it('adjustmentWizardMockApi.updateDatetimeAssign を透過し、実呼び出しできる', async () => {
+	it('adjustmentWizardMockApi.updateDatetimeAndAssignWithCascadeUnassign を透過し、実呼び出しできる', async () => {
 		const user = userEvent.setup();
 		const updateDatetimeAssignMock = vi.fn().mockResolvedValue({
 			data: {

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
@@ -85,6 +85,7 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 		onAssigned,
 		onClose,
 		onCascadeReopen,
+		mockApi,
 	}: {
 		isOpen: boolean;
 		shiftId: string;
@@ -98,6 +99,7 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 			newEndTime: Date;
 		}) => void;
 		onCascadeReopen?: (shiftIds: string[]) => void;
+		mockApi?: Partial<AdjustmentWizardMockApi>;
 	}) =>
 		isOpen ? (
 			<div>
@@ -127,10 +129,35 @@ vi.mock('../AdjustmentWizardDialog', () => ({
 				>
 					連鎖再オープン
 				</button>
+				<button
+					type="button"
+					onClick={async () => {
+						await mockApi?.assignStaffWithCascadeUnassign?.({
+							shiftId,
+							newStaffId: TEST_IDS.STAFF_2,
+						});
+					}}
+				>
+					mockApi assign
+				</button>
+				<button
+					type="button"
+					onClick={async () => {
+						await mockApi?.updateDatetimeAndAssignWithCascadeUnassign?.({
+							shiftId,
+							newStaffId: TEST_IDS.STAFF_2,
+							newStartTime: new Date('2026-01-19T02:00:00.000Z'),
+							newEndTime: new Date('2026-01-19T03:00:00.000Z'),
+						});
+					}}
+				>
+					mockApi datetime assign
+				</button>
 			</div>
 		) : null,
 }));
 
+import type { AdjustmentWizardMockApi } from '../AdjustmentWizardDialog';
 import type { ShiftDisplayRow } from '../ShiftTable';
 import {
 	WeeklySchedulePage,
@@ -237,6 +264,69 @@ describe('WeeklySchedulePage (Adjustment entry)', () => {
 		expect(screen.queryByText(/Suggested staff:/)).not.toBeInTheDocument();
 		expect(screen.queryByText(/Suggested start:/)).not.toBeInTheDocument();
 		expect(screen.queryByText(/Suggested end:/)).not.toBeInTheDocument();
+	});
+
+	it('adjustmentWizardMockApi.updateDatetimeAssign を透過し、実呼び出しできる', async () => {
+		const user = userEvent.setup();
+		const updateDatetimeAssignMock = vi.fn().mockResolvedValue({
+			data: {
+				updatedShift: { id: TEST_IDS.SCHEDULE_1 },
+				cascadeUnassignedShiftIds: [TEST_IDS.SCHEDULE_2],
+			},
+			error: null,
+			status: 200,
+		});
+		const mockApi: Partial<AdjustmentWizardMockApi> = {
+			updateDatetimeAndAssignWithCascadeUnassign: updateDatetimeAssignMock,
+		};
+
+		render(
+			<WeeklySchedulePage
+				{...defaultProps}
+				adjustmentWizardMockApi={mockApi}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+		await user.click(
+			screen.getByRole('button', { name: 'mockApi datetime assign' }),
+		);
+
+		expect(updateDatetimeAssignMock).toHaveBeenCalledWith({
+			shiftId: TEST_IDS.SCHEDULE_1,
+			newStaffId: TEST_IDS.STAFF_2,
+			newStartTime: new Date('2026-01-19T02:00:00.000Z'),
+			newEndTime: new Date('2026-01-19T03:00:00.000Z'),
+		});
+	});
+
+	it('adjustmentWizardMockApi を AdjustmentWizardDialog に透過し、実呼び出しできる', async () => {
+		const user = userEvent.setup();
+		const assignMock = vi.fn().mockResolvedValue({
+			data: { cascadeUnassignedShiftIds: [] },
+			error: null,
+			status: 200,
+		});
+		const mockApi: Partial<AdjustmentWizardMockApi> = {
+			assignStaffWithCascadeUnassign: assignMock,
+		};
+
+		render(
+			<WeeklySchedulePage
+				{...defaultProps}
+				adjustmentWizardMockApi={mockApi}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
+		await user.click(screen.getByRole('button', { name: '調整相談' }));
+		await user.click(screen.getByRole('button', { name: 'mockApi assign' }));
+
+		expect(assignMock).toHaveBeenCalledWith({
+			shiftId: TEST_IDS.SCHEDULE_1,
+			newStaffId: TEST_IDS.STAFF_2,
+		});
 	});
 
 	it('onCascadeReopen が unknown shiftId を返したときは wizard を開かない', async () => {

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import {
 	AdjustmentWizardDialog,
+	type AdjustmentWizardMockApi,
 	type AdjustmentWizardSuggestion,
 } from '../AdjustmentWizardDialog';
 import {
@@ -39,6 +40,7 @@ export interface WeeklySchedulePageProps {
 	initialShifts: ShiftDisplayRow[];
 	staffOptions: StaffPickerOption[];
 	clientOptions: { id: string; name: string }[];
+	adjustmentWizardMockApi?: Partial<AdjustmentWizardMockApi>;
 }
 
 const shiftToDateTime = (
@@ -187,6 +189,7 @@ export const WeeklySchedulePage = ({
 	initialShifts,
 	staffOptions,
 	clientOptions,
+	adjustmentWizardMockApi,
 }: WeeklySchedulePageProps) => {
 	const router = useRouter();
 	const weekStartDateStr = formatJstDateString(weekStartDate);
@@ -343,6 +346,7 @@ export const WeeklySchedulePage = ({
 					onCascadeReopen={(shiftIds) => {
 						setWizardShiftId(getReopenWizardShiftId(initialShifts, shiftIds));
 					}}
+					mockApi={adjustmentWizardMockApi}
 				/>
 			)}
 


### PR DESCRIPTION
## 概要
Issue #72 Phase1（UIモック注入境界）として、`AdjustmentWizardDialog` に mock API の注入境界を追加し、`WeeklySchedulePage` から透過的に受け渡せるようにしました。

> この変更は **non-persistent（保存未実行）** の振る舞いを維持したまま、UI モック差し替えを可能にするものです。

Refs #72

## 変更内容
- `AdjustmentWizardDialog` に `AdjustmentWizardMockApi` 型と `mockApi` prop を追加
  - `assignStaffWithCascadeUnassign`
  - `updateDatetimeAndAssignWithCascadeUnassign`
- `mockApi` が指定されている場合は各 `requestAssign` から透過的に呼び出し
- `mockApi` 未指定時は既存どおり non-persistent の成功レスポンスを返却
- `AdjustmentWizardDialog/index.ts` から `AdjustmentWizardMockApi` を export
- `WeeklySchedulePage` に `adjustmentWizardMockApi` prop を追加し、子へ透過受け渡し

## テスト
- `AdjustmentWizardDialog.test.tsx`
  - helper 割当経路での mockApi 透過呼び出し
  - helper 割当経路での mockApi 未指定（non-persistent 既定成功）
  - datetime 割当経路での mockApi 透過呼び出し
- `WeeklySchedulePage.adjustment.test.tsx`
  - `adjustmentWizardMockApi` の透過受け渡し（helper / datetime 経路）

実行コマンド:
```bash
pnpm vitest --run src/app/admin/weekly-schedules/_components/AdjustmentWizardDialog/AdjustmentWizardDialog.test.tsx src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
```

結果: 25 passed

## 影響範囲
- 既定挙動（non-persistent）は維持
- 永続化 API の実接続は Phase2 以降で実施予定
