### PR TITLE
feat: Service層に processStaffAbsence メソッドを追加

### DIFF
--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -1161,3 +1161,513 @@ describe('ShiftAdjustmentSuggestionService', () => {
 		});
 	});
 });
+
+describe('processStaffAbsence', () => {
+	let service: ShiftAdjustmentSuggestionService;
+	let mockStaffRepo: Mocked<StaffRepository>;
+	let mockShiftRepo: Mocked<ShiftRepository>;
+	let mockClientStaffAssignmentRepo: Mocked<ClientStaffAssignmentRepository>;
+	let mockSupabase: SupabaseClient<Database>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-02-22T00:00:00+09:00'));
+
+		mockStaffRepo = createMockStaffRepository();
+		mockShiftRepo = createMockShiftRepository();
+		mockClientStaffAssignmentRepo = createMockClientStaffAssignmentRepository();
+		mockSupabase = {} as SupabaseClient<Database>;
+		service = new ShiftAdjustmentSuggestionService(mockSupabase, {
+			staffRepository: mockStaffRepo,
+			shiftRepository: mockShiftRepo,
+			clientStaffAssignmentRepository: mockClientStaffAssignmentRepo,
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('非adminは403を返す', async () => {
+		const userId = createTestId();
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({
+				id: createTestId(),
+				auth_user_id: userId,
+				role: 'helper',
+			}),
+		);
+
+		await expect(
+			service.processStaffAbsence(userId, {
+				staffId: TEST_IDS.STAFF_2,
+				startDate: new Date('2026-02-25T00:00:00+09:00'),
+				endDate: new Date('2026-02-26T00:00:00+09:00'),
+			}),
+		).rejects.toMatchObject({ status: 403, message: 'Forbidden' });
+	});
+
+	it('欠勤スタッフが存在しない場合は404を返す', async () => {
+		const userId = createTestId();
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi.fn().mockResolvedValueOnce(null);
+
+		await expect(
+			service.processStaffAbsence(userId, {
+				staffId: TEST_IDS.STAFF_2,
+				startDate: new Date('2026-02-25T00:00:00+09:00'),
+				endDate: new Date('2026-02-26T00:00:00+09:00'),
+			}),
+		).rejects.toMatchObject({
+			status: 404,
+			message: 'Absence staff not found',
+		});
+	});
+
+	it('欠勤スタッフがadminと異なるofficeの場合は404を返す', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({
+				id: createTestId(),
+				auth_user_id: userId,
+				office_id: TEST_IDS.OFFICE_1,
+			}),
+		);
+		mockStaffRepo.findById = vi.fn().mockResolvedValueOnce(
+			createAdminStaff({
+				id: absenceStaffId,
+				office_id: TEST_IDS.OFFICE_2, // 別の事業所
+			}),
+		);
+
+		await expect(
+			service.processStaffAbsence(userId, {
+				staffId: absenceStaffId,
+				startDate: new Date('2026-02-25T00:00:00+09:00'),
+				endDate: new Date('2026-02-26T00:00:00+09:00'),
+			}),
+		).rejects.toMatchObject({
+			status: 404,
+			message: 'Absence staff not found',
+		});
+	});
+
+	it('影響シフトがない場合は空配列を返す', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createAdminStaff({ id: absenceStaffId, name: '欠勤者A' }),
+			);
+		mockShiftRepo.findAffectedShiftsByAbsence = vi
+			.fn()
+			.mockResolvedValueOnce([]);
+
+		const result = await service.processStaffAbsence(userId, {
+			staffId: absenceStaffId,
+			startDate: new Date('2026-02-25T00:00:00+09:00'),
+			endDate: new Date('2026-02-26T00:00:00+09:00'),
+		});
+
+		expect(result.absenceStaffId).toBe(absenceStaffId);
+		expect(result.absenceStaffName).toBe('欠勤者A');
+		expect(result.startDate).toBe('2026-02-25');
+		expect(result.endDate).toBe('2026-02-26');
+		expect(result.affectedShifts).toHaveLength(0);
+		expect(result.summary).toContain('影響シフト: 0件');
+	});
+
+	it('影響シフトに対して過去担当者が候補として優先される', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+		const pastStaffId = TEST_IDS.STAFF_3;
+		const clientId = TEST_IDS.CLIENT_1;
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createAdminStaff({ id: absenceStaffId, name: '欠勤者A' }),
+			);
+		// 事業所のスタッフ一覧
+		mockStaffRepo.listByOffice.mockResolvedValueOnce([
+			createStaffWithServiceTypes({
+				id: pastStaffId,
+				name: '過去担当者B',
+				role: 'helper',
+				service_type_ids: ['life-support'],
+			}),
+		]);
+
+		// 影響シフト
+		const affectedShift = createShift({
+			id: TEST_IDS.SCHEDULE_1,
+			client_id: clientId,
+			staff_id: absenceStaffId,
+			date: new Date('2026-02-25T00:00:00+09:00'),
+			time: { start: { hour: 10, minute: 0 }, end: { hour: 11, minute: 0 } },
+			status: 'scheduled',
+			service_type_id: 'life-support',
+		});
+		mockShiftRepo.findAffectedShiftsByAbsence = vi
+			.fn()
+			.mockResolvedValueOnce([affectedShift]);
+
+		// 過去担当者（shifts completed）
+		mockShiftRepo.findPastAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([pastStaffId]);
+		// client_staff_assignments
+		mockClientStaffAssignmentRepo.findAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([pastStaffId]);
+
+		// 空きヘルパー検索用のシフト一覧（重複チェック）
+		mockShiftRepo.list.mockResolvedValueOnce([]);
+
+		const result = await service.processStaffAbsence(userId, {
+			staffId: absenceStaffId,
+			startDate: new Date('2026-02-25T00:00:00+09:00'),
+			endDate: new Date('2026-02-26T00:00:00+09:00'),
+		});
+
+		expect(result.affectedShifts).toHaveLength(1);
+		const affected = result.affectedShifts[0]!;
+		expect(affected.shift.id).toBe(TEST_IDS.SCHEDULE_1);
+		expect(affected.candidates).toHaveLength(1);
+		expect(affected.candidates[0]).toMatchObject({
+			staffId: pastStaffId,
+			staffName: '過去担当者B',
+			priority: 'past_assigned',
+		});
+	});
+
+	it('過去担当者に空きがなければavailable優先度の候補が追加される', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+		const pastStaffId = TEST_IDS.STAFF_3;
+		const availableStaffId = TEST_IDS.STAFF_4;
+		const clientId = TEST_IDS.CLIENT_1;
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createAdminStaff({ id: absenceStaffId, name: '欠勤者A' }),
+			);
+		mockStaffRepo.listByOffice.mockResolvedValue([
+			createStaffWithServiceTypes({
+				id: pastStaffId,
+				name: '過去担当者B',
+				role: 'helper',
+				service_type_ids: ['life-support'],
+			}),
+			createStaffWithServiceTypes({
+				id: availableStaffId,
+				name: '空きスタッフC',
+				role: 'helper',
+				service_type_ids: ['life-support'],
+			}),
+		]);
+
+		const affectedShift = createShift({
+			id: TEST_IDS.SCHEDULE_1,
+			client_id: clientId,
+			staff_id: absenceStaffId,
+			date: new Date('2026-02-25T00:00:00+09:00'),
+			time: { start: { hour: 10, minute: 0 }, end: { hour: 11, minute: 0 } },
+			status: 'scheduled',
+			service_type_id: 'life-support',
+		});
+		mockShiftRepo.findAffectedShiftsByAbsence = vi
+			.fn()
+			.mockResolvedValueOnce([affectedShift]);
+
+		// 過去担当者
+		mockShiftRepo.findPastAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([pastStaffId]);
+		mockClientStaffAssignmentRepo.findAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([pastStaffId]);
+
+		// 過去担当者は同時間帯に別のシフトあり（空きなし）
+		// 空きスタッフCは空き
+		const shiftListCallIndex = { count: 0 };
+		mockShiftRepo.list.mockImplementation(async () => {
+			shiftListCallIndex.count++;
+			if (shiftListCallIndex.count === 1) {
+				// 最初の呼び出し: 過去担当者の空きチェック（重複あり）
+				return [
+					createShift({
+						id: createTestId(),
+						client_id: TEST_IDS.CLIENT_2,
+						staff_id: pastStaffId,
+						date: new Date('2026-02-25T00:00:00+09:00'),
+						time: {
+							start: { hour: 10, minute: 0 },
+							end: { hour: 11, minute: 0 },
+						},
+						status: 'scheduled',
+					}),
+				];
+			}
+			// 2回目以降: 空きスタッフ検索用（重複なし）
+			return [];
+		});
+
+		const result = await service.processStaffAbsence(userId, {
+			staffId: absenceStaffId,
+			startDate: new Date('2026-02-25T00:00:00+09:00'),
+			endDate: new Date('2026-02-26T00:00:00+09:00'),
+		});
+
+		expect(result.affectedShifts).toHaveLength(1);
+		const affected = result.affectedShifts[0]!;
+		expect(affected.candidates.length).toBeGreaterThanOrEqual(1);
+		// 空きスタッフCが候補に含まれる（available優先度）
+		const availableCandidate = affected.candidates.find(
+			(c) => c.staffId === availableStaffId,
+		);
+		expect(availableCandidate).toBeDefined();
+		expect(availableCandidate!.priority).toBe('available');
+	});
+
+	it('候補は最大3名まで', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+		const clientId = TEST_IDS.CLIENT_1;
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createAdminStaff({ id: absenceStaffId, name: '欠勤者A' }),
+			);
+
+		// 5人のスタッフ（すべて空き）
+		const staffIds = Array.from({ length: 5 }, () => createTestId());
+		mockStaffRepo.listByOffice.mockResolvedValue(
+			staffIds.map((id, i) =>
+				createStaffWithServiceTypes({
+					id,
+					name: `スタッフ${i + 1}`,
+					role: 'helper',
+					service_type_ids: ['life-support'],
+				}),
+			),
+		);
+
+		const affectedShift = createShift({
+			id: TEST_IDS.SCHEDULE_1,
+			client_id: clientId,
+			staff_id: absenceStaffId,
+			date: new Date('2026-02-25T00:00:00+09:00'),
+			time: { start: { hour: 10, minute: 0 }, end: { hour: 11, minute: 0 } },
+			status: 'scheduled',
+			service_type_id: 'life-support',
+		});
+		mockShiftRepo.findAffectedShiftsByAbsence = vi
+			.fn()
+			.mockResolvedValueOnce([affectedShift]);
+		mockShiftRepo.findPastAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([]);
+		mockClientStaffAssignmentRepo.findAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([]);
+		mockShiftRepo.list.mockResolvedValue([]);
+
+		const result = await service.processStaffAbsence(userId, {
+			staffId: absenceStaffId,
+			startDate: new Date('2026-02-25T00:00:00+09:00'),
+			endDate: new Date('2026-02-26T00:00:00+09:00'),
+		});
+
+		expect(result.affectedShifts).toHaveLength(1);
+		// 候補は最大3名
+		expect(result.affectedShifts[0]!.candidates.length).toBeLessThanOrEqual(3);
+	});
+
+	it('summaryに影響シフト数と候補がない件数が含まれる', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+		const clientId = TEST_IDS.CLIENT_1;
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createAdminStaff({ id: absenceStaffId, name: '欠勤者A' }),
+			);
+		mockStaffRepo.listByOffice.mockResolvedValue([]);
+
+		// 2件の影響シフト（候補なし）
+		const affectedShifts = [
+			createShift({
+				id: TEST_IDS.SCHEDULE_1,
+				client_id: clientId,
+				staff_id: absenceStaffId,
+				date: new Date('2026-02-25T00:00:00+09:00'),
+				status: 'scheduled',
+			}),
+			createShift({
+				id: TEST_IDS.SCHEDULE_2,
+				client_id: clientId,
+				staff_id: absenceStaffId,
+				date: new Date('2026-02-26T00:00:00+09:00'),
+				status: 'scheduled',
+			}),
+		];
+		mockShiftRepo.findAffectedShiftsByAbsence = vi
+			.fn()
+			.mockResolvedValueOnce(affectedShifts);
+		mockShiftRepo.findPastAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValue([]);
+		mockClientStaffAssignmentRepo.findAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValue([]);
+		mockShiftRepo.list.mockResolvedValue([]);
+
+		const result = await service.processStaffAbsence(userId, {
+			staffId: absenceStaffId,
+			startDate: new Date('2026-02-25T00:00:00+09:00'),
+			endDate: new Date('2026-02-26T00:00:00+09:00'),
+		});
+
+		expect(result.summary).toContain('影響シフト: 2件');
+		expect(result.summary).toContain('候補なし: 2件');
+	});
+
+	it('過去担当と割当可能スタッフが重複しても重複排除される', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+		const overlappingStaffId = TEST_IDS.STAFF_3;
+		const clientId = TEST_IDS.CLIENT_1;
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createAdminStaff({ id: absenceStaffId, name: '欠勤者A' }),
+			);
+		mockStaffRepo.listByOffice.mockResolvedValue([
+			createStaffWithServiceTypes({
+				id: overlappingStaffId,
+				name: '担当者B',
+				role: 'helper',
+				service_type_ids: ['life-support'],
+			}),
+		]);
+
+		const affectedShift = createShift({
+			id: TEST_IDS.SCHEDULE_1,
+			client_id: clientId,
+			staff_id: absenceStaffId,
+			date: new Date('2026-02-25T00:00:00+09:00'),
+			time: { start: { hour: 10, minute: 0 }, end: { hour: 11, minute: 0 } },
+			status: 'scheduled',
+			service_type_id: 'life-support',
+		});
+		mockShiftRepo.findAffectedShiftsByAbsence = vi
+			.fn()
+			.mockResolvedValueOnce([affectedShift]);
+
+		// 同じスタッフが過去担当とclient_staff_assignmentsの両方に存在
+		mockShiftRepo.findPastAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([overlappingStaffId]);
+		mockClientStaffAssignmentRepo.findAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([overlappingStaffId]);
+		mockShiftRepo.list.mockResolvedValue([]);
+
+		const result = await service.processStaffAbsence(userId, {
+			staffId: absenceStaffId,
+			startDate: new Date('2026-02-25T00:00:00+09:00'),
+			endDate: new Date('2026-02-26T00:00:00+09:00'),
+		});
+
+		expect(result.affectedShifts).toHaveLength(1);
+		// 重複排除されて1人だけ
+		expect(result.affectedShifts[0]!.candidates).toHaveLength(1);
+		expect(result.affectedShifts[0]!.candidates[0]!.staffId).toBe(
+			overlappingStaffId,
+		);
+	});
+
+	it('欠勤者自身は候補から除外される', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+		const clientId = TEST_IDS.CLIENT_1;
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createAdminStaff({ id: absenceStaffId, name: '欠勤者A' }),
+			);
+		mockStaffRepo.listByOffice.mockResolvedValue([
+			createStaffWithServiceTypes({
+				id: absenceStaffId,
+				name: '欠勤者A',
+				role: 'helper',
+				service_type_ids: ['life-support'],
+			}),
+		]);
+
+		const affectedShift = createShift({
+			id: TEST_IDS.SCHEDULE_1,
+			client_id: clientId,
+			staff_id: absenceStaffId,
+			date: new Date('2026-02-25T00:00:00+09:00'),
+			status: 'scheduled',
+			service_type_id: 'life-support',
+		});
+		mockShiftRepo.findAffectedShiftsByAbsence = vi
+			.fn()
+			.mockResolvedValueOnce([affectedShift]);
+		// 欠勤者が過去担当としても出てくるケース
+		mockShiftRepo.findPastAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([absenceStaffId]);
+		mockClientStaffAssignmentRepo.findAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValueOnce([]);
+		mockShiftRepo.list.mockResolvedValue([]);
+
+		const result = await service.processStaffAbsence(userId, {
+			staffId: absenceStaffId,
+			startDate: new Date('2026-02-25T00:00:00+09:00'),
+			endDate: new Date('2026-02-26T00:00:00+09:00'),
+		});
+
+		expect(result.affectedShifts).toHaveLength(1);
+		// 欠勤者自身は除外
+		expect(result.affectedShifts[0]!.candidates).toHaveLength(0);
+	});
+});

