### PR TITLE
feat: staffs kana の保存/更新経路を実装（スタッフ作成/編集） #101

### DIFF
--- a/docs/issues/issue-72-kana-save-update-path.md
+++ b/docs/issues/issue-72-kana-save-update-path.md
@@ -1,0 +1,78 @@
+# [Draft] staffs: kana の保存/更新経路を実装（スタッフ作成/編集）
+
+refs: #72
+related PR: #100 (merged)
+
+## 背景 / 問題
+
+- `staffs` テーブルに `kana` カラムは追加済み（migration: `supabase/migrations/20260312000000_add_kana_to_staffs.sql`）
+- `StaffSchema` でも `kana` は追加済み（`src/models/staff.ts`）
+- `searchStaffs` Tool は `name/kana` の検索に対応済み（#100）
+
+一方で、スタッフ作成/編集（UI → Action → Service → Repository → DB）で `kana` を保存・更新する経路が未実装のため、実運用では `kana` が常に `null` になりやすく、`kana` 検索の実効性が担保できていません（#100 review thread: `staff.ts:17`）。
+
+## 目的
+
+- スタッフ作成時に `kana` を入力して保存できる
+- スタッフ編集時に `kana` を更新できる
+- バリデーション/Action/Repository/UI が一貫した契約になる
+
+## スコープ（今回やる）
+
+- 管理画面のスタッフ作成/編集フォームに `kana` 入力欄を追加する
+- `createStaffAction` / `updateStaffAction` で `kana` を受け取り、Service/Repository を通して DB に保存する
+- 既存 `kana` があるスタッフを編集フォームに表示し、更新できる
+- 入力値の正規化（trim、空文字→null）を他フィールドと同様に揃える
+- ユニット/コンポーネントテスト（最低限）を追加・更新する
+
+## スコープ外（今回やらない）
+
+- スタッフ一覧テーブル/検索欄に `kana` の表示・フロント側フィルタを追加（必要なら別Issue）
+- `kana` の自動生成（名前→かな変換）や、ひらがな/カタカナの正規化
+- 既存データの一括移行・埋め戻し（バックフィル）
+
+## 受け入れ基準 (Acceptance Criteria)
+
+- [ ] スタッフ作成モーダルに `ふりがな (kana)` 入力欄があり、入力して登録すると `staffs.kana` に保存される
+- [ ] スタッフ編集モーダルに `ふりがな (kana)` が初期表示され、更新して保存すると `staffs.kana` が更新される
+- [ ] `kana` は任意入力であり、未入力/空文字は `null` として保存される
+- [ ] `kana` の最大長などのバリデーションが `StaffSchema` と矛盾しない（例: `max(100)`）
+- [ ] `createStaffAction` / `updateStaffAction` の入力スキーマと `StaffService` / `StaffRepository` の payload が `kana` を含む
+- [ ] テストが追加/更新され、少なくとも create/update の payload に `kana` が含まれることを担保できる
+
+## 影響範囲（変更が入りそうな箇所）
+
+### フロント/UI
+
+- `src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.tsx`
+  - フォーム項目追加（`kana`）
+  - edit の defaultValues に `kana` を含める
+
+### Action / Schema
+
+- `src/models/staffActionSchemas.ts`
+  - `StaffInputSchema` に `kana` を追加（optional/nullable, max 100）
+- `src/app/actions/staffs.ts`
+  - `createStaffAction` / `updateStaffAction` の `StaffInputSchema` バリデーションに `kana` が含まれるようにする
+
+### Service / Repository
+
+- `src/backend/services/staffService.ts`
+  - `create` / `update` の repository 呼び出し payload に `kana` を追加
+- `src/backend/repositories/staffRepository.ts`
+  - `StaffCreateParams` / `StaffUpdateParams` に `kana` を追加
+  - `create` の insert payload に `kana`
+  - `buildUpdatePayload` に `kana`
+
+### テスト
+
+- `src/backend/repositories/staffRepository.test.ts`（create/update の payload アサーション）
+- `src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.test.tsx`（フォーム送信値に `kana` が含まれること）
+  - 既存のテスト状況により追加先は調整
+
+## 実装メモ（plan agent向け）
+
+- `kana` の扱いは email/note と同様に「空文字 → null」へ寄せるのが自然
+  - 例: `StaffFormSchema` の transform で `kana` を trim し、空なら `null`
+- 既存の `StaffRecord` には `kana` が含まれるため、UI の edit 初期値へ流し込むだけで表示は可能
+- 既存 `searchStaffs` が `kana` を検索対象にしているため、データ投入経路ができれば検索の品質が上がる

