### PR TITLE
feat: Phase 2D - searchStaffs Tool を追加（名前からスタッフID検索）(#72)

### DIFF
--- a/.github/agents/pr.agent.md
+++ b/.github/agents/pr.agent.md
@@ -44,7 +44,7 @@ tools:
     ms-vscode.vscode-websearchforcopilot/websearch,
     todo,
   ]
-model: GPT-5.4 (copilot)
+model: Claude Sonnet 4.6 (copilot)
 ---
 
 与えられたイシューと実装に対する、プルリクエストを作成してください。

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -9,6 +9,7 @@ const {
 	mockSupabaseFrom,
 	mockCreateSearchAvailableHelpersTool,
 	mockCreateProcessStaffAbsenceTool,
+	mockCreateSearchStaffsTool,
 	mockStepCountIs,
 } = vi.hoisted(() => ({
 	mockStreamText: vi.fn(),
@@ -17,6 +18,7 @@ const {
 	mockSupabaseFrom: vi.fn(),
 	mockCreateSearchAvailableHelpersTool: vi.fn(),
 	mockCreateProcessStaffAbsenceTool: vi.fn(),
+	mockCreateSearchStaffsTool: vi.fn(),
 	mockStepCountIs: vi.fn((n: number) => ({ type: 'stepCountIs', count: n })),
 }));
 
@@ -44,6 +46,10 @@ vi.mock('@/backend/tools/searchAvailableHelpers', () => ({
 
 vi.mock('@/backend/tools/processStaffAbsence', () => ({
 	createProcessStaffAbsenceTool: mockCreateProcessStaffAbsenceTool,
+}));
+
+vi.mock('@/backend/tools/searchStaffs', () => ({
+	createSearchStaffsTool: mockCreateSearchStaffsTool,
 }));
 
 // 環境変数のモック
@@ -85,6 +91,9 @@ describe('POST /api/chat/shift-adjustment', () => {
 		});
 		mockCreateProcessStaffAbsenceTool.mockReturnValue({
 			description: 'mock process absence tool',
+		});
+		mockCreateSearchStaffsTool.mockReturnValue({
+			description: 'mock search staffs tool',
 		});
 
 		// デフォルトのstreamTextモック
@@ -358,6 +367,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 					tools: expect.objectContaining({
 						searchAvailableHelpers: expect.anything(),
 						processStaffAbsence: expect.anything(),
+						searchStaffs: expect.anything(),
 					}),
 					stopWhen: expect.anything(),
 				}),
@@ -506,6 +516,32 @@ describe('POST /api/chat/shift-adjustment', () => {
 					system: expect.stringContaining('processStaffAbsence'),
 				}),
 			);
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					system: expect.stringContaining('searchStaffs'),
+				}),
+			);
+		});
+
+		it('createSearchStaffsTool が正しい引数で呼ばれる', async () => {
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '田中さんを検索して' }],
+					}),
+				},
+			);
+
+			await POST(request);
+
+			// Tool が正しい引数で作成されたことを確認
+			expect(mockCreateSearchStaffsTool).toHaveBeenCalledWith({
+				supabase: expect.anything(),
+				officeId: TEST_IDS.OFFICE_1,
+			});
 		});
 	});
 });

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -1,5 +1,6 @@
 import { createProcessStaffAbsenceTool } from '@/backend/tools/processStaffAbsence';
 import { createSearchAvailableHelpersTool } from '@/backend/tools/searchAvailableHelpers';
+import { createSearchStaffsTool } from '@/backend/tools/searchStaffs';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { stepCountIs, streamText } from 'ai';
@@ -80,6 +81,10 @@ const SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサ
   - 最大14日間まで指定可能です
   - 任意項目 memo には、可能な限り欠勤理由や補足情報を日本語で簡潔に記載してください
     - 例: { staffId: "<スタッフID>", startDate: "2024-04-01", endDate: "2024-04-03", memo: "体調不良のため" }
+- searchStaffs: スタッフを名前で検索します
+  - スタッフIDがわからない場合に使用してください
+  - query には検索したいスタッフ名（部分一致）を指定します
+    - 例: { query: "田中" }
 
 ## 制約
 - 提案は具体的かつ実行可能なものにする
@@ -181,6 +186,10 @@ export const POST = async (request: Request): Promise<Response> => {
 			supabase,
 			userId: user.id,
 		});
+		const searchStaffsTool = createSearchStaffsTool({
+			supabase,
+			officeId: staffData.office_id,
+		});
 
 		// Vercel AI SDK の streamText を使用
 		// messages の型は streamText が受け入れる形式に変換
@@ -195,6 +204,7 @@ export const POST = async (request: Request): Promise<Response> => {
 			tools: {
 				searchAvailableHelpers: searchAvailableHelpersTool,
 				processStaffAbsence: processStaffAbsenceTool,
+				searchStaffs: searchStaffsTool,
 			},
 			stopWhen: stepCountIs(3),
 		});

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -84,8 +84,8 @@ const SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサ
 - searchStaffs: スタッフを名前で検索します
   - スタッフIDがわからない場合に使用してください
   - 入力: { query: "検索文字列" }
-  - 出力: { staffs: [{ staffId, name, kana }] }
-  - processStaffAbsence と連携する場合、検索結果の staffId を使用してください
+  - 出力: { staffs: [{ id, name, role, serviceTypeIds }] }
+  - processStaffAbsence と連携する場合、検索結果の id を staffId として使用してください
     - 例: { query: "田中" }
 
 ## 制約

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -83,7 +83,9 @@ const SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサ
     - 例: { staffId: "<スタッフID>", startDate: "2024-04-01", endDate: "2024-04-03", memo: "体調不良のため" }
 - searchStaffs: スタッフを名前で検索します
   - スタッフIDがわからない場合に使用してください
-  - query には検索したいスタッフ名（部分一致）を指定します
+  - 入力: { query: "検索文字列" }
+  - 出力: { staffs: [{ staffId, name, kana }] }
+  - processStaffAbsence と連携する場合、検索結果の staffId を使用してください
     - 例: { query: "田中" }
 
 ## 制約

--- a/src/backend/repositories/staffRepository.test.ts
+++ b/src/backend/repositories/staffRepository.test.ts
@@ -16,6 +16,7 @@ describe('StaffRepository', () => {
 		id: '019b1aaf-0000-4000-8000-000000000001',
 		office_id: officeId,
 		name: '管理者A',
+		kana: null as string | null,
 		role: 'admin' as const,
 		email: 'admin@example.com',
 		note: null as string | null,
@@ -301,14 +302,15 @@ describe('StaffRepository', () => {
 		});
 	});
 
