### PR TITLE
feat: Phase 2C - processStaffAbsence Tool をチャットルートに統合 (#72)

### DIFF
--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -8,6 +8,7 @@ const {
 	mockGetUser,
 	mockSupabaseFrom,
 	mockCreateSearchAvailableHelpersTool,
+	mockCreateProcessStaffAbsenceTool,
 	mockStepCountIs,
 } = vi.hoisted(() => ({
 	mockStreamText: vi.fn(),
@@ -15,6 +16,7 @@ const {
 	mockGetUser: vi.fn(),
 	mockSupabaseFrom: vi.fn(),
 	mockCreateSearchAvailableHelpersTool: vi.fn(),
+	mockCreateProcessStaffAbsenceTool: vi.fn(),
 	mockStepCountIs: vi.fn((n: number) => ({ type: 'stepCountIs', count: n })),
 }));
 
@@ -38,6 +40,10 @@ vi.mock('@/utils/supabase/server', () => ({
 
 vi.mock('@/backend/tools/searchAvailableHelpers', () => ({
 	createSearchAvailableHelpersTool: mockCreateSearchAvailableHelpersTool,
+}));
+
+vi.mock('@/backend/tools/processStaffAbsence', () => ({
+	createProcessStaffAbsenceTool: mockCreateProcessStaffAbsenceTool,
 }));
 
 // 環境変数のモック
@@ -75,7 +81,10 @@ describe('POST /api/chat/shift-adjustment', () => {
 
 		// Tool モックを返す
 		mockCreateSearchAvailableHelpersTool.mockReturnValue({
-			description: 'mock tool',
+			description: 'mock search tool',
+		});
+		mockCreateProcessStaffAbsenceTool.mockReturnValue({
+			description: 'mock process absence tool',
 		});
 
 		// デフォルトのstreamTextモック
@@ -348,6 +357,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 				expect.objectContaining({
 					tools: expect.objectContaining({
 						searchAvailableHelpers: expect.anything(),
+						processStaffAbsence: expect.anything(),
 					}),
 					stopWhen: expect.anything(),
 				}),
@@ -372,6 +382,29 @@ describe('POST /api/chat/shift-adjustment', () => {
 			expect(mockCreateSearchAvailableHelpersTool).toHaveBeenCalledWith({
 				supabase: expect.anything(),
 				officeId: TEST_IDS.OFFICE_1,
+			});
+		});
+
+		it('createProcessStaffAbsenceTool が正しい引数で呼ばれる', async () => {
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						messages: [
+							{ role: 'user', content: 'スタッフAが休みになりました' },
+						],
+					}),
+				},
+			);
+
+			await POST(request);
+
+			// Tool が正しい引数で作成されたことを確認
+			expect(mockCreateProcessStaffAbsenceTool).toHaveBeenCalledWith({
+				supabase: expect.anything(),
+				userId: 'test-user-id',
 			});
 		});
 
@@ -466,6 +499,11 @@ describe('POST /api/chat/shift-adjustment', () => {
 			expect(mockStreamText).toHaveBeenCalledWith(
 				expect.objectContaining({
 					system: expect.stringContaining('searchAvailableHelpers'),
+				}),
+			);
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					system: expect.stringContaining('processStaffAbsence'),
 				}),
 			);
 		});

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -1,3 +1,4 @@
+import { createProcessStaffAbsenceTool } from '@/backend/tools/processStaffAbsence';
 import { createSearchAvailableHelpersTool } from '@/backend/tools/searchAvailableHelpers';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
@@ -71,6 +72,10 @@ const SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサ
   - 代替スタッフを探す際に使用してください
   - 日付(YYYY-MM-DD)、開始時刻、終了時刻を指定します
   - 利用者IDを指定すると、その利用者に割当可能なスタッフに絞り込めます
+- processStaffAbsence: スタッフの欠勤を登録し、影響シフトと代替候補を取得します
+  - スタッフが休みになった場合に使用してください
+  - staffId（UUID）、startDate、endDate（YYYY-MM-DD）を指定します
+  - 最大14日間まで指定可能です
 
 ## 制約
 - 提案は具体的かつ実行可能なものにする