--- a/src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.test.tsx
+++ b/src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.test.tsx
@@ -1,5 +1,6 @@
 import { createStaffAction, updateStaffAction } from '@/app/actions/staffs';
 import type { StaffRecord } from '@/models/staffActionSchemas';
+import { TEST_IDS } from '@/test/helpers/testIds';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -24,10 +25,11 @@ const serviceTypes: ServiceTypeOption[] = [
 ];
 
 const sampleStaff: StaffRecord = {
-	id: 'staff-1',
-	office_id: 'office-1',
+	id: TEST_IDS.STAFF_1,
+	office_id: TEST_IDS.OFFICE_1,
 	auth_user_id: null,
 	name: '山田太郎',
+	kana: 'やまだたろう',
 	role: 'helper',
 	email: 'yamada@example.com',
 	note: 'メモ',
@@ -67,6 +69,7 @@ describe('StaffFormModal', () => {
 		expect(screen.getByText('担当者を追加')).toBeInTheDocument();
 		expect(screen.getByLabelText('氏名 *')).toHaveValue('');
 		expect(screen.getByLabelText('メールアドレス')).toHaveValue('');
+		expect(screen.getByLabelText('ふりがな')).toHaveValue('');
 		expect(screen.getByLabelText('備考 (最大500文字)')).toHaveValue('');
 	});
 
@@ -83,6 +86,7 @@ describe('StaffFormModal', () => {
 
 		expect(screen.getByDisplayValue('山田太郎')).toBeInTheDocument();
 		expect(screen.getByDisplayValue('yamada@example.com')).toBeInTheDocument();
+		expect(screen.getByDisplayValue('やまだたろう')).toBeInTheDocument();
 		expect(screen.getByLabelText('身体介護')).toBeChecked();
 	});
 
@@ -105,6 +109,7 @@ describe('StaffFormModal', () => {
 		);
 
 		await user.type(screen.getByLabelText('氏名 *'), '佐藤花子');
+		await user.type(screen.getByLabelText('ふりがな'), 'さとうはなこ');
 		await user.type(
 			screen.getByLabelText('メールアドレス'),
 			'hanako@example.com',
@@ -118,6 +123,7 @@ describe('StaffFormModal', () => {
 		await waitFor(() => {
 			expect(createStaffAction).toHaveBeenCalledWith({
 				name: '佐藤花子',
+				kana: 'さとうはなこ',
 				email: 'hanako@example.com',
 				role: 'helper',
 				note: 'テスト備考',
@@ -128,6 +134,33 @@ describe('StaffFormModal', () => {
 		expect(handleSuccess).toHaveBeenCalledWith(sampleStaff);
 		expect(handleClose).toHaveBeenCalled();
 		expect(handleActionResultMock).toHaveBeenCalled();
+	});
+
+	it('作成モードで kana を未入力のまま送信すると kana: null になる', async () => {
+		const user = userEvent.setup();
+		vi.mocked(createStaffAction).mockResolvedValue(
+			successResult(sampleStaff, 201),
+		);
+
+		render(
+			<StaffFormModal
+				isOpen
+				mode="create"
+				serviceTypes={serviceTypes}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		await user.type(screen.getByLabelText('氏名 *'), '佐藤花子');
+		// ふりがなは空のまま送信
+
+		await user.click(screen.getByRole('button', { name: '登録' }));
+
+		await waitFor(() => {
+			expect(createStaffAction).toHaveBeenCalledWith(
+				expect.objectContaining({ kana: null }),
+			);
+		});
 	});
 
 	it('編集モードで更新するとupdateStaffActionが呼ばれる', async () => {
@@ -150,8 +183,9 @@ describe('StaffFormModal', () => {
 		await user.click(screen.getByRole('button', { name: '保存' }));
 
 		await waitFor(() => {
-			expect(updateStaffAction).toHaveBeenCalledWith('staff-1', {
+			expect(updateStaffAction).toHaveBeenCalledWith(TEST_IDS.STAFF_1, {
 				name: '山田次郎',
+				kana: 'やまだたろう',
 				email: 'yamada@example.com',
 				role: 'helper',
 				note: 'メモ',
@@ -161,6 +195,33 @@ describe('StaffFormModal', () => {
 
 		expect(handleClose).toHaveBeenCalled();
 		expect(handleActionResultMock).toHaveBeenCalled();
+	});
+
+	it('編集モードで kana を編集して保存できる', async () => {
+		const user = userEvent.setup();
+		vi.mocked(updateStaffAction).mockResolvedValue(successResult(sampleStaff));
+
+		render(
+			<StaffFormModal
+				isOpen
+				mode="edit"
+				staff={sampleStaff}
+				serviceTypes={serviceTypes}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		const kanaInput = screen.getByLabelText('ふりがな');
+		await user.clear(kanaInput);
+		await user.type(kanaInput, 'やまだじろう');
+		await user.click(screen.getByRole('button', { name: '保存' }));
+
+		await waitFor(() => {
+			expect(updateStaffAction).toHaveBeenCalledWith(
+				TEST_IDS.STAFF_1,
+				expect.objectContaining({ kana: 'やまだじろう' }),
+			);
+		});
 	});
 
 	it('API エラー時にエラーメッセージを表示する', async () => {

--- a/src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.tsx
+++ b/src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.tsx
@@ -14,20 +14,21 @@ import { z } from 'zod';
 import type { ServiceTypeOption } from '../../_types';
 import { ServiceTypeSelector } from '../ServiceTypeSelector';
 
+const normalizeStringToNull = (
+	value: string | null | undefined,
+): string | null =>
+	typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+
 const StaffFormSchema = StaffInputSchema.extend({
+	kana: StaffInputSchema.shape.kana.or(z.literal('')),
 	email: StaffInputSchema.shape.email.or(z.literal('')),
 	note: StaffInputSchema.shape.note.or(z.literal('')),
 	service_type_ids: z.array(ServiceTypeIdSchema).default([]),
 }).transform((value) => ({
 	...value,
-	email:
-		typeof value.email === 'string' && value.email.trim() === ''
-			? null
-			: (value.email ?? null),
-	note:
-		typeof value.note === 'string' && value.note.trim().length === 0
-			? null
-			: (value.note?.trim() ?? null),
+	kana: normalizeStringToNull(value.kana),
+	email: normalizeStringToNull(value.email),
+	note: normalizeStringToNull(value.note),
 	service_type_ids: value.service_type_ids ?? [],
 }));
 
@@ -56,6 +57,7 @@ const buildDefaultValues = (props: StaffFormModalProps): StaffFormValues => {
 	if (props.mode === 'edit') {
 		return {
 			name: props.staff.name,
+			kana: props.staff.kana ?? '',
 			email: props.staff.email ?? '',
 			role: props.staff.role,
 			note: props.staff.note ?? '',
@@ -64,6 +66,7 @@ const buildDefaultValues = (props: StaffFormModalProps): StaffFormValues => {
 	}
 	return {
 		name: '',
+		kana: '',
 		email: '',
 		role: 'helper',
 		note: '',
@@ -143,6 +146,13 @@ export const StaffFormModal = (props: StaffFormModalProps) => {
 						label="氏名"
 						required
 						disabled={isSubmitting}
+					/>
+					<FormInput
+						control={control}
+						name="kana"
+						label="ふりがな"
+						disabled={isSubmitting}
+						placeholder="やまだたろう"
 					/>
 					<FormInput
 						control={control}

--- a/src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.tsx
+++ b/src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.tsx
@@ -20,9 +20,9 @@ const normalizeStringToNull = (
 	typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
 
 const StaffFormSchema = StaffInputSchema.extend({
-	kana: StaffInputSchema.shape.kana.or(z.literal('')),
+	kana: StaffInputSchema.shape.kana,
 	email: StaffInputSchema.shape.email.or(z.literal('')),
-	note: StaffInputSchema.shape.note.or(z.literal('')),
+	note: StaffInputSchema.shape.note,
 	service_type_ids: z.array(ServiceTypeIdSchema).default([]),
 }).transform((value) => ({
 	...value,

--- a/src/backend/repositories/staffRepository.test.ts
+++ b/src/backend/repositories/staffRepository.test.ts
@@ -1,4 +1,5 @@
 import type { Database } from '@/backend/types/supabase';
+import { TEST_IDS } from '@/test/helpers/testIds';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { StaffRepository } from './staffRepository';
@@ -6,14 +7,14 @@ import { StaffRepository } from './staffRepository';
 describe('StaffRepository', () => {
 	let supabase: SupabaseClient<Database>;
 	let repository: StaffRepository;
-	const officeId = '019b179f-c74d-75ef-a328-55a8f65a0d8a';
+	const officeId = TEST_IDS.OFFICE_1;
 	const serviceTypeIds = {
 		one: 'physical-care',
 		two: 'life-support',
 		three: 'commute-support',
 	};
 	const baseStaffRow = {
-		id: '019b1aaf-0000-4000-8000-000000000001',
+		id: TEST_IDS.STAFF_1,
 		office_id: officeId,
 		name: '管理者A',
 		kana: null as string | null,
@@ -39,7 +40,7 @@ describe('StaffRepository', () => {
 				baseStaffRow,
 				{
 					...baseStaffRow,
-					id: '019b1aaf-0000-4000-8000-000000000002',
+					id: TEST_IDS.STAFF_2,
 					name: 'ヘルパーB',
 					role: 'helper' as const,
 					email: 'helper@example.com',
@@ -161,7 +162,7 @@ describe('StaffRepository', () => {
 		it('スタッフを作成しサービス区分を設定できる', async () => {
 			const insertRow = {
 				...baseStaffRow,
-				id: '019b1aaf-0000-4000-8000-000000000099',
+				id: TEST_IDS.STAFF_4,
 				kana: 'しんきすたっふ',
 				note: 'メモ',
 			};
@@ -228,7 +229,7 @@ describe('StaffRepository', () => {
 		it('kanaがnullの場合はnullとして保存される', async () => {
 			const insertRow = {
 				...baseStaffRow,
-				id: '019b1aaf-0000-4000-8000-000000000099',
+				id: TEST_IDS.STAFF_4,
 				kana: null,
 			};
 			const mockInsert = vi.fn().mockReturnThis();
@@ -410,7 +411,7 @@ describe('StaffRepository', () => {
 				{ ...baseStaffRow, kana: 'かんりしゃえー' },
 				{
 					...baseStaffRow,
-					id: '019b1aaf-0000-4000-8000-000000000002',
+					id: TEST_IDS.STAFF_2,
 					name: '山田花子',
 					kana: 'やまだはなこ',
 					role: 'helper' as const,
@@ -464,7 +465,7 @@ describe('StaffRepository', () => {
 			const staffRows = [
 				{
 					...baseStaffRow,
-					id: '019b1aaf-0000-4000-8000-000000000003',
+					id: TEST_IDS.STAFF_3,
 					name: '田中太郎',
 					kana: 'たなかたろう',
 					role: 'helper' as const,

--- a/src/backend/repositories/staffRepository.test.ts
+++ b/src/backend/repositories/staffRepository.test.ts
@@ -162,6 +162,7 @@ describe('StaffRepository', () => {
 			const insertRow = {
 				...baseStaffRow,
 				id: '019b1aaf-0000-4000-8000-000000000099',
+				kana: 'しんきすたっふ',
 				note: 'メモ',
 			};
 			const mockInsert = vi.fn().mockReturnThis();
@@ -194,6 +195,7 @@ describe('StaffRepository', () => {
 			const input = {
 				office_id: officeId,
 				name: '新規スタッフ',
+				kana: 'しんきすたっふ',
 				role: 'helper' as const,
 				email: 'new@example.com',
 				note: 'メモ',
@@ -205,6 +207,7 @@ describe('StaffRepository', () => {
 			expect(mockInsert).toHaveBeenCalledWith({
 				office_id: input.office_id,
 				name: input.name,
+				kana: input.kana,
 				role: input.role,
 				email: input.email,
 				note: input.note,
@@ -221,6 +224,56 @@ describe('StaffRepository', () => {
 				serviceTypeIds.two,
 			]);
 		});
+
+		it('kanaがnullの場合はnullとして保存される', async () => {
+			const insertRow = {
+				...baseStaffRow,
+				id: '019b1aaf-0000-4000-8000-000000000099',
+				kana: null,
+			};
+			const mockInsert = vi.fn().mockReturnThis();
+			const mockSelect = vi.fn().mockReturnThis();
+			const mockSingle = vi
+				.fn()
+				.mockResolvedValue({ data: insertRow, error: null });
+
+			const mockAbilityDelete = vi.fn().mockReturnThis();
+			const mockAbilityEq = vi.fn().mockResolvedValue({ error: null });
+			const mockAbilityInsert = vi.fn().mockResolvedValue({ error: null });
+
+			(supabase.from as any).mockImplementation((table: string) => {
+				if (table === 'staffs') {
+					return { insert: mockInsert };
+				}
+				if (table === 'staff_service_type_abilities') {
+					return {
+						delete: mockAbilityDelete,
+						insert: mockAbilityInsert,
+					};
+				}
+				throw new Error(`Unexpected table: ${table}`);
+			});
+
+			mockInsert.mockReturnValue({ select: mockSelect });
+			mockSelect.mockReturnValue({ single: mockSingle });
+			mockAbilityDelete.mockReturnValue({ eq: mockAbilityEq });
+
+			const input = {
+				office_id: officeId,
+				name: '新規スタッフ',
+				kana: null,
+				role: 'helper' as const,
+				email: null,
+				note: null,
+				service_type_ids: [],
+			};
+
+			await repository.create(input);
+
+			expect(mockInsert).toHaveBeenCalledWith(
+				expect.objectContaining({ kana: null }),
+			);
+		});
 	});
 
 	describe('update', () => {
@@ -228,6 +281,7 @@ describe('StaffRepository', () => {
 			const updatedRow = {
 				...baseStaffRow,
 				name: '更新後スタッフ',
+				kana: 'こうしんごすたっふ',
 				email: 'updated@example.com',
 				note: '更新されたメモ',
 			};
@@ -263,6 +317,7 @@ describe('StaffRepository', () => {
 
 			const result = await repository.update(baseStaffRow.id, {
 				name: '更新後スタッフ',
+				kana: 'こうしんごすたっふ',
 				email: 'updated@example.com',
 				note: '更新されたメモ',
 				service_type_ids: [serviceTypeIds.three],
@@ -270,6 +325,7 @@ describe('StaffRepository', () => {
 
 			expect(mockUpdate).toHaveBeenCalledWith({
 				name: '更新後スタッフ',
+				kana: 'こうしんごすたっふ',
 				email: 'updated@example.com',
 				note: '更新されたメモ',
 			});
@@ -278,6 +334,52 @@ describe('StaffRepository', () => {
 			]);
 			expect(result.name).toBe('更新後スタッフ');
 			expect(result.service_type_ids).toEqual([serviceTypeIds.three]);
+		});
+
+		it('kanaがnullの場合はnullとして更新される', async () => {
+			const updatedRow = {
+				...baseStaffRow,
+				kana: null,
+			};
+
+			const mockUpdate = vi.fn().mockReturnThis();
+			const mockEq = vi.fn().mockReturnThis();
+			const mockSelect = vi.fn().mockReturnThis();
+			const mockSingle = vi
+				.fn()
+				.mockResolvedValue({ data: updatedRow, error: null });
+
+			const mockAbilityDelete = vi.fn().mockReturnThis();
+			const mockAbilityEq = vi.fn().mockResolvedValue({ error: null });
+			const mockAbilityInsert = vi.fn().mockResolvedValue({ error: null });
+
+			(supabase.from as any).mockImplementation((table: string) => {
+				if (table === 'staffs') {
+					return { update: mockUpdate };
+				}
+				if (table === 'staff_service_type_abilities') {
+					return {
+						delete: mockAbilityDelete,
+						insert: mockAbilityInsert,
+					};
+				}
+				throw new Error(`Unexpected table: ${table}`);
+			});
+
+			mockUpdate.mockReturnValue({ eq: mockEq });
+			mockEq.mockReturnValue({ select: mockSelect });
+			mockSelect.mockReturnValue({ single: mockSingle });
+			mockAbilityDelete.mockReturnValue({ eq: mockAbilityEq });
+
+			await repository.update(baseStaffRow.id, {
+				name: '管理者A',
+				kana: null,
+				service_type_ids: [],
+			});
+
+			expect(mockUpdate).toHaveBeenCalledWith(
+				expect.objectContaining({ kana: null }),
+			);
 		});
 	});
 

--- a/src/backend/repositories/staffRepository.ts
+++ b/src/backend/repositories/staffRepository.ts
@@ -16,6 +16,7 @@ type StaffUpdate = Database['public']['Tables']['staffs']['Update'];
 type StaffCreateParams = {
 	office_id: string;
 	name: string;
+	kana?: string | null;
 	role: UserRole;
 	email?: string | null;
 	note?: string | null;
@@ -24,6 +25,7 @@ type StaffCreateParams = {
 
 type StaffUpdateParams = {
 	name?: string;
+	kana?: string | null;
 	role?: UserRole;
 	email?: string | null;
 	note?: string | null;
@@ -94,6 +96,7 @@ export class StaffRepository {
 	private buildUpdatePayload(input: StaffUpdateParams): StaffUpdate {
 		const payload: StaffUpdate = {};
 		if (typeof input.name !== 'undefined') payload.name = input.name;
+		if (typeof input.kana !== 'undefined') payload.kana = input.kana ?? null;
 		if (typeof input.role !== 'undefined') payload.role = input.role;
 		if (typeof input.email !== 'undefined') payload.email = input.email ?? null;
 		if (typeof input.note !== 'undefined') payload.note = input.note ?? null;
@@ -143,6 +146,7 @@ export class StaffRepository {
 		const payload: StaffInsert = {
 			office_id: input.office_id,
 			name: input.name,
+			kana: input.kana ?? null,
 			role: input.role,
 			email: input.email ?? null,
 			note: input.note ?? null,

--- a/src/backend/services/staffService.test.ts
+++ b/src/backend/services/staffService.test.ts
@@ -81,6 +81,16 @@ describe('StaffService', () => {
 			service_type_ids: [ids.svc1],
 		};
 
+		const setupServiceTypesMock = (serviceIds: string[]) => {
+			const inMock = vi.fn().mockResolvedValue({
+				data: serviceIds.map((id) => ({ id })),
+				error: null,
+			});
+			const selectMock = vi.fn().mockReturnValue({ in: inMock });
+			const fromMock = supabase.from as ReturnType<typeof vi.fn>;
+			fromMock.mockReturnValue({ select: selectMock } as any);
+		};
+
 		it('バリデーションに成功すると作成', async () => {
 			const inMock = vi.fn().mockResolvedValue({
 				data: [{ id: ids.svc1 }],
@@ -130,6 +140,32 @@ describe('StaffService', () => {
 			expect(selectAllMock).toHaveBeenCalledWith('id');
 			expect(inMock).toHaveBeenCalledWith('id', defaultIds);
 		});
+
+		it('kana あり → repository.create に kana が渡される', async () => {
+			setupServiceTypesMock([ids.svc1]);
+			(staffRepository.create as any).mockResolvedValue(
+				mockStaff({ service_type_ids: [ids.svc1] }),
+			);
+
+			await service.create(ids.auth, { ...input, kana: 'てすとかな' });
+
+			expect(staffRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({ kana: 'てすとかな' }),
+			);
+		});
+
+		it('kana 空文字 → repository.create に kana: null が渡される', async () => {
+			setupServiceTypesMock([ids.svc1]);
+			(staffRepository.create as any).mockResolvedValue(
+				mockStaff({ service_type_ids: [ids.svc1] }),
+			);
+
+			await service.create(ids.auth, { ...input, kana: '' });
+
+			expect(staffRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({ kana: null }),
+			);
+		});
 	});
 
 	describe('update', () => {
@@ -164,6 +200,62 @@ describe('StaffService', () => {
 			const result = await service.update(ids.auth, ids.staffOther, input);
 			expect(result.service_type_ids).toEqual([ids.svc2]);
 			expect(staffRepository.update).toHaveBeenCalled();
+		});
+
+		it('kana あり → repository.update に kana が渡される', async () => {
+			const inMock = vi.fn().mockResolvedValue({
+				data: [{ id: ids.svc2 }],
+				error: null,
+			});
+			const fromMock = supabase.from as ReturnType<typeof vi.fn>;
+			fromMock.mockReturnValue({
+				select: () => ({ in: inMock }),
+			} as any);
+
+			(staffRepository.findWithServiceTypesById as any).mockResolvedValue(
+				mockStaff({ id: ids.staffOther, service_type_ids: [ids.svc1] }),
+			);
+			(staffRepository.update as any).mockResolvedValue(
+				mockStaff({ id: ids.staffOther, service_type_ids: [ids.svc2] }),
+			);
+
+			await service.update(ids.auth, ids.staffOther, {
+				...input,
+				kana: 'こうしんかな',
+			});
+
+			expect(staffRepository.update).toHaveBeenCalledWith(
+				ids.staffOther,
+				expect.objectContaining({ kana: 'こうしんかな' }),
+			);
+		});
+
+		it('kana 空文字 → repository.update に kana: null が渡される', async () => {
+			const inMock = vi.fn().mockResolvedValue({
+				data: [{ id: ids.svc2 }],
+				error: null,
+			});
+			const fromMock = supabase.from as ReturnType<typeof vi.fn>;
+			fromMock.mockReturnValue({
+				select: () => ({ in: inMock }),
+			} as any);
+
+			(staffRepository.findWithServiceTypesById as any).mockResolvedValue(
+				mockStaff({ id: ids.staffOther, service_type_ids: [ids.svc1] }),
+			);
+			(staffRepository.update as any).mockResolvedValue(
+				mockStaff({ id: ids.staffOther, service_type_ids: [ids.svc2] }),
+			);
+
+			await service.update(ids.auth, ids.staffOther, {
+				...input,
+				kana: '',
+			});
+
+			expect(staffRepository.update).toHaveBeenCalledWith(
+				ids.staffOther,
+				expect.objectContaining({ kana: null }),
+			);
 		});
 	});
 

--- a/src/backend/services/staffService.ts
+++ b/src/backend/services/staffService.ts
@@ -30,15 +30,11 @@ export class StaffService {
 		this.staffRepository = repo ?? new StaffRepository(supabase);
 	}
 
-	private normalizeNote(note?: string | null): string | null | undefined {
-		if (typeof note === 'undefined') return undefined;
-		const trimmed = note?.trim();
-		return trimmed ? trimmed : null;
-	}
-
-	private normalizeKana(kana?: string | null): string | null | undefined {
-		if (typeof kana === 'undefined') return undefined;
-		const trimmed = kana?.trim();
+	private normalizeOptionalText(
+		value?: string | null,
+	): string | null | undefined {
+		if (typeof value === 'undefined') return undefined;
+		const trimmed = value?.trim();
 		return trimmed ? trimmed : null;
 	}
 
@@ -100,10 +96,10 @@ export class StaffService {
 		const staff = await this.staffRepository.create({
 			office_id: admin.office_id,
 			name: data.name,
-			kana: this.normalizeKana(data.kana),
+			kana: this.normalizeOptionalText(data.kana),
 			role: data.role,
 			email: data.email ?? null,
-			note: this.normalizeNote(data.note),
+			note: this.normalizeOptionalText(data.note),
 			service_type_ids: serviceTypeIds,
 		});
 		return this.toRecord(staff);
@@ -131,10 +127,10 @@ export class StaffService {
 		await this.assertServiceTypesExist(serviceTypeIds);
 		const staff = await this.staffRepository.update(id, {
 			name: data.name,
-			kana: this.normalizeKana(data.kana),
+			kana: this.normalizeOptionalText(data.kana),
 			role: data.role,
 			email: data.email ?? null,
-			note: this.normalizeNote(data.note),
+			note: this.normalizeOptionalText(data.note),
 			service_type_ids: serviceTypeIds,
 		});
 		return this.toRecord(staff);

--- a/src/backend/services/staffService.ts
+++ b/src/backend/services/staffService.ts
@@ -36,6 +36,12 @@ export class StaffService {
 		return trimmed ? trimmed : null;
 	}
 
+	private normalizeKana(kana?: string | null): string | null | undefined {
+		if (typeof kana === 'undefined') return undefined;
+		const trimmed = kana?.trim();
+		return trimmed ? trimmed : null;
+	}
+
 	private async getAdminStaff(userId: string) {
 		const staff = await this.staffRepository.findByAuthUserId(userId);
 		if (!staff) throw new ServiceError(404, 'Staff not found');
@@ -94,6 +100,7 @@ export class StaffService {
 		const staff = await this.staffRepository.create({
 			office_id: admin.office_id,
 			name: data.name,
+			kana: this.normalizeKana(data.kana),
 			role: data.role,
 			email: data.email ?? null,
 			note: this.normalizeNote(data.note),
@@ -124,6 +131,7 @@ export class StaffService {
 		await this.assertServiceTypesExist(serviceTypeIds);
 		const staff = await this.staffRepository.update(id, {
 			name: data.name,
+			kana: this.normalizeKana(data.kana),
 			role: data.role,
 			email: data.email ?? null,
 			note: this.normalizeNote(data.note),

--- a/src/models/staffActionSchemas.ts
+++ b/src/models/staffActionSchemas.ts
@@ -11,6 +11,11 @@ const StaffNoteSchema = z
 
 export const StaffInputSchema = z.object({
 	name: z.string().min(1, { message: '氏名は必須です' }),
+	kana: z
+		.string()
+		.max(100, { message: 'ふりがなは100文字以内で入力してください' })
+		.nullable()
+		.optional(),
 	email: EmailSchema.optional().nullable(),
 	role: UserRoleSchema,
 	note: StaffNoteSchema,


### PR DESCRIPTION
## 概要

スタッフ作成・編集フローにおいて `kana` （ふりがな）を保存・更新できるよう、Schema / Service / Repository / UI を一貫して実装しました。

Closes #101
refs #72

---

## 背景

- `staffs` テーブルの `kana` カラムは追加済み（migration: `supabase/migrations/20260312000000_add_kana_to_staffs.sql`）
- `StaffSchema` にも `kana` は追加済み
- Issue #100 で `searchStaffs` Tool が `name/kana` 検索に対応済み
- ただしスタッフ作成/編集経路で `kana` が保存されておらず、常に `null` になっていた (#100 review thread)

Issue #72 は AI チャットによるシフト変更サポートを目的としており、ヘルパー検索精度向上のために本実装が必要でした。

---

## 変更内容

### Phase 1: バックエンド（Schema / Service / Repository）

| ファイル | 変更概要 |
|---|---|
| `src/models/staffActionSchemas.ts` | `StaffInputSchema` に `kana`（optional/nullable, max 100）を追加 |
| `src/backend/repositories/staffRepository.ts` | `StaffCreateParams` / `StaffUpdateParams` / `create` / `buildUpdatePayload` に `kana` を追加 |
| `src/backend/services/staffService.ts` | `create` / `update` の repository 呼び出し payload に `kana` を追加 |

### Phase 2: フロントエンド（StaffFormModal）

| ファイル | 変更概要 |
|---|---|
| `src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.tsx` | ふりがな入力欄を追加、defaultValues に `kana`、送信 payload に `kana` を含める |

### テスト補強

| ファイル | 変更概要 |
|---|---|
| `src/backend/repositories/staffRepository.test.ts` | create/update payload に `kana` が含まれることをアサーション |
| `src/backend/services/staffService.test.ts` | create/update 時の `kana` 正規化（trim・空文字 → null）テストを追加 |
| `src/app/admin/staffs/_components/StaffFormModal/StaffFormModal.test.tsx` | フォーム送信値に `kana` が含まれることをアサーション |

### ドキュメント

- `docs/issues/issue-72-kana-save-update-path.md` — 設計ドキュメントを追加

---

## 入力値の正規化ルール

`kana` は `email` / `note` と同様に **trim → 空文字なら `null`** として保存します。

---

## テスト結果

```
Test Files  160 passed | 1 skipped (161)
Tests       1177 passed | 1 skipped (1178)
```

---

## スコープ外（別 Issue）

- スタッフ一覧テーブルへの `kana` 表示・フロント側フィルタ
- `kana` 自動生成（名前→かな変換）・ひらがな/カタカナ正規化
- 既存データのバックフィル