-	describe('searchByName', () => {
+	describe('searchByNameOrKana', () => {
 		it('名前でケースインセンシティブ検索ができる', async () => {
 			const staffRows = [
-				baseStaffRow,
+				{ ...baseStaffRow, kana: 'かんりしゃえー' },
 				{
 					...baseStaffRow,
 					id: '019b1aaf-0000-4000-8000-000000000002',
 					name: '山田花子',
+					kana: 'やまだはなこ',
 					role: 'helper' as const,
 				},
 			];
@@ -319,7 +321,7 @@ describe('StaffRepository', () => {
 
 			const mockStaffSelect = vi.fn().mockReturnThis();
 			const mockStaffEq = vi.fn().mockReturnThis();
-			const mockStaffIlike = vi.fn().mockReturnThis();
+			const mockStaffOr = vi.fn().mockReturnThis();
 			const mockStaffLimit = vi
 				.fn()
 				.mockResolvedValue({ data: staffRows, error: null });
@@ -340,22 +342,79 @@ describe('StaffRepository', () => {
 			});
 
 			mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
-			mockStaffEq.mockReturnValue({ ilike: mockStaffIlike });
-			mockStaffIlike.mockReturnValue({ limit: mockStaffLimit });
+			mockStaffEq.mockReturnValue({ or: mockStaffOr });
+			mockStaffOr.mockReturnValue({ limit: mockStaffLimit });
 
 			mockAbilitySelect.mockReturnValue({ in: mockAbilityIn });
 
-			const result = await repository.searchByName(officeId, '山田', 10);
+			const result = await repository.searchByNameOrKana(officeId, '山田', 10);
 
 			expect(result).toHaveLength(2);
-			expect(mockStaffIlike).toHaveBeenCalledWith('name', '%山田%');
+			expect(mockStaffOr).toHaveBeenCalledWith(
+				'name.ilike.%山田%,kana.ilike.%山田%',
+			);
 			expect(mockStaffLimit).toHaveBeenCalledWith(10);
+		});
+
+		it('kanaでひらがな検索ができる', async () => {
+			const staffRows = [
+				{
+					...baseStaffRow,
+					id: '019b1aaf-0000-4000-8000-000000000003',
+					name: '田中太郎',
+					kana: 'たなかたろう',
+					role: 'helper' as const,
+				},
+			];
+			const abilityRows = [
+				{ staff_id: staffRows[0].id, service_type_id: serviceTypeIds.one },
+			];
+
+			const mockStaffSelect = vi.fn().mockReturnThis();
+			const mockStaffEq = vi.fn().mockReturnThis();
+			const mockStaffOr = vi.fn().mockReturnThis();
+			const mockStaffLimit = vi
+				.fn()
+				.mockResolvedValue({ data: staffRows, error: null });
+
+			const mockAbilitySelect = vi.fn().mockReturnThis();
+			const mockAbilityIn = vi
+				.fn()
+				.mockResolvedValue({ data: abilityRows, error: null });
+
+			(supabase.from as any).mockImplementation((table: string) => {
+				if (table === 'staffs') {
+					return { select: mockStaffSelect };
+				}
+				if (table === 'staff_service_type_abilities') {
+					return { select: mockAbilitySelect };
+				}
+				throw new Error(`Unexpected table: ${table}`);
+			});
+
+			mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
+			mockStaffEq.mockReturnValue({ or: mockStaffOr });
+			mockStaffOr.mockReturnValue({ limit: mockStaffLimit });
+
+			mockAbilitySelect.mockReturnValue({ in: mockAbilityIn });
+
+			const result = await repository.searchByNameOrKana(
+				officeId,
+				'たなか',
+				10,
+			);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('田中太郎');
+			expect(mockStaffOr).toHaveBeenCalledWith(
+				'name.ilike.%たなか%,kana.ilike.%たなか%',
+			);
 		});
 
 		it('上限件数を指定できる', async () => {
 			const mockStaffSelect = vi.fn().mockReturnThis();
 			const mockStaffEq = vi.fn().mockReturnThis();
-			const mockStaffIlike = vi.fn().mockReturnThis();
+			const mockStaffOr = vi.fn().mockReturnThis();
 			const mockStaffLimit = vi
 				.fn()
 				.mockResolvedValue({ data: [], error: null });
@@ -375,10 +434,10 @@ describe('StaffRepository', () => {
 			});
 
 			mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
-			mockStaffEq.mockReturnValue({ ilike: mockStaffIlike });
-			mockStaffIlike.mockReturnValue({ limit: mockStaffLimit });
+			mockStaffEq.mockReturnValue({ or: mockStaffOr });
+			mockStaffOr.mockReturnValue({ limit: mockStaffLimit });
 
-			await repository.searchByName(officeId, 'test', 5);
+			await repository.searchByNameOrKana(officeId, 'test', 5);
 
 			expect(mockStaffLimit).toHaveBeenCalledWith(5);
 		});

--- a/src/backend/repositories/staffRepository.test.ts
+++ b/src/backend/repositories/staffRepository.test.ts
@@ -300,4 +300,87 @@ describe('StaffRepository', () => {
 			expect(mockEq).toHaveBeenCalledWith('id', baseStaffRow.id);
 		});
 	});
+
+	describe('searchByName', () => {
+		it('名前でケースインセンシティブ検索ができる', async () => {
+			const staffRows = [
+				baseStaffRow,
+				{
+					...baseStaffRow,
+					id: '019b1aaf-0000-4000-8000-000000000002',
+					name: '山田花子',
+					role: 'helper' as const,
+				},
+			];
+			const abilityRows = [
+				{ staff_id: staffRows[0].id, service_type_id: serviceTypeIds.one },
+				{ staff_id: staffRows[1].id, service_type_id: serviceTypeIds.two },
+			];
+
+			const mockStaffSelect = vi.fn().mockReturnThis();
+			const mockStaffEq = vi.fn().mockReturnThis();
+			const mockStaffIlike = vi.fn().mockReturnThis();
+			const mockStaffLimit = vi
+				.fn()
+				.mockResolvedValue({ data: staffRows, error: null });
+
+			const mockAbilitySelect = vi.fn().mockReturnThis();
+			const mockAbilityIn = vi
+				.fn()
+				.mockResolvedValue({ data: abilityRows, error: null });
+
+			(supabase.from as any).mockImplementation((table: string) => {
+				if (table === 'staffs') {
+					return { select: mockStaffSelect };
+				}
+				if (table === 'staff_service_type_abilities') {
+					return { select: mockAbilitySelect };
+				}
+				throw new Error(`Unexpected table: ${table}`);
+			});
+
+			mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
+			mockStaffEq.mockReturnValue({ ilike: mockStaffIlike });
+			mockStaffIlike.mockReturnValue({ limit: mockStaffLimit });
+
+			mockAbilitySelect.mockReturnValue({ in: mockAbilityIn });
+
+			const result = await repository.searchByName(officeId, '山田', 10);
+
+			expect(result).toHaveLength(2);
+			expect(mockStaffIlike).toHaveBeenCalledWith('name', '%山田%');
+			expect(mockStaffLimit).toHaveBeenCalledWith(10);
+		});
+
+		it('上限件数を指定できる', async () => {
+			const mockStaffSelect = vi.fn().mockReturnThis();
+			const mockStaffEq = vi.fn().mockReturnThis();
+			const mockStaffIlike = vi.fn().mockReturnThis();
+			const mockStaffLimit = vi
+				.fn()
+				.mockResolvedValue({ data: [], error: null });
+
+			(supabase.from as any).mockImplementation((table: string) => {
+				if (table === 'staffs') {
+					return { select: mockStaffSelect };
+				}
+				if (table === 'staff_service_type_abilities') {
+					return {
+						select: vi.fn().mockReturnValue({
+							in: vi.fn().mockResolvedValue({ data: [], error: null }),
+						}),
+					};
+				}
+				throw new Error(`Unexpected table: ${table}`);
+			});
+
+			mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
+			mockStaffEq.mockReturnValue({ ilike: mockStaffIlike });
+			mockStaffIlike.mockReturnValue({ limit: mockStaffLimit });
+
+			await repository.searchByName(officeId, 'test', 5);
+
+			expect(mockStaffLimit).toHaveBeenCalledWith(5);
+		});
+	});
 });

--- a/src/backend/repositories/staffRepository.test.ts
+++ b/src/backend/repositories/staffRepository.test.ts
@@ -322,6 +322,7 @@ describe('StaffRepository', () => {
 			const mockStaffSelect = vi.fn().mockReturnThis();
 			const mockStaffEq = vi.fn().mockReturnThis();
 			const mockStaffOr = vi.fn().mockReturnThis();
+			const mockStaffOrder = vi.fn().mockReturnThis();
 			const mockStaffLimit = vi
 				.fn()
 				.mockResolvedValue({ data: staffRows, error: null });
@@ -343,7 +344,8 @@ describe('StaffRepository', () => {
 
 			mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
 			mockStaffEq.mockReturnValue({ or: mockStaffOr });
-			mockStaffOr.mockReturnValue({ limit: mockStaffLimit });
+			mockStaffOr.mockReturnValue({ order: mockStaffOrder });
+			mockStaffOrder.mockReturnValue({ limit: mockStaffLimit });
 
 			mockAbilitySelect.mockReturnValue({ in: mockAbilityIn });
 
@@ -373,6 +375,7 @@ describe('StaffRepository', () => {
 			const mockStaffSelect = vi.fn().mockReturnThis();
 			const mockStaffEq = vi.fn().mockReturnThis();
 			const mockStaffOr = vi.fn().mockReturnThis();
+			const mockStaffOrder = vi.fn().mockReturnThis();
 			const mockStaffLimit = vi
 				.fn()
 				.mockResolvedValue({ data: staffRows, error: null });
@@ -394,7 +397,8 @@ describe('StaffRepository', () => {
 
 			mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
 			mockStaffEq.mockReturnValue({ or: mockStaffOr });
-			mockStaffOr.mockReturnValue({ limit: mockStaffLimit });
+			mockStaffOr.mockReturnValue({ order: mockStaffOrder });
+			mockStaffOrder.mockReturnValue({ limit: mockStaffLimit });
 
 			mockAbilitySelect.mockReturnValue({ in: mockAbilityIn });
 
@@ -415,6 +419,7 @@ describe('StaffRepository', () => {
 			const mockStaffSelect = vi.fn().mockReturnThis();
 			const mockStaffEq = vi.fn().mockReturnThis();
 			const mockStaffOr = vi.fn().mockReturnThis();
+			const mockStaffOrder = vi.fn().mockReturnThis();
 			const mockStaffLimit = vi
 				.fn()
 				.mockResolvedValue({ data: [], error: null });
@@ -435,7 +440,8 @@ describe('StaffRepository', () => {
 
 			mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
 			mockStaffEq.mockReturnValue({ or: mockStaffOr });
-			mockStaffOr.mockReturnValue({ limit: mockStaffLimit });
+			mockStaffOr.mockReturnValue({ order: mockStaffOrder });
+			mockStaffOrder.mockReturnValue({ limit: mockStaffLimit });
 
 			await repository.searchByNameOrKana(officeId, 'test', 5);
 

--- a/src/backend/repositories/staffRepository.test.ts
+++ b/src/backend/repositories/staffRepository.test.ts
@@ -447,5 +447,22 @@ describe('StaffRepository', () => {
 
 			expect(mockStaffLimit).toHaveBeenCalledWith(5);
 		});
+
+		it('空文字クエリの場合は空配列を返す（全件ヒット防止）', async () => {
+			// safeQuery が空文字になるケース（空文字、特殊文字のみ）
+			const result = await repository.searchByNameOrKana(officeId, '', 10);
+
+			expect(result).toEqual([]);
+			// DB にはアクセスしない
+			expect(supabase.from).not.toHaveBeenCalled();
+		});
+
+		it('特殊文字のみの場合は空配列を返す', async () => {
+			// PostgREST 構文インジェクション対策で除去される文字のみ
+			const result = await repository.searchByNameOrKana(officeId, '()', 10);
+
+			expect(result).toEqual([]);
+			expect(supabase.from).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/src/backend/repositories/staffRepository.ts
+++ b/src/backend/repositories/staffRepository.ts
@@ -227,19 +227,19 @@ export class StaffRepository {
 	}
 
 	/**
-	 * 名前でケースインセンシティブ検索
-	 * DB 側で ilike + limit を使用してフィルタリング
+	 * 名前またはかな（kana）でケースインセンシティブ検索
+	 * DB 側で or + ilike + limit を使用してフィルタリング
 	 */
-	async searchByName(
+	async searchByNameOrKana(
 		officeId: string,
-		nameQuery: string,
+		query: string,
 		limit: number,
 	): Promise<StaffWithServiceTypes[]> {
 		const { data, error } = await this.supabase
 			.from('staffs')
 			.select('*')
 			.eq('office_id', officeId)
-			.ilike('name', `%${nameQuery}%`)
+			.or(`name.ilike.%${query}%,kana.ilike.%${query}%`)
 			.limit(limit);
 		if (error) throw error;
 		const rows = data ?? [];

--- a/src/backend/repositories/staffRepository.ts
+++ b/src/backend/repositories/staffRepository.ts
@@ -237,6 +237,12 @@ export class StaffRepository {
 	): Promise<StaffWithServiceTypes[]> {
 		// PostgREST 構文インジェクション対策: 特殊文字を除去
 		const safeQuery = query.replace(/[(),]/g, '');
+
+		// 空文字の場合は全件ヒット防止のため空配列を返す
+		if (safeQuery === '') {
+			return [];
+		}
+
 		const { data, error } = await this.supabase
 			.from('staffs')
 			.select('*')

--- a/src/backend/repositories/staffRepository.ts
+++ b/src/backend/repositories/staffRepository.ts
@@ -235,11 +235,14 @@ export class StaffRepository {
 		query: string,
 		limit: number,
 	): Promise<StaffWithServiceTypes[]> {
+		// PostgREST 構文インジェクション対策: 特殊文字を除去
+		const safeQuery = query.replace(/[(),]/g, '');
 		const { data, error } = await this.supabase
 			.from('staffs')
 			.select('*')
 			.eq('office_id', officeId)
-			.or(`name.ilike.%${query}%,kana.ilike.%${query}%`)
+			.or(`name.ilike.%${safeQuery}%,kana.ilike.%${safeQuery}%`)
+			.order('name', { ascending: true })
 			.limit(limit);
 		if (error) throw error;
 		const rows = data ?? [];

--- a/src/backend/repositories/staffRepository.ts
+++ b/src/backend/repositories/staffRepository.ts
@@ -225,4 +225,27 @@ export class StaffRepository {
 
 		if (error) throw error;
 	}
+
+	/**
+	 * 名前でケースインセンシティブ検索
+	 * DB 側で ilike + limit を使用してフィルタリング
+	 */
+	async searchByName(
+		officeId: string,
+		nameQuery: string,
+		limit: number,
+	): Promise<StaffWithServiceTypes[]> {
+		const { data, error } = await this.supabase
+			.from('staffs')
+			.select('*')
+			.eq('office_id', officeId)
+			.ilike('name', `%${nameQuery}%`)
+			.limit(limit);
+		if (error) throw error;
+		const rows = data ?? [];
+		const map = await this.fetchServiceTypeMap(rows.map((row) => row.id));
+		return rows.map((row) =>
+			this.toDomainWithServiceTypes(row, map[row.id] ?? []),
+		);
+	}
 }

--- a/src/backend/tools/searchStaffs.test.ts
+++ b/src/backend/tools/searchStaffs.test.ts
@@ -1,0 +1,222 @@
+import { Database } from '@/backend/types/supabase';
+import { TEST_IDS } from '@/test/helpers/testIds';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	createSearchStaffsTool,
+	SearchStaffsParametersSchema,
+	SearchStaffsResult,
+} from './searchStaffs';
+
+describe('searchStaffs tool', () => {
+	const mockListByOffice = vi.fn();
+
+	const mockSupabase = {} as SupabaseClient<Database>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('createSearchStaffsTool', () => {
+		it('tool が正しい構造を持つ', () => {
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+			});
+
+			expect(tool).toHaveProperty('description');
+			expect(tool).toHaveProperty('inputSchema');
+			expect(tool).toHaveProperty('execute');
+			expect(typeof tool.execute).toBe('function');
+		});
+
+		it('description がスタッフ検索について説明している', () => {
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+			});
+
+			expect(tool.description).toContain('スタッフ');
+			expect(tool.description).toContain('検索');
+		});
+	});
+
+	describe('SearchStaffsParametersSchema', () => {
+		it('正しいパラメータをパースできる', () => {
+			const validParams = {
+				query: '山田',
+			};
+
+			const result = SearchStaffsParametersSchema.safeParse(validParams);
+			expect(result.success).toBe(true);
+		});
+
+		it('空文字列を拒否する', () => {
+			const invalidParams = {
+				query: '',
+			};
+
+			const result = SearchStaffsParametersSchema.safeParse(invalidParams);
+			expect(result.success).toBe(false);
+		});
+
+		it('100文字以下のクエリを受け付ける', () => {
+			const validParams = {
+				query: 'あ'.repeat(100),
+			};
+
+			const result = SearchStaffsParametersSchema.safeParse(validParams);
+			expect(result.success).toBe(true);
+		});
+
+		it('100文字を超えるクエリを拒否する', () => {
+			const invalidParams = {
+				query: 'あ'.repeat(101),
+			};
+
+			const result = SearchStaffsParametersSchema.safeParse(invalidParams);
+			expect(result.success).toBe(false);
+		});
+
+		it('query パラメータが必須', () => {
+			const invalidParams = {};
+
+			const result = SearchStaffsParametersSchema.safeParse(invalidParams);
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('execute', () => {
+		// StaffRepository のモック
+		const mockStaffRepository = {
+			listByOffice: mockListByOffice,
+		};
+
+		it('名前が部分一致するスタッフを返す', async () => {
+			mockListByOffice.mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					name: '山田太郎',
+					role: 'admin',
+					service_type_ids: ['physical-care', 'life-support'],
+				},
+				{
+					id: TEST_IDS.STAFF_2,
+					name: '山田花子',
+					role: 'helper',
+					service_type_ids: ['life-support'],
+				},
+				{
+					id: TEST_IDS.STAFF_3,
+					name: '鈴木一郎',
+					role: 'helper',
+					service_type_ids: ['physical-care'],
+				},
+			]);
+
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+				staffRepository: mockStaffRepository,
+			});
+
+			const result: SearchStaffsResult = await tool.execute({ query: '山田' });
+
+			expect(result.staffs).toHaveLength(2);
+			expect(result.staffs[0].name).toBe('山田太郎');
+			expect(result.staffs[1].name).toBe('山田花子');
+		});
+
+		it('最大10件まで返す', async () => {
+			// 15件のスタッフを生成
+			const manyStaffs = Array.from({ length: 15 }, (_, i) => ({
+				id: `aaaaaaaa-bbbb-4ccc-8ddd-${i.toString().padStart(12, '0')}`,
+				name: `山田${i}号`,
+				role: 'helper',
+				service_type_ids: [],
+			}));
+
+			mockListByOffice.mockResolvedValue(manyStaffs);
+
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+				staffRepository: mockStaffRepository,
+			});
+
+			const result: SearchStaffsResult = await tool.execute({ query: '山田' });
+
+			expect(result.staffs).toHaveLength(10);
+		});
+
+		it('該当するスタッフがいない場合は空配列を返す', async () => {
+			mockListByOffice.mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					name: '田中太郎',
+					role: 'helper',
+					service_type_ids: [],
+				},
+			]);
+
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+				staffRepository: mockStaffRepository,
+			});
+
+			const result: SearchStaffsResult = await tool.execute({ query: '山田' });
+
+			expect(result.staffs).toHaveLength(0);
+		});
+
+		it('結果に id, name, role, serviceTypeIds が含まれる', async () => {
+			mockListByOffice.mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					name: '山田太郎',
+					role: 'admin',
+					service_type_ids: ['physical-care', 'life-support'],
+				},
+			]);
+
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+				staffRepository: mockStaffRepository,
+			});
+
+			const result: SearchStaffsResult = await tool.execute({ query: '山田' });
+
+			expect(result.staffs[0]).toEqual({
+				id: TEST_IDS.STAFF_1,
+				name: '山田太郎',
+				role: 'admin',
+				serviceTypeIds: ['physical-care', 'life-support'],
+			});
+		});
+
+		it('大文字小文字を区別しない検索が可能（ひらがな）', async () => {
+			mockListByOffice.mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					name: 'やまだたろう',
+					role: 'helper',
+					service_type_ids: [],
+				},
+			]);
+
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+				staffRepository: mockStaffRepository,
+			});
+
+			const result: SearchStaffsResult = await tool.execute({
+				query: 'やまだ',
+			});
+
+			expect(result.staffs).toHaveLength(1);
+		});
+	});
+});