@@ -168,6 +173,10 @@ export const POST = async (request: Request): Promise<Response> => {
 			supabase,
 			officeId: staffData.office_id,
 		});
+		const processStaffAbsenceTool = createProcessStaffAbsenceTool({
+			supabase,
+			userId: user.id,
+		});
 
 		// Vercel AI SDK の streamText を使用
 		// messages の型は streamText が受け入れる形式に変換
@@ -181,6 +190,7 @@ export const POST = async (request: Request): Promise<Response> => {
 			})),
 			tools: {
 				searchAvailableHelpers: searchAvailableHelpersTool,
+				processStaffAbsence: processStaffAbsenceTool,
 			},
 			stopWhen: stepCountIs(3),
 		});

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -70,12 +70,16 @@ const SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサ
 ## 利用可能なツール
 - searchAvailableHelpers: 指定した日時に空きのあるヘルパーを検索できます
   - 代替スタッフを探す際に使用してください
-  - 日付(YYYY-MM-DD)、開始時刻、終了時刻を指定します
-  - 利用者IDを指定すると、その利用者に割当可能なスタッフに絞り込めます
+  - date は日付(YYYY-MM-DD)、startTime / endTime は { hour, minute } 形式のオブジェクトで指定します
+    - 例: { date: "2024-04-01", startTime: { hour: 9, minute: 0 }, endTime: { hour: 10, minute: 0 } }
+  - clientId を指定する場合は、必ず対応する serviceTypeId（サービス種別ID）も一緒に指定してください
+    - 例: { clientId: "<利用者ID>", serviceTypeId: "<サービス種別ID>" }
 - processStaffAbsence: スタッフの欠勤を登録し、影響シフトと代替候補を取得します
   - スタッフが休みになった場合に使用してください
   - staffId（UUID）、startDate、endDate（YYYY-MM-DD）を指定します
   - 最大14日間まで指定可能です
+  - 任意項目 memo には、可能な限り欠勤理由や補足情報を日本語で簡潔に記載してください
+    - 例: { staffId: "<スタッフID>", startDate: "2024-04-01", endDate: "2024-04-03", memo: "体調不良のため" }
 
 ## 制約
 - 提案は具体的かつ実行可能なものにする


### PR DESCRIPTION
## 概要

Phase 2C: processStaffAbsence Tool をチャットルート（shift-adjustment API）に統合しました。

refs #72

## 変更内容

### ルート統合 (`src/app/api/chat/shift-adjustment/route.ts`)
- `createProcessStaffAbsenceTool` のインポートと作成
- `tools` オブジェクトへの `processStaffAbsence` ツール追加
- `SYSTEM_PROMPT` にツール説明を追加:
  - `processStaffAbsence`: スタッフの欠勤を処理し、シフト調整を実行

### テスト追加 (`src/app/api/chat/shift-adjustment/route.test.ts`)
- `createProcessStaffAbsenceTool が正しい引数で呼ばれる` テスト追加
- 全19件のテストが pass

## テスト結果

```
✓ POST /api/chat/shift-adjustment (19 tests)
  ✓ Tool integration (7)
    ✓ streamText に tools と stopWhen が渡される
    ✓ createSearchAvailableHelpersTool が正しい引数で呼ばれる
    ✓ createProcessStaffAbsenceTool が正しい引数で呼ばれる
    ✓ スタッフが見つからない場合は 404 エラーを返す
    ✓ スタッフ取得エラー時は 500 エラーを返す
    ✓ admin 権限がない場合は 403 エラーを返す
    ✓ システムプロンプトに Tool の使用方法が含まれる
```

## 次のステップ

Phase 2D: スタッフ検索 Tool の追加
- 現在の `processStaffAbsence` はスタッフIDを直接指定する必要がある
- スタッフ名からIDを取得する検索機能を追加予定