### PR TITLE
fix: AIチャットのストリーミング時スクロール挙動を最適化

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
@@ -1,0 +1,68 @@
+import { TEST_IDS } from '@/test/helpers/testIds';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatMessageList } from './ChatMessageList';
+import type { ChatMessage } from './useAdjustmentChat';
+
+const createMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+	id: TEST_IDS.SCHEDULE_1,
+	role: 'assistant',
+	content: 'AI response',
+	timestamp: new Date('2026-02-24T10:00:00.000Z'),
+	...overrides,
+});
+
+describe('ChatMessageList', () => {
+	const scrollIntoViewMock = vi.fn();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+			configurable: true,
+			value: scrollIntoViewMock,
+			writable: true,
+		});
+	});
+
+	it('streaming 中は scrollIntoView を auto で呼ぶ', () => {
+		render(<ChatMessageList messages={[createMessage()]} isStreaming={true} />);
+
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'auto' });
+	});
+
+	it('非 streaming で新規メッセージ追加時は scrollIntoView を smooth で呼ぶ', () => {
+		const initialMessages = [createMessage()];
+		const { rerender } = render(
+			<ChatMessageList messages={initialMessages} isStreaming={false} />,
+		);
+		scrollIntoViewMock.mockClear();
+
+		rerender(
+			<ChatMessageList
+				messages={[
+					...initialMessages,
+					createMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						content: 'follow-up message',
+					}),
+				]}
+				isStreaming={false}
+			/>,
+		);
+
+		expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth' });
+	});
+
+	it('streaming 終了だけでは追加スクロールしない', () => {
+		const messages = [createMessage()];
+		const { rerender } = render(
+			<ChatMessageList messages={messages} isStreaming={true} />,
+		);
+		scrollIntoViewMock.mockClear();
+
+		rerender(<ChatMessageList messages={messages} isStreaming={false} />);
+
+		expect(scrollIntoViewMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
@@ -1,6 +1,6 @@
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { render } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatMessageList } from './ChatMessageList';
 import type { ChatMessage } from './useAdjustmentChat';
 
@@ -14,6 +14,10 @@ const createMessage = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
 
 describe('ChatMessageList', () => {
 	const scrollIntoViewMock = vi.fn();
+	const originalScrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+		HTMLElement.prototype,
+		'scrollIntoView',
+	);
 
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -22,6 +26,19 @@ describe('ChatMessageList', () => {
 			value: scrollIntoViewMock,
 			writable: true,
 		});
+	});
+
+	afterAll(() => {
+		if (originalScrollIntoViewDescriptor) {
+			Object.defineProperty(
+				HTMLElement.prototype,
+				'scrollIntoView',
+				originalScrollIntoViewDescriptor,
+			);
+			return;
+		}
+
+		Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
 	});
 
 	it('streaming 中は scrollIntoView を auto で呼ぶ', () => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
@@ -13,13 +13,22 @@ export const ChatMessageList = ({
 	isStreaming = false,
 }: ChatMessageListProps) => {
 	const endRef = useRef<HTMLDivElement>(null);
+	const prevMessageCountRef = useRef(0);
 
 	// 自動スクロール
 	useEffect(() => {
+		const hasNewMessage = messages.length > prevMessageCountRef.current;
+
 		if (typeof endRef.current?.scrollIntoView === 'function') {
-			endRef.current.scrollIntoView({ behavior: 'smooth' });
+			if (isStreaming) {
+				endRef.current.scrollIntoView({ behavior: 'auto' });
+			} else if (hasNewMessage) {
+				endRef.current.scrollIntoView({ behavior: 'smooth' });
+			}
 		}
-	}, [messages]);
+
+		prevMessageCountRef.current = messages.length;
+	}, [messages, isStreaming]);
 
 	if (messages.length === 0) {
 		return (


### PR DESCRIPTION
## Summary
- SSE ストリーミング中の smooth scroll 連続発火によるカクつきを抑えるため、スクロール挙動を最適化
- `prevMessageCountRef` で前回メッセージ数を保持し、新規メッセージ追加時のみ smooth scroll するよう変更
- `ChatMessageList` に focused test を追加し、streaming 中は auto / 新規追加時のみ smooth / streaming 終了のみでは追加スクロールしないことを確認

## Changes
- streaming 中は `scrollIntoView({ behavior: 'auto' })` で追従
- 非 streaming では新規メッセージ追加時のみ `scrollIntoView({ behavior: 'smooth' })`
- `prevMessageCountRef` による新規メッセージ判定を追加
- `ChatMessageList.test.tsx` に focused test を追加

## Testing
- `pnpm test:ut --run src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx`
- `pnpm test:ut --run src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx`

Closes #91