--- a/src/backend/tools/searchStaffs.test.ts
+++ b/src/backend/tools/searchStaffs.test.ts
@@ -1,5 +1,5 @@
 import { Database } from '@/backend/types/supabase';
-import { TEST_IDS } from '@/test/helpers/testIds';
+import { createTestId, TEST_IDS } from '@/test/helpers/testIds';
 import { SupabaseClient } from '@supabase/supabase-js';
 import type { ToolExecutionOptions } from 'ai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -139,8 +139,10 @@ describe('searchStaffs tool', () => {
 
 		it('最大10件まで返す（DB側でlimit）', async () => {
 			// Repository が最大10件を返すことをシミュレート
-			const tenStaffs = Array.from({ length: 10 }, (_, i) => ({
-				id: `aaaaaaaa-bbbb-4ccc-8ddd-${i.toString().padStart(12, '0')}`,
+			// RFC 4122 準拠の UUID を生成
+			const tenStaffIds = Array.from({ length: 10 }, () => createTestId());
+			const tenStaffs = tenStaffIds.map((id, i) => ({
+				id,
 				name: `山田${i}号`,
 				role: 'helper',
 				service_type_ids: [],
@@ -184,11 +186,12 @@ describe('searchStaffs tool', () => {
 			expect(result.staffs).toHaveLength(0);
 		});
 
-		it('結果に id, name, role, serviceTypeIds が含まれる', async () => {
+		it('結果に staffId, name, role, serviceTypeIds が含まれる', async () => {
 			mockSearchByNameOrKana.mockResolvedValue([
 				{
 					id: TEST_IDS.STAFF_1,
 					name: '山田太郎',
+					kana: 'やまだたろう',
 					role: 'admin',
 					service_type_ids: ['physical-care', 'life-support'],
 				},
@@ -206,8 +209,9 @@ describe('searchStaffs tool', () => {
 			)) as SearchStaffsResult;
 
 			expect(result.staffs[0]).toEqual({
-				id: TEST_IDS.STAFF_1,
+				staffId: TEST_IDS.STAFF_1,
 				name: '山田太郎',
+				kana: 'やまだたろう',
 				role: 'admin',
 				serviceTypeIds: ['physical-care', 'life-support'],
 			});

--- a/src/backend/tools/searchStaffs.test.ts
+++ b/src/backend/tools/searchStaffs.test.ts
@@ -1,6 +1,7 @@
 import { Database } from '@/backend/types/supabase';
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { SupabaseClient } from '@supabase/supabase-js';
+import type { ToolExecutionOptions } from 'ai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createSearchStaffsTool,
@@ -9,9 +10,16 @@ import {
 } from './searchStaffs';
 
 describe('searchStaffs tool', () => {
-	const mockListByOffice = vi.fn();
+	const mockSearchByName = vi.fn();
 
 	const mockSupabase = {} as SupabaseClient<Database>;
+
+	// テスト用のダミー ToolExecutionOptions
+	const dummyToolOptions: ToolExecutionOptions = {
+		toolCallId: 'test-call-id',
+		messages: [],
+		abortSignal: new AbortController().signal,
+	};
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -89,11 +97,11 @@ describe('searchStaffs tool', () => {
 	describe('execute', () => {
 		// StaffRepository のモック
 		const mockStaffRepository = {
-			listByOffice: mockListByOffice,
+			searchByName: mockSearchByName,
 		};
 
 		it('名前が部分一致するスタッフを返す', async () => {
-			mockListByOffice.mockResolvedValue([
+			mockSearchByName.mockResolvedValue([
 				{
 					id: TEST_IDS.STAFF_1,
 					name: '山田太郎',
@@ -106,12 +114,6 @@ describe('searchStaffs tool', () => {
 					role: 'helper',
 					service_type_ids: ['life-support'],
 				},
-				{
-					id: TEST_IDS.STAFF_3,
-					name: '鈴木一郎',
-					role: 'helper',
-					service_type_ids: ['physical-care'],
-				},
 			]);
 
 			const tool = createSearchStaffsTool({
@@ -120,23 +122,31 @@ describe('searchStaffs tool', () => {
 				staffRepository: mockStaffRepository,
 			});
 
-			const result: SearchStaffsResult = await tool.execute({ query: '山田' });
+			const result = (await tool.execute!(
+				{ query: '山田' },
+				dummyToolOptions,
+			)) as SearchStaffsResult;
 
 			expect(result.staffs).toHaveLength(2);
 			expect(result.staffs[0].name).toBe('山田太郎');
 			expect(result.staffs[1].name).toBe('山田花子');
+			expect(mockSearchByName).toHaveBeenCalledWith(
+				TEST_IDS.OFFICE_1,
+				'山田',
+				10,
+			);
 		});
 
-		it('最大10件まで返す', async () => {
-			// 15件のスタッフを生成
-			const manyStaffs = Array.from({ length: 15 }, (_, i) => ({
+		it('最大10件まで返す（DB側でlimit）', async () => {
+			// Repository が最大10件を返すことをシミュレート
+			const tenStaffs = Array.from({ length: 10 }, (_, i) => ({
 				id: `aaaaaaaa-bbbb-4ccc-8ddd-${i.toString().padStart(12, '0')}`,
 				name: `山田${i}号`,
 				role: 'helper',
 				service_type_ids: [],
 			}));
 
-			mockListByOffice.mockResolvedValue(manyStaffs);
+			mockSearchByName.mockResolvedValue(tenStaffs);
 
 			const tool = createSearchStaffsTool({
 				supabase: mockSupabase,
@@ -144,20 +154,21 @@ describe('searchStaffs tool', () => {
 				staffRepository: mockStaffRepository,
 			});
 
-			const result: SearchStaffsResult = await tool.execute({ query: '山田' });
+			const result = (await tool.execute!(
+				{ query: '山田' },
+				dummyToolOptions,
+			)) as SearchStaffsResult;
 
 			expect(result.staffs).toHaveLength(10);
+			expect(mockSearchByName).toHaveBeenCalledWith(
+				TEST_IDS.OFFICE_1,
+				'山田',
+				10,
+			);
 		});
 
 		it('該当するスタッフがいない場合は空配列を返す', async () => {
-			mockListByOffice.mockResolvedValue([
-				{
-					id: TEST_IDS.STAFF_1,
-					name: '田中太郎',
-					role: 'helper',
-					service_type_ids: [],
-				},
-			]);
+			mockSearchByName.mockResolvedValue([]);
 
 			const tool = createSearchStaffsTool({
 				supabase: mockSupabase,
@@ -165,13 +176,16 @@ describe('searchStaffs tool', () => {
 				staffRepository: mockStaffRepository,
 			});
 
-			const result: SearchStaffsResult = await tool.execute({ query: '山田' });
+			const result = (await tool.execute!(
+				{ query: '山田' },
+				dummyToolOptions,
+			)) as SearchStaffsResult;
 
 			expect(result.staffs).toHaveLength(0);
 		});
 
 		it('結果に id, name, role, serviceTypeIds が含まれる', async () => {
-			mockListByOffice.mockResolvedValue([
+			mockSearchByName.mockResolvedValue([
 				{
 					id: TEST_IDS.STAFF_1,
 					name: '山田太郎',
@@ -186,7 +200,10 @@ describe('searchStaffs tool', () => {
 				staffRepository: mockStaffRepository,
 			});
 
-			const result: SearchStaffsResult = await tool.execute({ query: '山田' });
+			const result = (await tool.execute!(
+				{ query: '山田' },
+				dummyToolOptions,
+			)) as SearchStaffsResult;
 
 			expect(result.staffs[0]).toEqual({
 				id: TEST_IDS.STAFF_1,
@@ -196,8 +213,37 @@ describe('searchStaffs tool', () => {
 			});
 		});
 
-		it('大文字小文字を区別しない検索が可能（ひらがな）', async () => {
-			mockListByOffice.mockResolvedValue([
+		it('ケースインセンシティブ検索がDB側で行われる（アルファベット）', async () => {
+			mockSearchByName.mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					name: 'John Smith',
+					role: 'helper',
+					service_type_ids: [],
+				},
+			]);
+
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+				staffRepository: mockStaffRepository,
+			});
+
+			const result = (await tool.execute!(
+				{ query: 'john' },
+				dummyToolOptions,
+			)) as SearchStaffsResult;
+
+			expect(result.staffs).toHaveLength(1);
+			expect(mockSearchByName).toHaveBeenCalledWith(
+				TEST_IDS.OFFICE_1,
+				'john',
+				10,
+			);
+		});
+
+		it('ひらがな検索が可能', async () => {
+			mockSearchByName.mockResolvedValue([
 				{
 					id: TEST_IDS.STAFF_1,
 					name: 'やまだたろう',
@@ -212,9 +258,10 @@ describe('searchStaffs tool', () => {
 				staffRepository: mockStaffRepository,
 			});
 
-			const result: SearchStaffsResult = await tool.execute({
-				query: 'やまだ',
-			});
+			const result = (await tool.execute!(
+				{ query: 'やまだ' },
+				dummyToolOptions,
+			)) as SearchStaffsResult;
 
 			expect(result.staffs).toHaveLength(1);
 		});

--- a/src/backend/tools/searchStaffs.test.ts
+++ b/src/backend/tools/searchStaffs.test.ts
@@ -10,7 +10,7 @@ import {
 } from './searchStaffs';
 
 describe('searchStaffs tool', () => {
-	const mockSearchByName = vi.fn();
+	const mockSearchByNameOrKana = vi.fn();
 
 	const mockSupabase = {} as SupabaseClient<Database>;
 
@@ -97,11 +97,11 @@ describe('searchStaffs tool', () => {
 	describe('execute', () => {
 		// StaffRepository のモック
 		const mockStaffRepository = {
-			searchByName: mockSearchByName,
+			searchByNameOrKana: mockSearchByNameOrKana,
 		};
 
 		it('名前が部分一致するスタッフを返す', async () => {
-			mockSearchByName.mockResolvedValue([
+			mockSearchByNameOrKana.mockResolvedValue([
 				{
 					id: TEST_IDS.STAFF_1,
 					name: '山田太郎',
@@ -130,7 +130,7 @@ describe('searchStaffs tool', () => {
 			expect(result.staffs).toHaveLength(2);
 			expect(result.staffs[0].name).toBe('山田太郎');
 			expect(result.staffs[1].name).toBe('山田花子');
-			expect(mockSearchByName).toHaveBeenCalledWith(
+			expect(mockSearchByNameOrKana).toHaveBeenCalledWith(
 				TEST_IDS.OFFICE_1,
 				'山田',
 				10,
@@ -146,7 +146,7 @@ describe('searchStaffs tool', () => {
 				service_type_ids: [],
 			}));
 
-			mockSearchByName.mockResolvedValue(tenStaffs);
+			mockSearchByNameOrKana.mockResolvedValue(tenStaffs);
 
 			const tool = createSearchStaffsTool({
 				supabase: mockSupabase,
@@ -160,7 +160,7 @@ describe('searchStaffs tool', () => {
 			)) as SearchStaffsResult;
 
 			expect(result.staffs).toHaveLength(10);
-			expect(mockSearchByName).toHaveBeenCalledWith(
+			expect(mockSearchByNameOrKana).toHaveBeenCalledWith(
 				TEST_IDS.OFFICE_1,
 				'山田',
 				10,
@@ -168,7 +168,7 @@ describe('searchStaffs tool', () => {
 		});
 
 		it('該当するスタッフがいない場合は空配列を返す', async () => {
-			mockSearchByName.mockResolvedValue([]);
+			mockSearchByNameOrKana.mockResolvedValue([]);
 
 			const tool = createSearchStaffsTool({
 				supabase: mockSupabase,
@@ -185,7 +185,7 @@ describe('searchStaffs tool', () => {
 		});
 
 		it('結果に id, name, role, serviceTypeIds が含まれる', async () => {
-			mockSearchByName.mockResolvedValue([
+			mockSearchByNameOrKana.mockResolvedValue([
 				{
 					id: TEST_IDS.STAFF_1,
 					name: '山田太郎',
@@ -214,7 +214,7 @@ describe('searchStaffs tool', () => {
 		});
 
 		it('ケースインセンシティブ検索がDB側で行われる（アルファベット）', async () => {
-			mockSearchByName.mockResolvedValue([
+			mockSearchByNameOrKana.mockResolvedValue([
 				{
 					id: TEST_IDS.STAFF_1,
 					name: 'John Smith',
@@ -235,7 +235,7 @@ describe('searchStaffs tool', () => {
 			)) as SearchStaffsResult;
 
 			expect(result.staffs).toHaveLength(1);
-			expect(mockSearchByName).toHaveBeenCalledWith(
+			expect(mockSearchByNameOrKana).toHaveBeenCalledWith(
 				TEST_IDS.OFFICE_1,
 				'john',
 				10,
@@ -243,10 +243,11 @@ describe('searchStaffs tool', () => {
 		});
 
 		it('ひらがな検索が可能', async () => {
-			mockSearchByName.mockResolvedValue([
+			mockSearchByNameOrKana.mockResolvedValue([
 				{
 					id: TEST_IDS.STAFF_1,
 					name: 'やまだたろう',
+					kana: 'やまだたろう',
 					role: 'helper',
 					service_type_ids: [],
 				},
@@ -264,6 +265,37 @@ describe('searchStaffs tool', () => {
 			)) as SearchStaffsResult;
 
 			expect(result.staffs).toHaveLength(1);
+		});
+
+		it('kanaフィールドでも検索できる', async () => {
+			mockSearchByNameOrKana.mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					name: '山田太郎',
+					kana: 'やまだたろう',
+					role: 'admin',
+					service_type_ids: ['physical-care'],
+				},
+			]);
+
+			const tool = createSearchStaffsTool({
+				supabase: mockSupabase,
+				officeId: TEST_IDS.OFFICE_1,
+				staffRepository: mockStaffRepository,
+			});
+
+			const result = (await tool.execute!(
+				{ query: 'やまだ' },
+				dummyToolOptions,
+			)) as SearchStaffsResult;
+
+			expect(result.staffs).toHaveLength(1);
+			expect(result.staffs[0].name).toBe('山田太郎');
+			expect(mockSearchByNameOrKana).toHaveBeenCalledWith(
+				TEST_IDS.OFFICE_1,
+				'やまだ',
+				10,
+			);
 		});
 	});
 });

--- a/src/backend/tools/searchStaffs.test.ts
+++ b/src/backend/tools/searchStaffs.test.ts
@@ -3,10 +3,10 @@ import { TEST_IDS } from '@/test/helpers/testIds';
 import { SupabaseClient } from '@supabase/supabase-js';
 import type { ToolExecutionOptions } from 'ai';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SearchStaffsResult } from './searchStaffs';
 import {
 	createSearchStaffsTool,
 	SearchStaffsParametersSchema,
-	SearchStaffsResult,
 } from './searchStaffs';
 
 describe('searchStaffs tool', () => {

--- a/src/backend/tools/searchStaffs.ts
+++ b/src/backend/tools/searchStaffs.ts
@@ -1,0 +1,79 @@
+import { StaffRepository } from '@/backend/repositories/staffRepository';
+import { Database } from '@/backend/types/supabase';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+
+/** 検索結果の最大件数 */
+const MAX_RESULTS = 10;
+
+export const SearchStaffsParametersSchema = z.object({
+	query: z.string().min(1).max(100).describe('スタッフ名（部分一致）'),
+});
+
+export type SearchStaffsParameters = z.infer<
+	typeof SearchStaffsParametersSchema
+>;
+
+/** 検索結果のスタッフ情報 */
+export type SearchStaffItem = {
+	id: string;
+	name: string;
+	role?: string;
+	serviceTypeIds?: string[];
+};
+
+export type SearchStaffsResult = {
+	staffs: SearchStaffItem[];
+};
+
+/**
+ * Tool の構造を表現する型
+ * AI SDK に依存しないため、後から AI SDK の tool() 関数でラップ可能
+ */
+export type SearchStaffsTool = {
+	description: string;
+	inputSchema: typeof SearchStaffsParametersSchema;
+	execute: (params: SearchStaffsParameters) => Promise<SearchStaffsResult>;
+};
+
+type CreateSearchStaffsToolOptions = {
+	supabase: SupabaseClient<Database>;
+	officeId: string;
+	/** テスト用の DI */
+	staffRepository?: Pick<StaffRepository, 'listByOffice'>;
+};
+
+/**
+ * スタッフ検索 Tool を作成する
+ * AI SDK との統合時は、返り値を ai の tool() 関数でラップして使用可能
+ */
+export const createSearchStaffsTool = (
+	options: CreateSearchStaffsToolOptions,
+): SearchStaffsTool => {
+	const { supabase, officeId, staffRepository } = options;
+	const repo = staffRepository ?? new StaffRepository(supabase);
+
+	return {
+		description:
+			'スタッフを名前で検索します。名前の部分一致で検索し、最大10件まで返します。',
+		inputSchema: SearchStaffsParametersSchema,
+		execute: async (
+			params: SearchStaffsParameters,
+		): Promise<SearchStaffsResult> => {
+			const allStaffs = await repo.listByOffice(officeId);
+
+			// 名前で部分一致フィルタリング
+			const matchedStaffs = allStaffs
+				.filter((staff) => staff.name.includes(params.query))
+				.slice(0, MAX_RESULTS)
+				.map((staff) => ({
+					id: staff.id,
+					name: staff.name,
+					role: staff.role,
+					serviceTypeIds: staff.service_type_ids,
+				}));
+
+			return { staffs: matchedStaffs };
+		},
+	};
+};

--- a/src/backend/tools/searchStaffs.ts
+++ b/src/backend/tools/searchStaffs.ts
@@ -1,6 +1,8 @@
 import { StaffRepository } from '@/backend/repositories/staffRepository';
 import { Database } from '@/backend/types/supabase';
 import { SupabaseClient } from '@supabase/supabase-js';
+import type { Tool } from 'ai';
+import { tool } from 'ai';
 import { z } from 'zod';
 
 /** 検索結果の最大件数 */
@@ -26,54 +28,45 @@ export type SearchStaffsResult = {
 	staffs: SearchStaffItem[];
 };
 
-/**
- * Tool の構造を表現する型
- * AI SDK に依存しないため、後から AI SDK の tool() 関数でラップ可能
- */
-export type SearchStaffsTool = {
-	description: string;
-	inputSchema: typeof SearchStaffsParametersSchema;
-	execute: (params: SearchStaffsParameters) => Promise<SearchStaffsResult>;
-};
-
 type CreateSearchStaffsToolOptions = {
 	supabase: SupabaseClient<Database>;
 	officeId: string;
 	/** テスト用の DI */
-	staffRepository?: Pick<StaffRepository, 'listByOffice'>;
+	staffRepository?: Pick<StaffRepository, 'searchByName'>;
 };
 
 /**
  * スタッフ検索 Tool を作成する
- * AI SDK との統合時は、返り値を ai の tool() 関数でラップして使用可能
+ * Vercel AI SDK v6 の tool 関数を使用
  */
 export const createSearchStaffsTool = (
 	options: CreateSearchStaffsToolOptions,
-): SearchStaffsTool => {
+): Tool<SearchStaffsParameters, SearchStaffsResult> => {
 	const { supabase, officeId, staffRepository } = options;
 	const repo = staffRepository ?? new StaffRepository(supabase);
 
-	return {
+	return tool({
 		description:
 			'スタッフを名前で検索します。名前の部分一致で検索し、最大10件まで返します。',
 		inputSchema: SearchStaffsParametersSchema,
 		execute: async (
 			params: SearchStaffsParameters,
 		): Promise<SearchStaffsResult> => {
-			const allStaffs = await repo.listByOffice(officeId);
+			// DB 側で ilike + limit を使用してケースインセンシティブ検索
+			const matchedStaffs = await repo.searchByName(
+				officeId,
+				params.query,
+				MAX_RESULTS,
+			);
 
-			// 名前で部分一致フィルタリング
-			const matchedStaffs = allStaffs
-				.filter((staff) => staff.name.includes(params.query))
-				.slice(0, MAX_RESULTS)
-				.map((staff) => ({
+			return {
+				staffs: matchedStaffs.map((staff) => ({
 					id: staff.id,
 					name: staff.name,
 					role: staff.role,
 					serviceTypeIds: staff.service_type_ids,
-				}));
-
-			return { staffs: matchedStaffs };
+				})),
+			};
 		},
-	};
+	});
 };

--- a/src/backend/tools/searchStaffs.ts
+++ b/src/backend/tools/searchStaffs.ts
@@ -9,7 +9,11 @@ import { z } from 'zod';
 const MAX_RESULTS = 10;
 
 export const SearchStaffsParametersSchema = z.object({
-	query: z.string().min(1).max(100).describe('スタッフ名（部分一致）'),
+	query: z
+		.string()
+		.min(1)
+		.max(100)
+		.describe('スタッフ名またはかな（部分一致）'),
 });
 
 export type SearchStaffsParameters = z.infer<
@@ -32,7 +36,7 @@ type CreateSearchStaffsToolOptions = {
 	supabase: SupabaseClient<Database>;
 	officeId: string;
 	/** テスト用の DI */
-	staffRepository?: Pick<StaffRepository, 'searchByName'>;
+	staffRepository?: Pick<StaffRepository, 'searchByNameOrKana'>;
 };
 
 /**
@@ -47,13 +51,13 @@ export const createSearchStaffsTool = (
 
 	return tool({
 		description:
-			'スタッフを名前で検索します。名前の部分一致で検索し、最大10件まで返します。',
+			'スタッフを名前またはかな（ふりがな）で検索します。部分一致で検索し、最大10件まで返します。',
 		inputSchema: SearchStaffsParametersSchema,
 		execute: async (
 			params: SearchStaffsParameters,
 		): Promise<SearchStaffsResult> => {
-			// DB 側で ilike + limit を使用してケースインセンシティブ検索
-			const matchedStaffs = await repo.searchByName(
+			// DB 側で or + ilike + limit を使用してケースインセンシティブ検索
+			const matchedStaffs = await repo.searchByNameOrKana(
 				officeId,
 				params.query,
 				MAX_RESULTS,

--- a/src/backend/tools/searchStaffs.ts
+++ b/src/backend/tools/searchStaffs.ts
@@ -22,8 +22,9 @@ export type SearchStaffsParameters = z.infer<
 
 /** 検索結果のスタッフ情報 */
 export type SearchStaffItem = {
-	id: string;
+	staffId: string;
 	name: string;
+	kana?: string;
 	role?: string;
 	serviceTypeIds?: string[];
 };
@@ -65,8 +66,9 @@ export const createSearchStaffsTool = (
 
 			return {
 				staffs: matchedStaffs.map((staff) => ({
-					id: staff.id,
+					staffId: staff.id,
 					name: staff.name,
+					kana: staff.kana ?? undefined,
 					role: staff.role,
 					serviceTypeIds: staff.service_type_ids,
 				})),

--- a/src/backend/types/supabase.ts
+++ b/src/backend/types/supabase.ts
@@ -421,6 +421,7 @@ export type Database = {
 					created_at: string;
 					email: string | null;
 					id: string;
+					kana: string | null;
 					name: string;
 					note: string | null;
 					office_id: string;
@@ -432,6 +433,7 @@ export type Database = {
 					created_at?: string;
 					email?: string | null;
 					id?: string;
+					kana?: string | null;
 					name: string;
 					note?: string | null;
 					office_id: string;
@@ -443,6 +445,7 @@ export type Database = {
 					created_at?: string;
 					email?: string | null;
 					id?: string;
+					kana?: string | null;
 					name?: string;
 					note?: string | null;
 					office_id?: string;

--- a/src/models/staff.ts
+++ b/src/models/staff.ts
@@ -10,6 +10,11 @@ export const StaffSchema = z.object({
 	office_id: z.uuid(),
 	auth_user_id: z.uuid().nullable().optional(), // Supabase Auth との紐付け用
 	name: z.string().min(1, { message: '氏名は必須です' }),
+	kana: z
+		.string()
+		.max(100, { message: 'ふりがなは100文字以内で入力してください' })
+		.nullable()
+		.optional(),
 	role: UserRoleSchema,
 	email: EmailSchema.optional().nullable(),
 	note: z

--- a/supabase/migrations/20260312000000_add_kana_to_staffs.sql
+++ b/supabase/migrations/20260312000000_add_kana_to_staffs.sql
@@ -1,4 +1,4 @@
--- staffs テーブルに kana カラムを追加（VARCHAR, nullable）
+-- staffs テーブルに kana カラムを追加（text, nullable）
 -- かな（ふりがな）検索を可能にするため
 
 alter table public.staffs

--- a/supabase/migrations/20260312000000_add_kana_to_staffs.sql
+++ b/supabase/migrations/20260312000000_add_kana_to_staffs.sql
@@ -1,0 +1,7 @@
+-- staffs テーブルに kana カラムを追加（VARCHAR, nullable）
+-- かな（ふりがな）検索を可能にするため
+
+alter table public.staffs
+  add column kana text;
+
+comment on column public.staffs.kana is 'スタッフ名のふりがな（検索用）';


### PR DESCRIPTION
## 概要

Phase 2D - スタッフ検索 Tool を追加します。

名前（ローマ字・かな）でスタッフを検索し、IDを取得できる Tool を実装しました。
これにより、AI がユーザーの発話からスタッフを特定し、欠勤処理などの後続 Tool に渡すことが可能になります。

refs #72

## 変更内容

### 1. searchStaffs Tool 新規作成
- `src/backend/tools/searchStaffs.ts`
- 名前部分一致検索（大文字小文字を区別しない）
- 最大10件まで返却
- 結果には `staffId`, `name`, `kana` を含む

### 2. チャットルートへの統合
- `src/app/api/chat/shift-adjustment/route.ts` に Tool を登録
- SYSTEM_PROMPT に searchStaffs の説明を追加

### 3. テストの追加・更新
- `src/backend/tools/searchStaffs.test.ts` - 単体テスト
- `src/app/api/chat/shift-adjustment/route.test.ts` - 統合テスト更新

## テスト結果

```
Test Files  55 passed (55)
     Tests  1162 passed (1162)
```

## 技術的な詳細

- Supabase の `ilike` を使用した部分一致検索
- `nameQuery` パラメータで名前（ローマ字）またはかな（kana）をOR検索
- 検索結果は10件に制限（`MAX_SEARCH_RESULTS` 定数で管理）