--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -1446,6 +1446,9 @@ describe('processStaffAbsence', () => {
 		);
 		expect(availableCandidate).toBeDefined();
 		expect(availableCandidate!.priority).toBe('available');
+
+		// シフト一覧取得が1回だけ呼ばれることを検証（N+1対策）
+		expect(mockShiftRepo.list).toHaveBeenCalledTimes(1);
 	});
 
 	it('候補は最大3名まで', async () => {

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -948,6 +948,8 @@ export class ShiftAdjustmentSuggestionService {
 		input: StaffAbsenceInput,
 	): Promise<StaffAbsenceProcessResult> {
 		const MAX_CANDIDATES = 3;
+		// 時間衝突で候補外になる可能性を考慮し、多めに取得してからフィルタする
+		const FETCH_CANDIDATES_BUFFER = 10;
 
 		// 管理者権限チェック
 		const admin = await this.getAdminStaff(userId);
@@ -1026,7 +1028,7 @@ export class ShiftAdjustmentSuggestionService {
 						clientId,
 						officeId,
 						serviceTypeId,
-						MAX_CANDIDATES,
+						FETCH_CANDIDATES_BUFFER,
 					),
 				})),
 			),

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -10,10 +10,12 @@ import {
 	ShiftAdjustmentRationaleItem,
 	ShiftAdjustmentSuggestion,
 	ShiftSnapshot,
+	StaffAbsenceInput,
 } from '@/models/shiftAdjustmentActionSchemas';
 import { ServiceTypeId } from '@/models/valueObjects/serviceTypeId';
 import {
 	addJstDays,
+	formatJstDateString,
 	getJstDateOnly,
 	parseJstDateString,
 	setJstTime,
@@ -61,6 +63,41 @@ export type FindAvailableHelpersInput = {
 export type AvailableHelper = {
 	id: string;
 	name: string;
+};
+
+// ======================================
+// processStaffAbsence 関連の型定義
+// ======================================
+
+/**
+ * 代替候補スタッフ
+ */
+export type StaffCandidate = {
+	staffId: string;
+	staffName: string;
+	/** 優先順位の理由: past_assigned = 過去に担当, available = 空き時間あり */
+	priority: 'past_assigned' | 'available';
+};
+
+/**
+ * 影響シフトとその代替候補
+ */
+export type AffectedShiftWithCandidates = {
+	shift: ShiftSnapshot;
+	candidates: StaffCandidate[];
+};
+
+/**
+ * processStaffAbsence の戻り値
+ */
+export type StaffAbsenceProcessResult = {
+	absenceStaffId: string;
+	absenceStaffName: string;
+	startDate: string; // YYYY-MM-DD
+	endDate: string; // YYYY-MM-DD
+	affectedShifts: AffectedShiftWithCandidates[];
+	/** AI が読む用のサマリー */
+	summary: string;
 };
 
 const isOverlapping = (
@@ -875,5 +912,206 @@ export class ShiftAdjustmentSuggestionService {
 			range,
 		});
 		return !hasConflict;
+	};
+
+	/**
+	 * スタッフ急休の処理
+	 * 影響シフトを特定し、各シフトに対する代替候補を取得する
+	 */
+	async processStaffAbsence(
+		userId: string,
+		input: StaffAbsenceInput,
+	): Promise<StaffAbsenceProcessResult> {
+		const MAX_CANDIDATES = 3;
+
+		// 管理者権限チェック
+		const admin = await this.getAdminStaff(userId);
+
+		// 欠勤スタッフの存在と同一事業所チェック
+		const absenceStaff = await this.staffRepository.findById(input.staffId);
+		if (!absenceStaff || absenceStaff.office_id !== admin.office_id) {
+			throw new ServiceError(404, 'Absence staff not found');
+		}
+
+		const officeId = admin.office_id;
+		const startDate = input.startDate;
+		const endDate = input.endDate;
+
+		// 影響シフトを取得
+		const affectedShifts =
+			await this.shiftRepository.findAffectedShiftsByAbsence(
+				input.staffId,
+				startDate,
+				endDate,
+				officeId,
+			);
+
+		// 影響シフトがない場合は早期リターン
+		if (affectedShifts.length === 0) {
+			return {
+				absenceStaffId: input.staffId,
+				absenceStaffName: absenceStaff.name,
+				startDate: formatJstDateString(startDate),
+				endDate: formatJstDateString(endDate),
+				affectedShifts: [],
+				summary: `影響シフト: 0件`,
+			};
+		}
+
+		// 事業所のスタッフ一覧を取得（候補検索用）
+		const officeStaffs = await this.staffRepository.listByOffice(officeId);
+		const staffMap = new Map(officeStaffs.map((s) => [s.id, s]));
+
+		// 各影響シフトに対して代替候補を検索
+		const affectedShiftsWithCandidates: AffectedShiftWithCandidates[] = [];
+
+		for (const shift of affectedShifts) {
+			const candidates = await this.findCandidatesForShift({
+				shift,
+				absenceStaffId: input.staffId,
+				officeId,
+				staffMap,
+				maxCandidates: MAX_CANDIDATES,
+			});
+
+			affectedShiftsWithCandidates.push({
+				shift: toShiftSnapshot(shift),
+				candidates,
+			});
+		}
+
+		// 候補なしの件数をカウント
+		const noCandidatesCount = affectedShiftsWithCandidates.filter(
+			(a) => a.candidates.length === 0,
+		).length;
+
+		return {
+			absenceStaffId: input.staffId,
+			absenceStaffName: absenceStaff.name,
+			startDate: formatJstDateString(startDate),
+			endDate: formatJstDateString(endDate),
+			affectedShifts: affectedShiftsWithCandidates,
+			summary:
+				`影響シフト: ${affectedShifts.length}件` +
+				(noCandidatesCount > 0 ? `, 候補なし: ${noCandidatesCount}件` : ''),
+		};
+	}
+
+	/**
+	 * 単一シフトに対する代替候補を検索
+	 */
+	private findCandidatesForShift = async (params: {
+		shift: ScheduledShift;
+		absenceStaffId: string;
+		officeId: string;
+		staffMap: Map<string, OfficeStaff>;
+		maxCandidates: number;
+	}): Promise<StaffCandidate[]> => {
+		const { shift, absenceStaffId, officeId, staffMap, maxCandidates } = params;
+
+		// 1. 過去担当者を取得（shifts completed + client_staff_assignments）
+		const [pastStaffIds, assignedStaffIds] = await Promise.all([
+			this.shiftRepository.findPastAssignedStaffIdsByClient(
+				shift.client_id,
+				officeId,
+				shift.service_type_id,
+				maxCandidates,
+			),
+			this.clientStaffAssignmentRepository.findAssignedStaffIdsByClient(
+				officeId,
+				shift.client_id,
+				shift.service_type_id,
+			),
+		]);
+
+		// 重複排除して結合（過去担当優先）
+		const pastAssignedStaffIds = [
+			...new Set([...pastStaffIds, ...assignedStaffIds]),
+		].filter((id) => id !== absenceStaffId); // 欠勤者自身を除外
+
+		// 2. シフトの時間帯を計算
+		const targetDate = shift.date;
+		const range = this.buildRangeOnDate({
+			date: targetDate,
+			startTime: shift.time.start,
+			endTime: shift.time.end,
+		});
+
+		// 3. 空き状況チェック用のシフトを取得（前後1日）
+		const shiftsNearDate = await this.shiftRepository.list({
+			officeId,
+			startDate: addJstDays(targetDate, -1),
+			endDate: addJstDays(targetDate, 1),
+			excludeStatus: 'canceled',
+		});
+		const shiftsByStaff = this.buildShiftsByStaff(shiftsNearDate);
+
+		const candidates: StaffCandidate[] = [];
+
+		// 4. 過去担当者の空き状況をチェック（past_assigned 優先）
+		for (const staffId of pastAssignedStaffIds) {
+			if (candidates.length >= maxCandidates) break;
+
+			const staff = staffMap.get(staffId);
+			if (!staff || staff.role !== 'helper') continue;
+
+			// サービス種別対応可能かチェック
+			if (!staff.service_type_ids.includes(shift.service_type_id)) continue;
+
+			// 空き時間チェック
+			const hasConflict = this.hasConflictForRangeWithInterval({
+				shiftsByStaff,
+				staffId,
+				range,
+			});
+			if (hasConflict) continue;
+
+			candidates.push({
+				staffId,
+				staffName: staff.name,
+				priority: 'past_assigned',
+			});
+		}
+
+		// 5. 候補が足りなければ追加候補を検索（available 優先）
+		if (candidates.length < maxCandidates) {
+			const candidateIds = new Set(candidates.map((c) => c.staffId));
+			const excludeIds = new Set([
+				absenceStaffId,
+				...pastAssignedStaffIds,
+				...candidateIds,
+			]);
+
+			// 全ヘルパーから空きスタッフを検索
+			const availableHelpers = Array.from(staffMap.values())
+				.filter((staff) => {
+					// 除外対象は除く
+					if (excludeIds.has(staff.id)) return false;
+					// ヘルパーのみ
+					if (staff.role !== 'helper') return false;
+					// サービス種別対応可能か
+					if (!staff.service_type_ids.includes(shift.service_type_id))
+						return false;
+					// 空き時間チェック
+					const hasConflict = this.hasConflictForRangeWithInterval({
+						shiftsByStaff,
+						staffId: staff.id,
+						range,
+					});
+					return !hasConflict;
+				})
+				.sort((a, b) => a.name.localeCompare(b.name, 'ja')); // 名前順
+
+			for (const staff of availableHelpers) {
+				if (candidates.length >= maxCandidates) break;
+				candidates.push({
+					staffId: staff.id,
+					staffName: staff.name,
+					priority: 'available',
+				});
+			}
+		}
+
+		return candidates;
 	};
 }

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -75,7 +75,12 @@ export type AvailableHelper = {
 export type StaffCandidate = {
 	staffId: string;
 	staffName: string;
-	/** 優先順位の理由: past_assigned = 過去に担当, assigned = 割当可能（担当経験なし）, available = 空き時間あり */
+	/**
+	 * 優先順位の理由（いずれも時間帯の重複チェック済みで「空き時間あり」のスタッフ）:
+	 * - past_assigned = 過去にその利用者を担当したことがある
+	 * - assigned = 現在その利用者に割当済みだが、担当経験はない
+	 * - available = 現在その利用者には割当されておらず、今回の時間帯が空いている
+	 */
 	priority: 'past_assigned' | 'assigned' | 'available';
 };
 
@@ -943,7 +948,6 @@ export class ShiftAdjustmentSuggestionService {
 		input: StaffAbsenceInput,
 	): Promise<StaffAbsenceProcessResult> {
 		const MAX_CANDIDATES = 3;
-		const MAX_PARALLEL_CANDIDATE_QUERIES = 10;
 
 		// 管理者権限チェック
 		const admin = await this.getAdminStaff(userId);
@@ -1004,7 +1008,10 @@ export class ShiftAdjustmentSuggestionService {
 		const uniqueClientServicePairs = [
 			...new Map(
 				affectedShifts.map((s) => [
-					`${s.client_id}:${s.service_type_id}`,
+					this.assignmentKey({
+						clientId: s.client_id,
+						serviceTypeId: s.service_type_id,
+					}),
 					{ clientId: s.client_id, serviceTypeId: s.service_type_id },
 				]),
 			).values(),
@@ -1014,7 +1021,7 @@ export class ShiftAdjustmentSuggestionService {
 		const [pastStaffResults, assignedStaffResults] = await Promise.all([
 			Promise.all(
 				uniqueClientServicePairs.map(async ({ clientId, serviceTypeId }) => ({
-					key: `${clientId}:${serviceTypeId}`,
+					key: this.assignmentKey({ clientId, serviceTypeId }),
 					staffIds: await this.shiftRepository.findPastAssignedStaffIdsByClient(
 						clientId,
 						officeId,
@@ -1025,7 +1032,7 @@ export class ShiftAdjustmentSuggestionService {
 			),
 			Promise.all(
 				uniqueClientServicePairs.map(async ({ clientId, serviceTypeId }) => ({
-					key: `${clientId}:${serviceTypeId}`,
+					key: this.assignmentKey({ clientId, serviceTypeId }),
 					staffIds:
 						await this.clientStaffAssignmentRepository.findAssignedStaffIdsByClient(
 							officeId,
@@ -1044,35 +1051,24 @@ export class ShiftAdjustmentSuggestionService {
 			assignedStaffResults.map((r) => [r.key, r.staffIds]),
 		);
 
-		// 各影響シフトに対して代替候補を検索（バッチ並列化: DB接続負荷を制限）
-		const affectedShiftsWithCandidates: AffectedShiftWithCandidates[] = [];
+		// 各影響シフトに対して代替候補を検索（同期処理）
+		const affectedShiftsWithCandidates: AffectedShiftWithCandidates[] =
+			affectedShifts.map((shift) => {
+				const candidates = this.findCandidatesForShift({
+					shift,
+					absenceStaffId: input.staffId,
+					staffMap,
+					maxCandidates: MAX_CANDIDATES,
+					shiftsByDate,
+					pastStaffCache,
+					assignedStaffCache,
+				});
 
-		for (
-			let i = 0;
-			i < affectedShifts.length;
-			i += MAX_PARALLEL_CANDIDATE_QUERIES
-		) {
-			const batch = affectedShifts.slice(i, i + MAX_PARALLEL_CANDIDATE_QUERIES);
-			const batchResults = await Promise.all(
-				batch.map(async (shift) => {
-					const candidates = this.findCandidatesForShift({
-						shift,
-						absenceStaffId: input.staffId,
-						staffMap,
-						maxCandidates: MAX_CANDIDATES,
-						shiftsByDate,
-						pastStaffCache,
-						assignedStaffCache,
-					});
-
-					return {
-						shift: toShiftSnapshot(shift),
-						candidates,
-					};
-				}),
-			);
-			affectedShiftsWithCandidates.push(...batchResults);
-		}
+				return {
+					shift: toShiftSnapshot(shift),
+					candidates,
+				};
+			});
 
 		// 候補なしの件数をカウント
 		const noCandidatesCount = affectedShiftsWithCandidates.filter(
@@ -1160,9 +1156,15 @@ export class ShiftAdjustmentSuggestionService {
 		} = params;
 
 		// キャッシュから過去担当者と割当スタッフを取得
-		const cacheKey = `${shift.client_id}:${shift.service_type_id}`;
+		const cacheKey = this.assignmentKey({
+			clientId: shift.client_id,
+			serviceTypeId: shift.service_type_id,
+		});
 		const pastStaffIds = pastStaffCache.get(cacheKey) ?? [];
 		const assignedStaffIds = assignedStaffCache.get(cacheKey) ?? [];
+
+		// Set でO(1)ルックアップを実現
+		const pastStaffIdSet = new Set(pastStaffIds);
 
 		// 過去担当者（欠勤者除外）
 		const pastAssignedStaffIds = pastStaffIds.filter(
@@ -1170,7 +1172,7 @@ export class ShiftAdjustmentSuggestionService {
 		);
 		// 割当可能だが担当経験なし（欠勤者除外）
 		const assignedOnlyStaffIds = assignedStaffIds.filter(
-			(id) => id !== absenceStaffId && !pastStaffIds.includes(id),
+			(id) => id !== absenceStaffId && !pastStaffIdSet.has(id),
 		);
 
 		// 時間帯と空き状況チェック用のデータを準備

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -75,8 +75,8 @@ export type AvailableHelper = {
 export type StaffCandidate = {
 	staffId: string;
 	staffName: string;
-	/** 優先順位の理由: past_assigned = 過去に担当, available = 空き時間あり */
-	priority: 'past_assigned' | 'available';
+	/** 優先順位の理由: past_assigned = 過去に担当, assigned = 割当可能（担当経験なし）, available = 空き時間あり */
+	priority: 'past_assigned' | 'assigned' | 'available';
 };
 
 /**
@@ -1000,11 +1000,52 @@ export class ShiftAdjustmentSuggestionService {
 			shiftsByDate.set(dateKey, existing);
 		}
 
+		// (client_id, service_type_id) ペアの重複を排除して過去担当/割当スタッフを一括取得（N+1対策）
+		const uniqueClientServicePairs = [
+			...new Map(
+				affectedShifts.map((s) => [
+					`${s.client_id}:${s.service_type_id}`,
+					{ clientId: s.client_id, serviceTypeId: s.service_type_id },
+				]),
+			).values(),
+		];
+
+		// 過去担当者と割当スタッフを並列で取得してキャッシュ
+		const [pastStaffResults, assignedStaffResults] = await Promise.all([
+			Promise.all(
+				uniqueClientServicePairs.map(async ({ clientId, serviceTypeId }) => ({
+					key: `${clientId}:${serviceTypeId}`,
+					staffIds: await this.shiftRepository.findPastAssignedStaffIdsByClient(
+						clientId,
+						officeId,
+						serviceTypeId,
+						MAX_CANDIDATES,
+					),
+				})),
+			),
+			Promise.all(
+				uniqueClientServicePairs.map(async ({ clientId, serviceTypeId }) => ({
+					key: `${clientId}:${serviceTypeId}`,
+					staffIds:
+						await this.clientStaffAssignmentRepository.findAssignedStaffIdsByClient(
+							officeId,
+							clientId,
+							serviceTypeId,
+						),
+				})),
+			),
+		]);
+
+		// キャッシュ Map を作成
+		const pastStaffCache = new Map(
+			pastStaffResults.map((r) => [r.key, r.staffIds]),
+		);
+		const assignedStaffCache = new Map(
+			assignedStaffResults.map((r) => [r.key, r.staffIds]),
+		);
+
 		// 各影響シフトに対して代替候補を検索（バッチ並列化: DB接続負荷を制限）
-		const affectedShiftsWithCandidates: {
-			shift: ShiftSnapshot;
-			candidates: StaffCandidate[];
-		}[] = [];
+		const affectedShiftsWithCandidates: AffectedShiftWithCandidates[] = [];
 
 		for (
 			let i = 0;
@@ -1014,14 +1055,14 @@ export class ShiftAdjustmentSuggestionService {
 			const batch = affectedShifts.slice(i, i + MAX_PARALLEL_CANDIDATE_QUERIES);
 			const batchResults = await Promise.all(
 				batch.map(async (shift) => {
-					const candidates = await this.findCandidatesForShift({
+					const candidates = this.findCandidatesForShift({
 						shift,
 						absenceStaffId: input.staffId,
-						officeId,
 						staffMap,
 						maxCandidates: MAX_CANDIDATES,
-						allShiftsInPeriod,
 						shiftsByDate,
+						pastStaffCache,
+						assignedStaffCache,
 					});
 
 					return {
@@ -1051,72 +1092,38 @@ export class ShiftAdjustmentSuggestionService {
 	}
 
 	/**
-	 * 単一シフトに対する代替候補を検索
+	 * スタッフリストから候補を抽出（空き状況チェック付き）
 	 */
-	private findCandidatesForShift = async (params: {
-		shift: ScheduledShift;
-		absenceStaffId: string;
-		officeId: string;
+	private extractCandidatesFromStaffIds = (params: {
+		staffIds: string[];
 		staffMap: Map<string, OfficeStaff>;
+		shiftsByStaff: StaffShiftsByStaff;
+		range: { start: Date; end: Date };
+		serviceTypeId: ServiceTypeId;
 		maxCandidates: number;
-		allShiftsInPeriod: ScheduledShift[];
-		shiftsByDate: Map<string, ScheduledShift[]>;
-	}): Promise<StaffCandidate[]> => {
+		currentCount: number;
+		priority: StaffCandidate['priority'];
+	}): StaffCandidate[] => {
 		const {
-			shift,
-			absenceStaffId,
-			officeId,
+			staffIds,
 			staffMap,
+			shiftsByStaff,
+			range,
+			serviceTypeId,
 			maxCandidates,
-			shiftsByDate,
+			currentCount,
+			priority,
 		} = params;
-
-		// 1. 過去担当者を取得（shifts completed + client_staff_assignments）
-		const [pastStaffIds, assignedStaffIds] = await Promise.all([
-			this.shiftRepository.findPastAssignedStaffIdsByClient(
-				shift.client_id,
-				officeId,
-				shift.service_type_id,
-				maxCandidates,
-			),
-			this.clientStaffAssignmentRepository.findAssignedStaffIdsByClient(
-				officeId,
-				shift.client_id,
-				shift.service_type_id,
-			),
-		]);
-
-		// 重複排除して結合（過去担当優先）
-		const pastAssignedStaffIds = [
-			...new Set([...pastStaffIds, ...assignedStaffIds]),
-		].filter((id) => id !== absenceStaffId); // 欠勤者自身を除外
-
-		// 2. シフトの時間帯を計算
-		const targetDate = shift.date;
-		const range = this.buildRangeOnDate({
-			date: targetDate,
-			startTime: shift.time.start,
-			endTime: shift.time.end,
-		});
-
-		// 3. 空き状況チェック用のシフトを取得（前後1日）
-		// 事前にグループ化されたMapからO(1)でアクセス
-		const shiftsNearDate = this.getShiftsForDateRange(shiftsByDate, targetDate);
-		const shiftsByStaff = this.buildShiftsByStaff(shiftsNearDate);
-
 		const candidates: StaffCandidate[] = [];
+		let count = currentCount;
 
-		// 4. 過去担当者の空き状況をチェック（past_assigned 優先）
-		for (const staffId of pastAssignedStaffIds) {
-			if (candidates.length >= maxCandidates) break;
+		for (const staffId of staffIds) {
+			if (count >= maxCandidates) break;
 
 			const staff = staffMap.get(staffId);
 			if (!staff || staff.role !== 'helper') continue;
+			if (!staff.service_type_ids.includes(serviceTypeId)) continue;
 
-			// サービス種別対応可能かチェック
-			if (!staff.service_type_ids.includes(shift.service_type_id)) continue;
-
-			// 空き時間チェック
 			const hasConflict = this.hasConflictForRangeWithInterval({
 				shiftsByStaff,
 				staffId,
@@ -1124,41 +1131,109 @@ export class ShiftAdjustmentSuggestionService {
 			});
 			if (hasConflict) continue;
 
-			candidates.push({
-				staffId,
-				staffName: staff.name,
-				priority: 'past_assigned',
-			});
+			candidates.push({ staffId, staffName: staff.name, priority });
+			count++;
 		}
+		return candidates;
+	};
 
-		// 5. 候補が足りなければ追加候補を検索（available 優先）
+	/**
+	 * 単一シフトに対する代替候補を検索（キャッシュ使用、同期処理）
+	 */
+	private findCandidatesForShift = (params: {
+		shift: ScheduledShift;
+		absenceStaffId: string;
+		staffMap: Map<string, OfficeStaff>;
+		maxCandidates: number;
+		shiftsByDate: Map<string, ScheduledShift[]>;
+		pastStaffCache: Map<string, string[]>;
+		assignedStaffCache: Map<string, string[]>;
+	}): StaffCandidate[] => {
+		const {
+			shift,
+			absenceStaffId,
+			staffMap,
+			maxCandidates,
+			shiftsByDate,
+			pastStaffCache,
+			assignedStaffCache,
+		} = params;
+
+		// キャッシュから過去担当者と割当スタッフを取得
+		const cacheKey = `${shift.client_id}:${shift.service_type_id}`;
+		const pastStaffIds = pastStaffCache.get(cacheKey) ?? [];
+		const assignedStaffIds = assignedStaffCache.get(cacheKey) ?? [];
+
+		// 過去担当者（欠勤者除外）
+		const pastAssignedStaffIds = pastStaffIds.filter(
+			(id) => id !== absenceStaffId,
+		);
+		// 割当可能だが担当経験なし（欠勤者除外）
+		const assignedOnlyStaffIds = assignedStaffIds.filter(
+			(id) => id !== absenceStaffId && !pastStaffIds.includes(id),
+		);
+
+		// 時間帯と空き状況チェック用のデータを準備
+		const range = this.buildRangeOnDate({
+			date: shift.date,
+			startTime: shift.time.start,
+			endTime: shift.time.end,
+		});
+		const shiftsNearDate = this.getShiftsForDateRange(shiftsByDate, shift.date);
+		const shiftsByStaff = this.buildShiftsByStaff(shiftsNearDate);
+
+		const candidates: StaffCandidate[] = [];
+
+		// 1. 過去担当者から候補抽出（past_assigned 優先）
+		candidates.push(
+			...this.extractCandidatesFromStaffIds({
+				staffIds: pastAssignedStaffIds,
+				staffMap,
+				shiftsByStaff,
+				range,
+				serviceTypeId: shift.service_type_id,
+				maxCandidates,
+				currentCount: candidates.length,
+				priority: 'past_assigned',
+			}),
+		);
+
+		// 2. 割当可能スタッフから候補抽出（assigned 優先）
+		candidates.push(
+			...this.extractCandidatesFromStaffIds({
+				staffIds: assignedOnlyStaffIds,
+				staffMap,
+				shiftsByStaff,
+				range,
+				serviceTypeId: shift.service_type_id,
+				maxCandidates,
+				currentCount: candidates.length,
+				priority: 'assigned',
+			}),
+		);
+
+		// 3. 候補が足りなければ全ヘルパーから検索（available）
 		if (candidates.length < maxCandidates) {
-			const candidateIds = new Set(candidates.map((c) => c.staffId));
 			const excludeIds = new Set([
 				absenceStaffId,
 				...pastAssignedStaffIds,
-				...candidateIds,
+				...assignedOnlyStaffIds,
+				...candidates.map((c) => c.staffId),
 			]);
 
-			// 全ヘルパーから空きスタッフを検索
 			const availableHelpers = Array.from(staffMap.values())
 				.filter((staff) => {
-					// 除外対象は除く
 					if (excludeIds.has(staff.id)) return false;
-					// ヘルパーのみ
 					if (staff.role !== 'helper') return false;
-					// サービス種別対応可能か
 					if (!staff.service_type_ids.includes(shift.service_type_id))
 						return false;
-					// 空き時間チェック
-					const hasConflict = this.hasConflictForRangeWithInterval({
+					return !this.hasConflictForRangeWithInterval({
 						shiftsByStaff,
 						staffId: staff.id,
 						range,
 					});
-					return !hasConflict;
 				})
-				.sort((a, b) => a.name.localeCompare(b.name, 'ja')); // 名前順
+				.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
 
 			for (const staff of availableHelpers) {
 				if (candidates.length >= maxCandidates) break;

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -962,23 +962,32 @@ export class ShiftAdjustmentSuggestionService {
 		const officeStaffs = await this.staffRepository.listByOffice(officeId);
 		const staffMap = new Map(officeStaffs.map((s) => [s.id, s]));
 
-		// 各影響シフトに対して代替候補を検索
-		const affectedShiftsWithCandidates: AffectedShiftWithCandidates[] = [];
+		// 欠勤期間のシフトを一度だけ取得（N+1対策：前後1日のバッファを含む）
+		const allShiftsInPeriod = await this.shiftRepository.list({
+			officeId,
+			startDate: addJstDays(startDate, -1),
+			endDate: addJstDays(endDate, 1),
+			excludeStatus: 'canceled',
+		});
 
-		for (const shift of affectedShifts) {
-			const candidates = await this.findCandidatesForShift({
-				shift,
-				absenceStaffId: input.staffId,
-				officeId,
-				staffMap,
-				maxCandidates: MAX_CANDIDATES,
-			});
+		// 各影響シフトに対して代替候補を検索（並列化）
+		const affectedShiftsWithCandidates = await Promise.all(
+			affectedShifts.map(async (shift) => {
+				const candidates = await this.findCandidatesForShift({
+					shift,
+					absenceStaffId: input.staffId,
+					officeId,
+					staffMap,
+					maxCandidates: MAX_CANDIDATES,
+					allShiftsInPeriod,
+				});
 
-			affectedShiftsWithCandidates.push({
-				shift: toShiftSnapshot(shift),
-				candidates,
-			});
-		}
+				return {
+					shift: toShiftSnapshot(shift),
+					candidates,
+				};
+			}),
+		);
 
 		// 候補なしの件数をカウント
 		const noCandidatesCount = affectedShiftsWithCandidates.filter(
@@ -1006,8 +1015,16 @@ export class ShiftAdjustmentSuggestionService {
 		officeId: string;
 		staffMap: Map<string, OfficeStaff>;
 		maxCandidates: number;
+		allShiftsInPeriod: ScheduledShift[];
 	}): Promise<StaffCandidate[]> => {
-		const { shift, absenceStaffId, officeId, staffMap, maxCandidates } = params;
+		const {
+			shift,
+			absenceStaffId,
+			officeId,
+			staffMap,
+			maxCandidates,
+			allShiftsInPeriod,
+		} = params;
 
 		// 1. 過去担当者を取得（shifts completed + client_staff_assignments）
 		const [pastStaffIds, assignedStaffIds] = await Promise.all([
@@ -1037,12 +1054,12 @@ export class ShiftAdjustmentSuggestionService {
 			endTime: shift.time.end,
 		});
 
-		// 3. 空き状況チェック用のシフトを取得（前後1日）
-		const shiftsNearDate = await this.shiftRepository.list({
-			officeId,
-			startDate: addJstDays(targetDate, -1),
-			endDate: addJstDays(targetDate, 1),
-			excludeStatus: 'canceled',
+		// 3. 空き状況チェック用のシフトをフィルタリング（前後1日）
+		// 既に取得済みのallShiftsInPeriodから該当日付範囲を抽出
+		const targetStart = addJstDays(targetDate, -1);
+		const targetEnd = addJstDays(targetDate, 1);
+		const shiftsNearDate = allShiftsInPeriod.filter((s) => {
+			return s.date >= targetStart && s.date <= targetEnd;
 		});
 		const shiftsByStaff = this.buildShiftsByStaff(shiftsNearDate);
 

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -336,6 +336,26 @@ export class ShiftAdjustmentSuggestionService {
 		return shiftsByStaff;
 	};
 
+	/**
+	 * 日付ごとにグループ化されたMapから、指定日付の前後1日のシフトを取得
+	 * O(1)でアクセスし、O(n)のfilterを回避
+	 */
+	private getShiftsForDateRange = (
+		shiftsByDate: Map<string, ScheduledShift[]>,
+		targetDate: Date,
+	): ScheduledShift[] => {
+		const result: ScheduledShift[] = [];
+		for (let delta = -1; delta <= 1; delta++) {
+			const date = addJstDays(targetDate, delta);
+			const dateKey = formatJstDateString(date);
+			const shifts = shiftsByDate.get(dateKey);
+			if (shifts) {
+				result.push(...shifts);
+			}
+		}
+		return result;
+	};
+
 	private buildAssignableStaffMap = async (params: {
 		officeId: string;
 		shifts: ScheduledShift[];
@@ -923,6 +943,7 @@ export class ShiftAdjustmentSuggestionService {
 		input: StaffAbsenceInput,
 	): Promise<StaffAbsenceProcessResult> {
 		const MAX_CANDIDATES = 3;
+		const MAX_PARALLEL_CANDIDATE_QUERIES = 10;
 
 		// 管理者権限チェック
 		const admin = await this.getAdminStaff(userId);
@@ -970,24 +991,47 @@ export class ShiftAdjustmentSuggestionService {
 			excludeStatus: 'canceled',
 		});
 
-		// 各影響シフトに対して代替候補を検索（並列化）
-		const affectedShiftsWithCandidates = await Promise.all(
-			affectedShifts.map(async (shift) => {
-				const candidates = await this.findCandidatesForShift({
-					shift,
-					absenceStaffId: input.staffId,
-					officeId,
-					staffMap,
-					maxCandidates: MAX_CANDIDATES,
-					allShiftsInPeriod,
-				});
+		// 日付ごとにシフトをグループ化（findCandidatesForShift での O(n) フィルタリングを回避）
+		const shiftsByDate = new Map<string, ScheduledShift[]>();
+		for (const s of allShiftsInPeriod) {
+			const dateKey = formatJstDateString(s.date);
+			const existing = shiftsByDate.get(dateKey) ?? [];
+			existing.push(s);
+			shiftsByDate.set(dateKey, existing);
+		}
 
-				return {
-					shift: toShiftSnapshot(shift),
-					candidates,
-				};
-			}),
-		);
+		// 各影響シフトに対して代替候補を検索（バッチ並列化: DB接続負荷を制限）
+		const affectedShiftsWithCandidates: {
+			shift: ShiftSnapshot;
+			candidates: StaffCandidate[];
+		}[] = [];
+
+		for (
+			let i = 0;
+			i < affectedShifts.length;
+			i += MAX_PARALLEL_CANDIDATE_QUERIES
+		) {
+			const batch = affectedShifts.slice(i, i + MAX_PARALLEL_CANDIDATE_QUERIES);
+			const batchResults = await Promise.all(
+				batch.map(async (shift) => {
+					const candidates = await this.findCandidatesForShift({
+						shift,
+						absenceStaffId: input.staffId,
+						officeId,
+						staffMap,
+						maxCandidates: MAX_CANDIDATES,
+						allShiftsInPeriod,
+						shiftsByDate,
+					});
+
+					return {
+						shift: toShiftSnapshot(shift),
+						candidates,
+					};
+				}),
+			);
+			affectedShiftsWithCandidates.push(...batchResults);
+		}
 
 		// 候補なしの件数をカウント
 		const noCandidatesCount = affectedShiftsWithCandidates.filter(
@@ -1016,6 +1060,7 @@ export class ShiftAdjustmentSuggestionService {
 		staffMap: Map<string, OfficeStaff>;
 		maxCandidates: number;
 		allShiftsInPeriod: ScheduledShift[];
+		shiftsByDate: Map<string, ScheduledShift[]>;
 	}): Promise<StaffCandidate[]> => {
 		const {
 			shift,
@@ -1023,7 +1068,7 @@ export class ShiftAdjustmentSuggestionService {
 			officeId,
 			staffMap,
 			maxCandidates,
-			allShiftsInPeriod,
+			shiftsByDate,
 		} = params;
 
 		// 1. 過去担当者を取得（shifts completed + client_staff_assignments）
@@ -1054,13 +1099,9 @@ export class ShiftAdjustmentSuggestionService {
 			endTime: shift.time.end,
 		});
 
-		// 3. 空き状況チェック用のシフトをフィルタリング（前後1日）
-		// 既に取得済みのallShiftsInPeriodから該当日付範囲を抽出
-		const targetStart = addJstDays(targetDate, -1);
-		const targetEnd = addJstDays(targetDate, 1);
-		const shiftsNearDate = allShiftsInPeriod.filter((s) => {
-			return s.date >= targetStart && s.date <= targetEnd;
-		});
+		// 3. 空き状況チェック用のシフトを取得（前後1日）
+		// 事前にグループ化されたMapからO(1)でアクセス
+		const shiftsNearDate = this.getShiftsForDateRange(shiftsByDate, targetDate);
 		const shiftsByStaff = this.buildShiftsByStaff(shiftsNearDate);
 
 		const candidates: StaffCandidate[] = [];


### PR DESCRIPTION
## 概要
Service層に `processStaffAbsence` メソッドを追加しました（Phase 2A）。

スタッフ欠勤時の影響シフト取得と代替候補者の検索を行います。

## 変更内容

### 追加した型定義
- `StaffCandidate`: 代替候補スタッフ（staffId, staffName, priority）
- `AffectedShiftWithCandidates`: 影響シフトと代替候補
- `StaffAbsenceProcessResult`: processStaffAbsence の戻り値

### ロジック
1. 影響シフトを取得（scheduled + confirmed ステータス）
2. 各シフトについて過去担当者を優先的に候補に追加
3. 3名未満なら追加候補を検索
4. summary に影響シフト数と候補なし件数を含める

### 実装詳細
- 欠勤者自身は候補から除外
- 過去担当と割当可能スタッフの重複排除
- 候補は最大3名まで

## テスト
10件のユニットテストを追加（全てパス）

## 関連
Related to #94