### PR TITLE
fix: Issue #97 processStaffAbsence の timeout 契約を整備

### DIFF
--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -1284,8 +1284,95 @@ describe('processStaffAbsence', () => {
 		expect(result.absenceStaffName).toBe('欠勤者A');
 		expect(result.startDate).toBe('2026-02-25');
 		expect(result.endDate).toBe('2026-02-26');
+		expect(result.meta).toEqual({
+			timedOut: false,
+			processedCount: 0,
+			totalCount: 0,
+		});
 		expect(result.affectedShifts).toHaveLength(0);
 		expect(result.summary).toContain('影響シフト: 0件');
+	});
+
+	it('タイムアウト時は partial result を正常系で返す', async () => {
+		const userId = createTestId();
+		const absenceStaffId = TEST_IDS.STAFF_2;
+		const clientId = TEST_IDS.CLIENT_1;
+
+		let t = 0;
+		service = new ShiftAdjustmentSuggestionService(mockSupabase, {
+			staffRepository: mockStaffRepo,
+			shiftRepository: mockShiftRepo,
+			clientStaffAssignmentRepository: mockClientStaffAssignmentRepo,
+			maxExecutionMs: 1,
+			now: () => {
+				t += 1;
+				return t;
+			},
+		});
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+		mockStaffRepo.findById = vi
+			.fn()
+			.mockResolvedValueOnce(
+				createAdminStaff({ id: absenceStaffId, name: '欠勤者A' }),
+			);
+		mockStaffRepo.listByOffice.mockResolvedValue([
+			createStaffWithServiceTypes({
+				id: TEST_IDS.STAFF_3,
+				name: '候補者B',
+				role: 'helper',
+				service_type_ids: ['life-support'],
+			}),
+		]);
+
+		const affectedShifts = [
+			createShift({
+				id: TEST_IDS.SCHEDULE_1,
+				client_id: clientId,
+				staff_id: absenceStaffId,
+				date: new Date('2026-02-25T00:00:00+09:00'),
+				time: { start: { hour: 10, minute: 0 }, end: { hour: 11, minute: 0 } },
+				status: 'scheduled',
+				service_type_id: 'life-support',
+			}),
+			createShift({
+				id: TEST_IDS.SCHEDULE_2,
+				client_id: clientId,
+				staff_id: absenceStaffId,
+				date: new Date('2026-02-26T00:00:00+09:00'),
+				time: { start: { hour: 12, minute: 0 }, end: { hour: 13, minute: 0 } },
+				status: 'scheduled',
+				service_type_id: 'life-support',
+			}),
+		];
+		mockShiftRepo.findAffectedShiftsByAbsence = vi
+			.fn()
+			.mockResolvedValueOnce(affectedShifts);
+		mockShiftRepo.findPastAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValue([TEST_IDS.STAFF_3]);
+		mockClientStaffAssignmentRepo.findAssignedStaffIdsByClient = vi
+			.fn()
+			.mockResolvedValue([TEST_IDS.STAFF_3]);
+		mockShiftRepo.list.mockResolvedValue([]);
+
+		const result = await service.processStaffAbsence(userId, {
+			staffId: absenceStaffId,
+			startDate: new Date('2026-02-25T00:00:00+09:00'),
+			endDate: new Date('2026-02-26T00:00:00+09:00'),
+		});
+
+		expect(result.meta).toEqual({
+			timedOut: true,
+			processedCount: 1,
+			totalCount: 2,
+		});
+		expect(result.affectedShifts).toHaveLength(1);
+		expect(result.affectedShifts[0]?.shift.id).toBe(TEST_IDS.SCHEDULE_1);
+		expect(result.summary).toContain('影響シフト: 1/2件');
+		expect(result.summary).toContain('一部のみ処理');
 	});
 
 	it('影響シフトに対して過去担当者が候補として優先される', async () => {
@@ -1558,6 +1645,11 @@ describe('processStaffAbsence', () => {
 			endDate: new Date('2026-02-26T00:00:00+09:00'),
 		});
 
+		expect(result.meta).toEqual({
+			timedOut: false,
+			processedCount: 2,
+			totalCount: 2,
+		});
 		expect(result.summary).toContain('影響シフト: 2件');
 		expect(result.summary).toContain('候補なし: 2件');
 	});

--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -1188,6 +1188,35 @@ describe('processStaffAbsence', () => {
 		vi.useRealTimers();
 	});
 
+	it('存在しない日付文字列を日本語メッセージで拒否する', async () => {
+		const userId = createTestId();
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+
+		const invalidInput = {
+			staffId: TEST_IDS.STAFF_2,
+			startDate: '2026-02-31',
+			endDate: '2026-03-01',
+		} as unknown as Parameters<
+			ShiftAdjustmentSuggestionService['processStaffAbsence']
+		>[1];
+
+		await expect(
+			service.processStaffAbsence(userId, invalidInput),
+		).rejects.toMatchObject({
+			status: 400,
+			message: 'Validation error',
+			details: expect.arrayContaining([
+				expect.objectContaining({
+					message: '存在する日付を指定してください',
+					path: ['startDate'],
+				}),
+			]),
+		});
+	});
+
 	it('入力が不正な場合は400を返す', async () => {
 		const userId = createTestId();
 

--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -1188,6 +1188,22 @@ describe('processStaffAbsence', () => {
 		vi.useRealTimers();
 	});
 
+	it('入力が不正な場合は400を返す', async () => {
+		const userId = createTestId();
+
+		mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
+		);
+
+		await expect(
+			service.processStaffAbsence(userId, {
+				staffId: TEST_IDS.STAFF_2,
+				startDate: new Date('2026-02-26T00:00:00+09:00'),
+				endDate: new Date('2026-02-25T00:00:00+09:00'),
+			}),
+		).rejects.toMatchObject({ status: 400, message: 'Validation error' });
+	});
+
 	it('非adminは403を返す', async () => {
 		const userId = createTestId();
 

--- a/src/backend/services/shiftAdjustmentSuggestionService.test.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.test.ts
@@ -3,6 +3,7 @@ import { ShiftRepository } from '@/backend/repositories/shiftRepository';
 import { StaffRepository } from '@/backend/repositories/staffRepository';
 import { Database } from '@/backend/types/supabase';
 import { Shift } from '@/models/shift';
+import type { StaffAbsenceActionInput } from '@/models/shiftAdjustmentActionSchemas';
 import { Staff, StaffWithServiceTypes } from '@/models/staff';
 import { createTestId, TEST_IDS } from '@/test/helpers/testIds';
 import { SupabaseClient } from '@supabase/supabase-js';
@@ -1195,13 +1196,11 @@ describe('processStaffAbsence', () => {
 			createAdminStaff({ id: createTestId(), auth_user_id: userId }),
 		);
 
-		const invalidInput = {
+		const invalidInput: StaffAbsenceActionInput = {
 			staffId: TEST_IDS.STAFF_2,
 			startDate: '2026-02-31',
 			endDate: '2026-03-01',
-		} as unknown as Parameters<
-			ShiftAdjustmentSuggestionService['processStaffAbsence']
-		>[1];
+		};
 
 		await expect(
 			service.processStaffAbsence(userId, invalidInput),

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -11,6 +11,7 @@ import {
 	ShiftAdjustmentRationaleItem,
 	ShiftAdjustmentSuggestion,
 	ShiftSnapshot,
+	StaffAbsenceActionInput,
 	StaffAbsenceInput,
 	StaffAbsenceInputSchema,
 	StaffAbsenceProcessResult,
@@ -229,7 +230,7 @@ export class ShiftAdjustmentSuggestionService {
 	}
 
 	private validateStaffAbsence = (
-		input: StaffAbsenceInput,
+		input: StaffAbsenceActionInput,
 	): StaffAbsenceInput => {
 		const parsedInput = StaffAbsenceInputSchema.safeParse(input);
 		if (!parsedInput.success) {
@@ -920,7 +921,7 @@ export class ShiftAdjustmentSuggestionService {
 	 */
 	async processStaffAbsence(
 		userId: string,
-		input: StaffAbsenceInput,
+		input: StaffAbsenceActionInput,
 	): Promise<StaffAbsenceProcessResult> {
 		const MAX_CANDIDATES = 3;
 		// 時間衝突で候補外になる可能性を考慮し、多めに取得してからフィルタする

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -4,6 +4,7 @@ import { ShiftRepository } from '@/backend/repositories/shiftRepository';
 import { StaffRepository } from '@/backend/repositories/staffRepository';
 import { Database } from '@/backend/types/supabase';
 import {
+	AffectedShiftWithCandidates,
 	ClientDatetimeChangeInput,
 	ClientDatetimeChangeInputSchema,
 	ShiftAdjustmentOperation,
@@ -11,6 +12,9 @@ import {
 	ShiftAdjustmentSuggestion,
 	ShiftSnapshot,
 	StaffAbsenceInput,
+	StaffAbsenceInputSchema,
+	StaffAbsenceProcessResult,
+	StaffCandidate,
 } from '@/models/shiftAdjustmentActionSchemas';
 import { ServiceTypeId } from '@/models/valueObjects/serviceTypeId';
 import {
@@ -63,51 +67,6 @@ export type FindAvailableHelpersInput = {
 export type AvailableHelper = {
 	id: string;
 	name: string;
-};
-
-// ======================================
-// processStaffAbsence 関連の型定義
-// ======================================
-
-/**
- * 代替候補スタッフ
- */
-export type StaffCandidate = {
-	staffId: string;
-	staffName: string;
-	/**
-	 * 優先順位の理由（いずれも時間帯の重複チェック済みで「空き時間あり」のスタッフ）:
-	 * - past_assigned = 過去にその利用者を担当したことがある
-	 * - assigned = 現在その利用者に割当済みだが、担当経験はない
-	 * - available = 現在その利用者には割当されておらず、今回の時間帯が空いている
-	 */
-	priority: 'past_assigned' | 'assigned' | 'available';
-};
-
-/**
- * 影響シフトとその代替候補
- */
-export type AffectedShiftWithCandidates = {
-	shift: ShiftSnapshot;
-	candidates: StaffCandidate[];
-};
-
-/**
- * processStaffAbsence の戻り値
- */
-export type StaffAbsenceProcessResult = {
-	meta: {
-		timedOut: boolean;
-		processedCount: number;
-		totalCount: number;
-	};
-	absenceStaffId: string;
-	absenceStaffName: string;
-	startDate: string; // YYYY-MM-DD
-	endDate: string; // YYYY-MM-DD
-	affectedShifts: AffectedShiftWithCandidates[];
-	/** AI が読む用のサマリー */
-	summary: string;
 };
 
 const isOverlapping = (
@@ -268,6 +227,17 @@ export class ShiftAdjustmentSuggestionService {
 	}): string {
 		return `${params.clientId}|${params.serviceTypeId}`;
 	}
+
+	private validateStaffAbsence = (
+		input: StaffAbsenceInput,
+	): StaffAbsenceInput => {
+		const parsedInput = StaffAbsenceInputSchema.safeParse(input);
+		if (!parsedInput.success) {
+			throw new ServiceError(400, 'Validation error', parsedInput.error.issues);
+		}
+
+		return parsedInput.data;
+	};
 
 	private validateClientDatetimeChange = (
 		change: ClientDatetimeChangeInput,
@@ -959,21 +929,24 @@ export class ShiftAdjustmentSuggestionService {
 
 		// 管理者権限チェック
 		const admin = await this.getAdminStaff(userId);
+		const validatedInput = this.validateStaffAbsence(input);
 
 		// 欠勤スタッフの存在と同一事業所チェック
-		const absenceStaff = await this.staffRepository.findById(input.staffId);
+		const absenceStaff = await this.staffRepository.findById(
+			validatedInput.staffId,
+		);
 		if (!absenceStaff || absenceStaff.office_id !== admin.office_id) {
 			throw new ServiceError(404, 'Absence staff not found');
 		}
 
 		const officeId = admin.office_id;
-		const startDate = input.startDate;
-		const endDate = input.endDate;
+		const startDate = validatedInput.startDate;
+		const endDate = validatedInput.endDate;
 
 		// 影響シフトを取得
 		const affectedShifts =
 			await this.shiftRepository.findAffectedShiftsByAbsence(
-				input.staffId,
+				validatedInput.staffId,
 				startDate,
 				endDate,
 				officeId,
@@ -984,7 +957,7 @@ export class ShiftAdjustmentSuggestionService {
 		if (totalCount === 0) {
 			return {
 				meta: { timedOut: false, processedCount: 0, totalCount: 0 },
-				absenceStaffId: input.staffId,
+				absenceStaffId: validatedInput.staffId,
 				absenceStaffName: absenceStaff.name,
 				startDate: formatJstDateString(startDate),
 				endDate: formatJstDateString(endDate),
@@ -1067,7 +1040,7 @@ export class ShiftAdjustmentSuggestionService {
 
 			const candidates = this.findCandidatesForShift({
 				shift,
-				absenceStaffId: input.staffId,
+				absenceStaffId: validatedInput.staffId,
 				staffMap,
 				maxCandidates: MAX_CANDIDATES,
 				shiftsByDate,
@@ -1091,7 +1064,7 @@ export class ShiftAdjustmentSuggestionService {
 
 		return {
 			meta: { timedOut: isTimedOut(), processedCount, totalCount },
-			absenceStaffId: input.staffId,
+			absenceStaffId: validatedInput.staffId,
 			absenceStaffName: absenceStaff.name,
 			startDate: formatJstDateString(startDate),
 			endDate: formatJstDateString(endDate),

--- a/src/backend/services/shiftAdjustmentSuggestionService.ts
+++ b/src/backend/services/shiftAdjustmentSuggestionService.ts
@@ -96,6 +96,11 @@ export type AffectedShiftWithCandidates = {
  * processStaffAbsence の戻り値
  */
 export type StaffAbsenceProcessResult = {
+	meta: {
+		timedOut: boolean;
+		processedCount: number;
+		totalCount: number;
+	};
 	absenceStaffId: string;
 	absenceStaffName: string;
 	startDate: string; // YYYY-MM-DD
@@ -950,6 +955,7 @@ export class ShiftAdjustmentSuggestionService {
 		const MAX_CANDIDATES = 3;
 		// 時間衝突で候補外になる可能性を考慮し、多めに取得してからフィルタする
 		const FETCH_CANDIDATES_BUFFER = 10;
+		const { checkTimeout, isTimedOut } = this.createTimeoutChecker();
 
 		// 管理者権限チェック
 		const admin = await this.getAdminStaff(userId);
@@ -972,10 +978,12 @@ export class ShiftAdjustmentSuggestionService {
 				endDate,
 				officeId,
 			);
+		const totalCount = affectedShifts.length;
 
 		// 影響シフトがない場合は早期リターン
-		if (affectedShifts.length === 0) {
+		if (totalCount === 0) {
 			return {
+				meta: { timedOut: false, processedCount: 0, totalCount: 0 },
 				absenceStaffId: input.staffId,
 				absenceStaffName: absenceStaff.name,
 				startDate: formatJstDateString(startDate),
@@ -1053,38 +1061,43 @@ export class ShiftAdjustmentSuggestionService {
 			assignedStaffResults.map((r) => [r.key, r.staffIds]),
 		);
 
-		// 各影響シフトに対して代替候補を検索（同期処理）
-		const affectedShiftsWithCandidates: AffectedShiftWithCandidates[] =
-			affectedShifts.map((shift) => {
-				const candidates = this.findCandidatesForShift({
-					shift,
-					absenceStaffId: input.staffId,
-					staffMap,
-					maxCandidates: MAX_CANDIDATES,
-					shiftsByDate,
-					pastStaffCache,
-					assignedStaffCache,
-				});
+		const affectedShiftsWithCandidates: AffectedShiftWithCandidates[] = [];
+		for (const shift of affectedShifts) {
+			if (checkTimeout()) break;
 
-				return {
-					shift: toShiftSnapshot(shift),
-					candidates,
-				};
+			const candidates = this.findCandidatesForShift({
+				shift,
+				absenceStaffId: input.staffId,
+				staffMap,
+				maxCandidates: MAX_CANDIDATES,
+				shiftsByDate,
+				pastStaffCache,
+				assignedStaffCache,
 			});
 
-		// 候補なしの件数をカウント
+			affectedShiftsWithCandidates.push({
+				shift: toShiftSnapshot(shift),
+				candidates,
+			});
+		}
+
+		const processedCount = affectedShiftsWithCandidates.length;
 		const noCandidatesCount = affectedShiftsWithCandidates.filter(
 			(a) => a.candidates.length === 0,
 		).length;
+		const summaryPrefix = isTimedOut()
+			? `影響シフト: ${processedCount}/${totalCount}件（タイムアウトにより一部のみ処理）`
+			: `影響シフト: ${processedCount}件`;
 
 		return {
+			meta: { timedOut: isTimedOut(), processedCount, totalCount },
 			absenceStaffId: input.staffId,
 			absenceStaffName: absenceStaff.name,
 			startDate: formatJstDateString(startDate),
 			endDate: formatJstDateString(endDate),
 			affectedShifts: affectedShiftsWithCandidates,
 			summary:
-				`影響シフト: ${affectedShifts.length}件` +
+				summaryPrefix +
 				(noCandidatesCount > 0 ? `, 候補なし: ${noCandidatesCount}件` : ''),
 		};
 	}

--- a/src/backend/tools/_shared/dateValidation.ts
+++ b/src/backend/tools/_shared/dateValidation.ts
@@ -1,22 +1,13 @@
-import dayjs from 'dayjs';
-import customParseFormat from 'dayjs/plugin/customParseFormat';
-import utc from 'dayjs/plugin/utc';
-
-// customParseFormat プラグインを有効化（strict parsing に必要）
-dayjs.extend(customParseFormat);
-// UTC プラグインを有効化
-dayjs.extend(utc);
+import {
+	getInclusiveJstDateRangeDays,
+	isValidJstDateString,
+} from '@/models/valueObjects/jstDate';
 
 /**
  * 日付文字列が実在する日付かどうかを検証する
- * UTC 固定で解析することで、環境のタイムゾーンに依存しない判定を行う
- * 正規表現で形式は確認済みの前提で、dayjs の strict parsing で実在性をチェック
  */
 export const isValidDate = (dateStr: string): boolean => {
-	// UTC 固定でパースし、タイムゾーンの影響を排除
-	const parsed = dayjs.utc(dateStr, 'YYYY-MM-DD', true);
-	// strict parsing で isValid() かつ、parse した結果が元の文字列と一致することを確認
-	return parsed.isValid() && parsed.format('YYYY-MM-DD') === dateStr;
+	return isValidJstDateString(dateStr);
 };
 
 /**
@@ -27,7 +18,5 @@ export const getDaysDifference = (
 	startDate: string,
 	endDate: string,
 ): number => {
-	const start = dayjs.utc(startDate, 'YYYY-MM-DD', true);
-	const end = dayjs.utc(endDate, 'YYYY-MM-DD', true);
-	return end.diff(start, 'day') + 1;
+	return getInclusiveJstDateRangeDays(startDate, endDate);
 };

--- a/src/backend/tools/processStaffAbsence.test.ts
+++ b/src/backend/tools/processStaffAbsence.test.ts
@@ -1,30 +1,46 @@
 import { Database } from '@/backend/types/supabase';
+import { StaffAbsenceProcessResultSchema } from '@/models/shiftAdjustmentActionSchemas';
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createProcessStaffAbsenceTool,
 	ProcessStaffAbsenceParametersSchema,
 } from './processStaffAbsence';
 
+const { mockProcessStaffAbsence } = vi.hoisted(() => ({
+	mockProcessStaffAbsence: vi.fn(),
+}));
+
 // ShiftAdjustmentSuggestionService をモック（クラスモックには function を使用）
 vi.mock('@/backend/services/shiftAdjustmentSuggestionService', () => ({
 	ShiftAdjustmentSuggestionService: function MockService() {
 		return {
-			processStaffAbsence: vi.fn().mockResolvedValue({
-				absenceStaffId: TEST_IDS.STAFF_1,
-				absenceStaffName: '山田太郎',
-				startDate: '2026-02-25',
-				endDate: '2026-02-27',
-				affectedShifts: [],
-				summary: '影響シフト: 0件',
-			}),
+			processStaffAbsence: mockProcessStaffAbsence,
 		};
 	},
 }));
 
 describe('processStaffAbsence tool', () => {
 	const mockSupabase = {} as SupabaseClient<Database>;
+	const defaultResult = {
+		meta: {
+			timedOut: false,
+			processedCount: 0,
+			totalCount: 0,
+		},
+		absenceStaffId: TEST_IDS.STAFF_1,
+		absenceStaffName: '山田太郎',
+		startDate: '2026-02-25',
+		endDate: '2026-02-27',
+		affectedShifts: [],
+		summary: '影響シフト: 0件',
+	};
+
+	beforeEach(() => {
+		mockProcessStaffAbsence.mockReset();
+		mockProcessStaffAbsence.mockResolvedValue(defaultResult);
+	});
 
 	it('tool が正しい構造を持つ', () => {
 		const tool = createProcessStaffAbsenceTool({
@@ -78,7 +94,7 @@ describe('processStaffAbsence tool', () => {
 		it('不正な日付形式を拒否する', () => {
 			const invalidParams = {
 				staffId: TEST_IDS.STAFF_1,
-				startDate: '2026/02/25', // 不正な形式
+				startDate: '2026/02/25',
 				endDate: '2026-02-27',
 			};
 
@@ -195,7 +211,7 @@ describe('processStaffAbsence tool', () => {
 				const invalidParams = {
 					staffId: TEST_IDS.STAFF_1,
 					startDate: '2026-03-01',
-					endDate: '2026-03-16', // 16日間 = 14日超過
+					endDate: '2026-03-16',
 				};
 
 				const result =
@@ -211,7 +227,7 @@ describe('processStaffAbsence tool', () => {
 				const validParams = {
 					staffId: TEST_IDS.STAFF_1,
 					startDate: '2026-03-01',
-					endDate: '2026-03-14', // 14日間
+					endDate: '2026-03-14',
 				};
 
 				const result =
@@ -234,13 +250,12 @@ describe('processStaffAbsence tool', () => {
 	});
 
 	describe('execute', () => {
-		it('execute が ShiftAdjustmentSuggestionService.processStaffAbsence を呼び出す', async () => {
+		it('service の返却値を meta 付き契約で返す', async () => {
 			const tool = createProcessStaffAbsenceTool({
 				supabase: mockSupabase,
 				userId: TEST_IDS.USER_1,
 			});
 
-			// AI SDK v6 の tool.execute は options 引数が必須
 			const result = await tool.execute!(
 				{
 					staffId: TEST_IDS.STAFF_1,
@@ -254,14 +269,107 @@ describe('processStaffAbsence tool', () => {
 				},
 			);
 
-			expect(result).toEqual({
+			const parsedResult = StaffAbsenceProcessResultSchema.parse(result);
+
+			expect(parsedResult).toEqual(defaultResult);
+		});
+
+		it('partial result の shape を保持する', async () => {
+			mockProcessStaffAbsence.mockResolvedValueOnce({
+				meta: {
+					timedOut: true,
+					processedCount: 1,
+					totalCount: 2,
+				},
+				absenceStaffId: TEST_IDS.STAFF_1,
+				absenceStaffName: '山田太郎',
+				startDate: '2026-02-25',
+				endDate: '2026-02-27',
+				affectedShifts: [
+					{
+						shift: {
+							id: TEST_IDS.SCHEDULE_1,
+							client_id: TEST_IDS.CLIENT_1,
+							service_type_id: 'life-support',
+							staff_id: TEST_IDS.STAFF_1,
+							date: new Date('2026-02-25T00:00:00+09:00'),
+							start_time: { hour: 9, minute: 0 },
+							end_time: { hour: 10, minute: 0 },
+							status: 'scheduled',
+						},
+						candidates: [
+							{
+								staffId: TEST_IDS.STAFF_2,
+								staffName: '佐藤花子',
+								priority: 'past_assigned',
+							},
+						],
+					},
+				],
+				summary: '影響シフト: 1/2件（一部のみ処理）',
+			});
+
+			const tool = createProcessStaffAbsenceTool({
+				supabase: mockSupabase,
+				userId: TEST_IDS.USER_1,
+			});
+
+			const result = await tool.execute!(
+				{
+					staffId: TEST_IDS.STAFF_1,
+					startDate: '2026-02-25',
+					endDate: '2026-02-27',
+				},
+				{
+					abortSignal: new AbortController().signal,
+					toolCallId: 'test-call-id',
+					messages: [],
+				},
+			);
+
+			const parsedResult = StaffAbsenceProcessResultSchema.parse(result);
+
+			expect(parsedResult.meta).toEqual({
+				timedOut: true,
+				processedCount: 1,
+				totalCount: 2,
+			});
+			expect(parsedResult.summary).toContain('1/2件');
+		});
+
+		it('契約に合わない service 応答を拒否する', async () => {
+			mockProcessStaffAbsence.mockResolvedValueOnce({
+				meta: {
+					timedOut: false,
+					processedCount: 0,
+					totalCount: 0,
+				},
 				absenceStaffId: TEST_IDS.STAFF_1,
 				absenceStaffName: '山田太郎',
 				startDate: '2026-02-25',
 				endDate: '2026-02-27',
 				affectedShifts: [],
-				summary: '影響シフト: 0件',
+			} as never);
+
+			const tool = createProcessStaffAbsenceTool({
+				supabase: mockSupabase,
+				userId: TEST_IDS.USER_1,
 			});
+
+			await expect(
+				tool.execute!(
+					{
+						staffId: TEST_IDS.STAFF_1,
+						startDate: '2026-02-25',
+						endDate: '2026-02-27',
+					},
+					{
+						abortSignal: new AbortController().signal,
+						toolCallId: 'test-call-id',
+						messages: [],
+					},
+				),
+			).rejects.toThrow();
 		});
 	});
 });

--- a/src/backend/tools/processStaffAbsence.test.ts
+++ b/src/backend/tools/processStaffAbsence.test.ts
@@ -1,4 +1,4 @@
-import { Database } from '@/backend/types/supabase';
+import type { Database } from '@/backend/types/supabase';
 import { StaffAbsenceProcessResultSchema } from '@/models/shiftAdjustmentActionSchemas';
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { SupabaseClient } from '@supabase/supabase-js';

--- a/src/backend/tools/processStaffAbsence.test.ts
+++ b/src/backend/tools/processStaffAbsence.test.ts
@@ -308,7 +308,7 @@ describe('processStaffAbsence tool', () => {
 						],
 					},
 				],
-				summary: '影響シフト: 1/2件（一部のみ処理）',
+				summary: '影響シフト: 1/2件（一部のみ処理)',
 			});
 
 			const tool = createProcessStaffAbsenceTool({
@@ -372,6 +372,33 @@ describe('processStaffAbsence tool', () => {
 					},
 				),
 			).rejects.toThrow();
+		});
+
+		it('service 応答の output 日付が実在しない場合は拒否する', async () => {
+			mockProcessStaffAbsence.mockResolvedValueOnce({
+				...defaultResult,
+				startDate: '2026-02-31',
+			} as never);
+
+			const tool = createProcessStaffAbsenceTool({
+				supabase: mockSupabase,
+				userId: TEST_IDS.USER_1,
+			});
+
+			await expect(
+				tool.execute!(
+					{
+						staffId: TEST_IDS.STAFF_1,
+						startDate: '2026-02-25',
+						endDate: '2026-02-27',
+					},
+					{
+						abortSignal: new AbortController().signal,
+						toolCallId: 'test-call-id',
+						messages: [],
+					},
+				),
+			).rejects.toThrow('存在する日付を指定してください');
 		});
 	});
 });

--- a/src/backend/tools/processStaffAbsence.test.ts
+++ b/src/backend/tools/processStaffAbsence.test.ts
@@ -50,6 +50,8 @@ describe('processStaffAbsence tool', () => {
 
 		expect(tool).toHaveProperty('description');
 		expect(tool).toHaveProperty('inputSchema');
+		expect(tool).toHaveProperty('outputSchema');
+		expect(tool.outputSchema).toBe(StaffAbsenceProcessResultSchema);
 		expect(tool).toHaveProperty('execute');
 		expect(typeof tool.execute).toBe('function');
 	});

--- a/src/backend/tools/processStaffAbsence.ts
+++ b/src/backend/tools/processStaffAbsence.ts
@@ -1,46 +1,42 @@
 import { ShiftAdjustmentSuggestionService } from '@/backend/services/shiftAdjustmentSuggestionService';
-import { getDaysDifference, isValidDate } from '@/backend/tools/_shared';
 import { Database } from '@/backend/types/supabase';
 import {
+	addStaffAbsenceDateRangeValidationIssues,
+	STAFF_ABSENCE_DATE_FORMAT_MESSAGE,
+	STAFF_ABSENCE_INVALID_DATE_MESSAGE,
+	STAFF_ABSENCE_MAX_DAYS,
 	StaffAbsenceProcessResult,
 	StaffAbsenceProcessResultSchema,
 } from '@/models/shiftAdjustmentActionSchemas';
+import { createJstDateStringSchema } from '@/models/valueObjects/jstDate';
 import { parseJstDateString } from '@/utils/date';
 import { SupabaseClient } from '@supabase/supabase-js';
 import type { Tool } from 'ai';
 import { tool } from 'ai';
 import { z } from 'zod';
 
-/** 欠勤期間の最大日数 */
-const MAX_ABSENCE_DAYS = 14;
-
 export const ProcessStaffAbsenceParametersSchema = z
 	.object({
 		staffId: z.string().uuid().describe('欠勤するスタッフのID'),
-		startDate: z
-			.string()
-			.regex(/^\d{4}-\d{2}-\d{2}$/, '日付はYYYY-MM-DD形式で指定してください')
-			.refine(isValidDate, '存在する日付を指定してください')
-			.describe('欠勤開始日 (YYYY-MM-DD)'),
-		endDate: z
-			.string()
-			.regex(/^\d{4}-\d{2}-\d{2}$/, '日付はYYYY-MM-DD形式で指定してください')
-			.refine(isValidDate, '存在する日付を指定してください')
-			.describe('欠勤終了日 (YYYY-MM-DD)'),
+		startDate: createJstDateStringSchema({
+			formatMessage: STAFF_ABSENCE_DATE_FORMAT_MESSAGE,
+			invalidDateMessage: STAFF_ABSENCE_INVALID_DATE_MESSAGE,
+		}).describe('欠勤開始日 (YYYY-MM-DD)'),
+		endDate: createJstDateStringSchema({
+			formatMessage: STAFF_ABSENCE_DATE_FORMAT_MESSAGE,
+			invalidDateMessage: STAFF_ABSENCE_INVALID_DATE_MESSAGE,
+		}).describe('欠勤終了日 (YYYY-MM-DD)'),
 		memo: z.string().max(500).optional().describe('メモ（任意）'),
 	})
-	.refine((data) => data.startDate <= data.endDate, {
-		message: '開始日は終了日以前に設定してください',
-		path: ['startDate'],
-	})
-	.refine(
-		(data) =>
-			getDaysDifference(data.startDate, data.endDate) <= MAX_ABSENCE_DAYS,
-		{
-			message: `欠勤期間は最大${MAX_ABSENCE_DAYS}日間までです`,
-			path: ['endDate'],
-		},
-	);
+	.superRefine((data, ctx) => {
+		addStaffAbsenceDateRangeValidationIssues({
+			ctx,
+			startDate: data.startDate,
+			endDate: data.endDate,
+			startField: 'startDate',
+			endField: 'endDate',
+		});
+	});
 
 export type ProcessStaffAbsenceParameters = z.infer<
 	typeof ProcessStaffAbsenceParametersSchema
@@ -61,8 +57,9 @@ export const createProcessStaffAbsenceTool = (
 	const { supabase, userId } = options;
 
 	return tool({
-		description: `スタッフの欠勤を登録し、影響するシフトと代替候補スタッフを取得します。欠勤期間は最大${MAX_ABSENCE_DAYS}日間まで指定できます。`,
+		description: `スタッフの欠勤を登録し、影響するシフトと代替候補スタッフを取得します。欠勤期間は最大${STAFF_ABSENCE_MAX_DAYS}日間まで指定できます。`,
 		inputSchema: ProcessStaffAbsenceParametersSchema,
+		outputSchema: StaffAbsenceProcessResultSchema,
 		execute: async (
 			params: ProcessStaffAbsenceParameters,
 		): Promise<StaffAbsenceProcessResult> => {

--- a/src/backend/tools/processStaffAbsence.ts
+++ b/src/backend/tools/processStaffAbsence.ts
@@ -1,9 +1,10 @@
-import {
-	ShiftAdjustmentSuggestionService,
-	StaffAbsenceProcessResult,
-} from '@/backend/services/shiftAdjustmentSuggestionService';
+import { ShiftAdjustmentSuggestionService } from '@/backend/services/shiftAdjustmentSuggestionService';
 import { getDaysDifference, isValidDate } from '@/backend/tools/_shared';
 import { Database } from '@/backend/types/supabase';
+import {
+	StaffAbsenceProcessResult,
+	StaffAbsenceProcessResultSchema,
+} from '@/models/shiftAdjustmentActionSchemas';
 import { parseJstDateString } from '@/utils/date';
 import { SupabaseClient } from '@supabase/supabase-js';
 import type { Tool } from 'ai';
@@ -71,12 +72,14 @@ export const createProcessStaffAbsenceTool = (
 			const startDate = parseJstDateString(params.startDate);
 			const endDate = parseJstDateString(params.endDate);
 
-			return service.processStaffAbsence(userId, {
+			const result = await service.processStaffAbsence(userId, {
 				staffId: params.staffId,
 				startDate,
 				endDate,
 				memo: params.memo,
 			});
+
+			return StaffAbsenceProcessResultSchema.parse(result);
 		},
 	});
 };

--- a/src/backend/tools/processStaffAbsence.ts
+++ b/src/backend/tools/processStaffAbsence.ts
@@ -33,7 +33,6 @@ export const ProcessStaffAbsenceParametersSchema = z
 			ctx,
 			startDate: data.startDate,
 			endDate: data.endDate,
-			startField: 'startDate',
 			endField: 'endDate',
 		});
 	});

--- a/src/backend/tools/processStaffAbsence.ts
+++ b/src/backend/tools/processStaffAbsence.ts
@@ -1,5 +1,5 @@
 import { ShiftAdjustmentSuggestionService } from '@/backend/services/shiftAdjustmentSuggestionService';
-import { Database } from '@/backend/types/supabase';
+import type { Database } from '@/backend/types/supabase';
 import {
 	addStaffAbsenceDateRangeValidationIssues,
 	STAFF_ABSENCE_DATE_FORMAT_MESSAGE,

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -4,6 +4,7 @@ import {
 	ShiftAdjustmentOperationSchema,
 	ShiftAdjustmentRequestSchema,
 	StaffAbsenceInputSchema,
+	StaffAbsenceProcessMetaSchema,
 	StaffAbsenceProcessResultSchema,
 	SuggestClientDatetimeChangeAdjustmentsOutputSchema,
 	SuggestShiftAdjustmentsOutputSchema,
@@ -32,9 +33,9 @@ describe('StaffAbsenceInputSchema', () => {
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.error.issues[0]?.message).toBe(
-				'startDate must be before or equal to endDate',
+				'開始日は終了日以前に設定してください',
 			);
-			expect(result.error.issues[0]?.path).toEqual(['endDate']);
+			expect(result.error.issues[0]?.path).toEqual(['startDate']);
 		}
 	});
 
@@ -48,7 +49,7 @@ describe('StaffAbsenceInputSchema', () => {
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.error.issues[0]?.message).toBe(
-				'Date range must be within 14 days',
+				'欠勤期間は最大14日間までです',
 			);
 			expect(result.error.issues[0]?.path).toEqual(['endDate']);
 		}
@@ -62,6 +63,22 @@ describe('StaffAbsenceInputSchema', () => {
 		});
 
 		expect(result.success).toBe(true);
+	});
+
+	it('存在しない日付を日本語メッセージで拒否する', () => {
+		const result = StaffAbsenceInputSchema.safeParse({
+			staffId: TEST_IDS.STAFF_1,
+			startDate: '2026-02-31',
+			endDate: '2026-03-01',
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				'存在する日付を指定してください',
+			);
+			expect(result.error.issues[0]?.path).toEqual(['startDate']);
+		}
 	});
 });
 
@@ -212,6 +229,44 @@ describe('ShiftAdjustmentOperationSchema', () => {
 
 		expect(newEndTimeIssue).toBeDefined();
 		expect(newEndTimeIssue?.message).toBe(timeRangeErrorMessage);
+	});
+});
+
+describe('StaffAbsenceProcessMetaSchema', () => {
+	it('timedOut=false かつ processedCount===totalCount を受け付ける', () => {
+		const result = StaffAbsenceProcessMetaSchema.safeParse({
+			timedOut: false,
+			processedCount: 2,
+			totalCount: 2,
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('timedOut=false で processedCount と totalCount が不一致なら拒否する', () => {
+		const result = StaffAbsenceProcessMetaSchema.safeParse({
+			timedOut: false,
+			processedCount: 1,
+			totalCount: 2,
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				'processedCount must equal totalCount when timedOut is false',
+			);
+			expect(result.error.issues[0]?.path).toEqual(['processedCount']);
+		}
+	});
+
+	it('timedOut=true の partial result は受け付ける', () => {
+		const result = StaffAbsenceProcessMetaSchema.safeParse({
+			timedOut: true,
+			processedCount: 1,
+			totalCount: 2,
+		});
+
+		expect(result.success).toBe(true);
 	});
 });
 

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -4,6 +4,7 @@ import {
 	ShiftAdjustmentOperationSchema,
 	ShiftAdjustmentRequestSchema,
 	StaffAbsenceInputSchema,
+	StaffAbsenceProcessResultSchema,
 	SuggestClientDatetimeChangeAdjustmentsOutputSchema,
 	SuggestShiftAdjustmentsOutputSchema,
 } from './shiftAdjustmentActionSchemas';
@@ -211,6 +212,56 @@ describe('ShiftAdjustmentOperationSchema', () => {
 
 		expect(newEndTimeIssue).toBeDefined();
 		expect(newEndTimeIssue?.message).toBe(timeRangeErrorMessage);
+	});
+});
+
+describe('StaffAbsenceProcessResultSchema', () => {
+	it('partial result の shape をパースできる', () => {
+		const result = StaffAbsenceProcessResultSchema.safeParse({
+			meta: { timedOut: true, processedCount: 1, totalCount: 2 },
+			absenceStaffId: TEST_IDS.STAFF_1,
+			absenceStaffName: '山田太郎',
+			startDate: '2026-02-01',
+			endDate: '2026-02-02',
+			affectedShifts: [
+				{
+					shift: {
+						id: TEST_IDS.SCHEDULE_1,
+						client_id: TEST_IDS.CLIENT_1,
+						service_type_id: 'life-support',
+						staff_id: TEST_IDS.STAFF_1,
+						date: '2026-02-01',
+						start_time: { hour: 9, minute: 0 },
+						end_time: { hour: 10, minute: 0 },
+						status: 'scheduled',
+					},
+					candidates: [
+						{
+							staffId: TEST_IDS.STAFF_2,
+							staffName: '佐藤花子',
+							priority: 'available',
+						},
+					],
+				},
+			],
+			summary: '影響シフト: 1/2件（一部のみ処理）',
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('processedCount が totalCount を超える場合は拒否する', () => {
+		const result = StaffAbsenceProcessResultSchema.safeParse({
+			meta: { timedOut: true, processedCount: 2, totalCount: 1 },
+			absenceStaffId: TEST_IDS.STAFF_1,
+			absenceStaffName: '山田太郎',
+			startDate: '2026-02-01',
+			endDate: '2026-02-02',
+			affectedShifts: [],
+			summary: '影響シフト: 0件',
+		});
+
+		expect(result.success).toBe(false);
 	});
 });
 

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -35,7 +35,7 @@ describe('StaffAbsenceInputSchema', () => {
 			expect(result.error.issues[0]?.message).toBe(
 				'開始日は終了日以前に設定してください',
 			);
-			expect(result.error.issues[0]?.path).toEqual(['startDate']);
+			expect(result.error.issues[0]?.path).toEqual(['endDate']);
 		}
 	});
 

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -11,6 +11,23 @@ import {
 } from './shiftAdjustmentActionSchemas';
 import { TimeRangeSchema } from './valueObjects/timeRange';
 
+type StaffAbsenceDateRangeValidationParams = Parameters<
+	typeof import('./shiftAdjustmentActionSchemas').addStaffAbsenceDateRangeValidationIssues
+>[0];
+
+describe('addStaffAbsenceDateRangeValidationIssues', () => {
+	it('startField を helper の引数として公開しない', () => {
+		type HasStartField =
+			'startField' extends keyof StaffAbsenceDateRangeValidationParams
+				? true
+				: false;
+
+		const hasStartField: HasStartField = false;
+
+		expect(hasStartField).toBe(false);
+	});
+});
+
 describe('StaffAbsenceInputSchema', () => {
 	it('start=1日目, end=14日目 は OK（最大14日）', () => {
 		const result = StaffAbsenceInputSchema.safeParse({

--- a/src/models/shiftAdjustmentActionSchemas.test.ts
+++ b/src/models/shiftAdjustmentActionSchemas.test.ts
@@ -253,7 +253,23 @@ describe('StaffAbsenceProcessMetaSchema', () => {
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.error.issues[0]?.message).toBe(
-				'processedCount must equal totalCount when timedOut is false',
+				'timedOut が false の場合、processedCount は totalCount と一致する必要があります',
+			);
+			expect(result.error.issues[0]?.path).toEqual(['processedCount']);
+		}
+	});
+
+	it('processedCount が totalCount を超える場合は日本語メッセージで拒否する', () => {
+		const result = StaffAbsenceProcessMetaSchema.safeParse({
+			timedOut: true,
+			processedCount: 3,
+			totalCount: 2,
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				'processedCount は totalCount 以下である必要があります',
 			);
 			expect(result.error.issues[0]?.path).toEqual(['processedCount']);
 		}
@@ -299,7 +315,7 @@ describe('StaffAbsenceProcessResultSchema', () => {
 					],
 				},
 			],
-			summary: '影響シフト: 1/2件（一部のみ処理）',
+			summary: '影響シフト: 1/2件（一部のみ処理)',
 		});
 
 		expect(result.success).toBe(true);
@@ -317,6 +333,26 @@ describe('StaffAbsenceProcessResultSchema', () => {
 		});
 
 		expect(result.success).toBe(false);
+	});
+
+	it('output の startDate/endDate でも実在しない日付を拒否する', () => {
+		const result = StaffAbsenceProcessResultSchema.safeParse({
+			meta: { timedOut: false, processedCount: 0, totalCount: 0 },
+			absenceStaffId: TEST_IDS.STAFF_1,
+			absenceStaffName: '山田太郎',
+			startDate: '2026-02-31',
+			endDate: '2026-03-01',
+			affectedShifts: [],
+			summary: '影響シフト: 0件',
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				'存在する日付を指定してください',
+			);
+			expect(result.error.issues[0]?.path).toEqual(['startDate']);
+		}
 	});
 });
 

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { ShiftStatusSchema } from './shift';
 import {
 	createJstDateInputSchema,
+	createJstDateStringSchema,
 	JstDateInputSchema,
 } from './valueObjects/jstDate';
 import { ServiceTypeIdSchema } from './valueObjects/serviceTypeId';
@@ -10,8 +11,6 @@ import { TimeValueSchema } from './valueObjects/time';
 import { TimeRangeSchema } from './valueObjects/timeRange';
 
 const toJstDay = (date: Date) => dateJst(date).startOf('day');
-
-const JstDateStringOutputSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
 
 export const STAFF_ABSENCE_MAX_DAYS = 14;
 export const STAFF_ABSENCE_DATE_FORMAT_MESSAGE =
@@ -21,8 +20,16 @@ export const STAFF_ABSENCE_INVALID_DATE_MESSAGE =
 export const STAFF_ABSENCE_DATE_ORDER_MESSAGE =
 	'開始日は終了日以前に設定してください';
 export const STAFF_ABSENCE_MAX_RANGE_MESSAGE = `欠勤期間は最大${STAFF_ABSENCE_MAX_DAYS}日間までです`;
+const STAFF_ABSENCE_PROCESSED_COUNT_EXCEEDS_TOTAL_MESSAGE =
+	'processedCount は totalCount 以下である必要があります';
+const STAFF_ABSENCE_PROCESSED_COUNT_MISMATCH_MESSAGE =
+	'timedOut が false の場合、processedCount は totalCount と一致する必要があります';
 
 const StaffAbsenceDateInputSchema = createJstDateInputSchema({
+	formatMessage: STAFF_ABSENCE_DATE_FORMAT_MESSAGE,
+	invalidDateMessage: STAFF_ABSENCE_INVALID_DATE_MESSAGE,
+});
+const StaffAbsenceDateStringSchema = createJstDateStringSchema({
 	formatMessage: STAFF_ABSENCE_DATE_FORMAT_MESSAGE,
 	invalidDateMessage: STAFF_ABSENCE_INVALID_DATE_MESSAGE,
 });
@@ -270,7 +277,7 @@ export const StaffAbsenceProcessMetaSchema = z
 		if (meta.processedCount > meta.totalCount) {
 			ctx.addIssue({
 				code: 'custom',
-				message: 'processedCount must be less than or equal to totalCount',
+				message: STAFF_ABSENCE_PROCESSED_COUNT_EXCEEDS_TOTAL_MESSAGE,
 				path: ['processedCount'],
 			});
 		}
@@ -278,7 +285,7 @@ export const StaffAbsenceProcessMetaSchema = z
 		if (!meta.timedOut && meta.processedCount !== meta.totalCount) {
 			ctx.addIssue({
 				code: 'custom',
-				message: 'processedCount must equal totalCount when timedOut is false',
+				message: STAFF_ABSENCE_PROCESSED_COUNT_MISMATCH_MESSAGE,
 				path: ['processedCount'],
 			});
 		}
@@ -291,8 +298,8 @@ export const StaffAbsenceProcessResultSchema = z.object({
 	meta: StaffAbsenceProcessMetaSchema,
 	absenceStaffId: z.uuid(),
 	absenceStaffName: z.string().min(1),
-	startDate: JstDateStringOutputSchema,
-	endDate: JstDateStringOutputSchema,
+	startDate: StaffAbsenceDateStringSchema,
+	endDate: StaffAbsenceDateStringSchema,
 	affectedShifts: z.array(AffectedShiftWithCandidatesSchema),
 	summary: z.string().min(1),
 });

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -41,7 +41,6 @@ export const addStaffAbsenceDateRangeValidationIssues = (params: {
 	startField?: string;
 	endField?: string;
 }) => {
-	const startField = params.startField ?? 'startDate';
 	const endField = params.endField ?? 'endDate';
 	const parsedStartDate = StaffAbsenceDateInputSchema.safeParse(
 		params.startDate,
@@ -59,7 +58,7 @@ export const addStaffAbsenceDateRangeValidationIssues = (params: {
 		params.ctx.addIssue({
 			code: z.ZodIssueCode.custom,
 			message: STAFF_ABSENCE_DATE_ORDER_MESSAGE,
-			path: [startField],
+			path: [endField],
 		});
 	}
 

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -38,7 +38,6 @@ export const addStaffAbsenceDateRangeValidationIssues = (params: {
 	ctx: RefinementCtx;
 	startDate: unknown;
 	endDate: unknown;
-	startField?: string;
 	endField?: string;
 }) => {
 	const endField = params.endField ?? 'endDate';

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -1,7 +1,10 @@
 import { dateJst } from '@/utils/date';
 import { z } from 'zod';
 import { ShiftStatusSchema } from './shift';
-import { JstDateInputSchema } from './valueObjects/jstDate';
+import {
+	createJstDateInputSchema,
+	JstDateInputSchema,
+} from './valueObjects/jstDate';
 import { ServiceTypeIdSchema } from './valueObjects/serviceTypeId';
 import { TimeValueSchema } from './valueObjects/time';
 import { TimeRangeSchema } from './valueObjects/timeRange';
@@ -9,6 +12,59 @@ import { TimeRangeSchema } from './valueObjects/timeRange';
 const toJstDay = (date: Date) => dateJst(date).startOf('day');
 
 const JstDateStringOutputSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
+export const STAFF_ABSENCE_MAX_DAYS = 14;
+export const STAFF_ABSENCE_DATE_FORMAT_MESSAGE =
+	'日付はYYYY-MM-DD形式で指定してください';
+export const STAFF_ABSENCE_INVALID_DATE_MESSAGE =
+	'存在する日付を指定してください';
+export const STAFF_ABSENCE_DATE_ORDER_MESSAGE =
+	'開始日は終了日以前に設定してください';
+export const STAFF_ABSENCE_MAX_RANGE_MESSAGE = `欠勤期間は最大${STAFF_ABSENCE_MAX_DAYS}日間までです`;
+
+const StaffAbsenceDateInputSchema = createJstDateInputSchema({
+	formatMessage: STAFF_ABSENCE_DATE_FORMAT_MESSAGE,
+	invalidDateMessage: STAFF_ABSENCE_INVALID_DATE_MESSAGE,
+});
+
+export const addStaffAbsenceDateRangeValidationIssues = (params: {
+	ctx: z.core.$RefinementCtx;
+	startDate: unknown;
+	endDate: unknown;
+	startField?: string;
+	endField?: string;
+}) => {
+	const startField = params.startField ?? 'startDate';
+	const endField = params.endField ?? 'endDate';
+	const parsedStartDate = StaffAbsenceDateInputSchema.safeParse(
+		params.startDate,
+	);
+	const parsedEndDate = StaffAbsenceDateInputSchema.safeParse(params.endDate);
+
+	if (!parsedStartDate.success || !parsedEndDate.success) {
+		return;
+	}
+
+	const start = toJstDay(parsedStartDate.data);
+	const end = toJstDay(parsedEndDate.data);
+
+	if (start.isAfter(end)) {
+		params.ctx.addIssue({
+			code: 'custom',
+			message: STAFF_ABSENCE_DATE_ORDER_MESSAGE,
+			path: [startField],
+		});
+	}
+
+	const diffDays = end.diff(start, 'day');
+	if (diffDays > STAFF_ABSENCE_MAX_DAYS - 1) {
+		params.ctx.addIssue({
+			code: 'custom',
+			message: STAFF_ABSENCE_MAX_RANGE_MESSAGE,
+			path: [endField],
+		});
+	}
+};
 
 const addTimeRangeValidationIssues = (
 	ctx: z.core.$RefinementCtx,
@@ -34,27 +90,17 @@ const addTimeRangeValidationIssues = (
 export const StaffAbsenceInputSchema = z
 	.object({
 		staffId: z.uuid(),
-		startDate: JstDateInputSchema,
-		endDate: JstDateInputSchema,
+		startDate: StaffAbsenceDateInputSchema,
+		endDate: StaffAbsenceDateInputSchema,
 		memo: z.string().max(500).optional(),
 	})
-	.refine((v) => !toJstDay(v.startDate).isAfter(toJstDay(v.endDate)), {
-		message: 'startDate must be before or equal to endDate',
-		path: ['endDate'],
-	})
-	.refine(
-		(v) => {
-			const start = toJstDay(v.startDate);
-			const end = toJstDay(v.endDate);
-			const diffDays = end.diff(start, 'day');
-			// start=1日目, end=14日目 を許容するため diffDays<=13
-			return diffDays <= 13;
-		},
-		{
-			message: 'Date range must be within 14 days',
-			path: ['endDate'],
-		},
-	);
+	.superRefine((value, ctx) => {
+		addStaffAbsenceDateRangeValidationIssues({
+			ctx,
+			startDate: value.startDate,
+			endDate: value.endDate,
+		});
+	});
 
 export type StaffAbsenceInput = z.output<typeof StaffAbsenceInputSchema>;
 export type StaffAbsenceActionInput = z.input<typeof StaffAbsenceInputSchema>;
@@ -220,9 +266,22 @@ export const StaffAbsenceProcessMetaSchema = z
 		processedCount: z.number().int().min(0),
 		totalCount: z.number().int().min(0),
 	})
-	.refine((meta) => meta.processedCount <= meta.totalCount, {
-		message: 'processedCount must be less than or equal to totalCount',
-		path: ['processedCount'],
+	.superRefine((meta, ctx) => {
+		if (meta.processedCount > meta.totalCount) {
+			ctx.addIssue({
+				code: 'custom',
+				message: 'processedCount must be less than or equal to totalCount',
+				path: ['processedCount'],
+			});
+		}
+
+		if (!meta.timedOut && meta.processedCount !== meta.totalCount) {
+			ctx.addIssue({
+				code: 'custom',
+				message: 'processedCount must equal totalCount when timedOut is false',
+				path: ['processedCount'],
+			});
+		}
 	});
 export type StaffAbsenceProcessMeta = z.infer<
 	typeof StaffAbsenceProcessMetaSchema

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -1,5 +1,5 @@
 import { dateJst } from '@/utils/date';
-import { z } from 'zod';
+import { z, type RefinementCtx } from 'zod';
 import { ShiftStatusSchema } from './shift';
 import {
 	createJstDateInputSchema,
@@ -35,7 +35,7 @@ const StaffAbsenceDateStringSchema = createJstDateStringSchema({
 });
 
 export const addStaffAbsenceDateRangeValidationIssues = (params: {
-	ctx: z.core.$RefinementCtx;
+	ctx: RefinementCtx;
 	startDate: unknown;
 	endDate: unknown;
 	startField?: string;
@@ -57,7 +57,7 @@ export const addStaffAbsenceDateRangeValidationIssues = (params: {
 
 	if (start.isAfter(end)) {
 		params.ctx.addIssue({
-			code: 'custom',
+			code: z.ZodIssueCode.custom,
 			message: STAFF_ABSENCE_DATE_ORDER_MESSAGE,
 			path: [startField],
 		});
@@ -66,7 +66,7 @@ export const addStaffAbsenceDateRangeValidationIssues = (params: {
 	const diffDays = end.diff(start, 'day');
 	if (diffDays > STAFF_ABSENCE_MAX_DAYS - 1) {
 		params.ctx.addIssue({
-			code: 'custom',
+			code: z.ZodIssueCode.custom,
 			message: STAFF_ABSENCE_MAX_RANGE_MESSAGE,
 			path: [endField],
 		});
@@ -74,7 +74,7 @@ export const addStaffAbsenceDateRangeValidationIssues = (params: {
 };
 
 const addTimeRangeValidationIssues = (
-	ctx: z.core.$RefinementCtx,
+	ctx: RefinementCtx,
 	start: unknown,
 	end: unknown,
 	startField: string,
@@ -276,7 +276,7 @@ export const StaffAbsenceProcessMetaSchema = z
 	.superRefine((meta, ctx) => {
 		if (meta.processedCount > meta.totalCount) {
 			ctx.addIssue({
-				code: 'custom',
+				code: z.ZodIssueCode.custom,
 				message: STAFF_ABSENCE_PROCESSED_COUNT_EXCEEDS_TOTAL_MESSAGE,
 				path: ['processedCount'],
 			});
@@ -284,7 +284,7 @@ export const StaffAbsenceProcessMetaSchema = z
 
 		if (!meta.timedOut && meta.processedCount !== meta.totalCount) {
 			ctx.addIssue({
-				code: 'custom',
+				code: z.ZodIssueCode.custom,
 				message: STAFF_ABSENCE_PROCESSED_COUNT_MISMATCH_MESSAGE,
 				path: ['processedCount'],
 			});

--- a/src/models/shiftAdjustmentActionSchemas.ts
+++ b/src/models/shiftAdjustmentActionSchemas.ts
@@ -8,6 +8,8 @@ import { TimeRangeSchema } from './valueObjects/timeRange';
 
 const toJstDay = (date: Date) => dateJst(date).startOf('day');
 
+const JstDateStringOutputSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+
 const addTimeRangeValidationIssues = (
 	ctx: z.core.$RefinementCtx,
 	start: unknown,
@@ -186,6 +188,57 @@ export const ShiftAdjustmentShiftSuggestionSchema = z.object({
 });
 export type ShiftAdjustmentShiftSuggestion = z.infer<
 	typeof ShiftAdjustmentShiftSuggestionSchema
+>;
+
+export const StaffCandidatePrioritySchema = z.enum([
+	'past_assigned',
+	'assigned',
+	'available',
+]);
+export type StaffCandidatePriority = z.infer<
+	typeof StaffCandidatePrioritySchema
+>;
+
+export const StaffCandidateSchema = z.object({
+	staffId: z.uuid(),
+	staffName: z.string().min(1),
+	priority: StaffCandidatePrioritySchema,
+});
+export type StaffCandidate = z.infer<typeof StaffCandidateSchema>;
+
+export const AffectedShiftWithCandidatesSchema = z.object({
+	shift: ShiftSnapshotSchema,
+	candidates: z.array(StaffCandidateSchema),
+});
+export type AffectedShiftWithCandidates = z.infer<
+	typeof AffectedShiftWithCandidatesSchema
+>;
+
+export const StaffAbsenceProcessMetaSchema = z
+	.object({
+		timedOut: z.boolean(),
+		processedCount: z.number().int().min(0),
+		totalCount: z.number().int().min(0),
+	})
+	.refine((meta) => meta.processedCount <= meta.totalCount, {
+		message: 'processedCount must be less than or equal to totalCount',
+		path: ['processedCount'],
+	});
+export type StaffAbsenceProcessMeta = z.infer<
+	typeof StaffAbsenceProcessMetaSchema
+>;
+
+export const StaffAbsenceProcessResultSchema = z.object({
+	meta: StaffAbsenceProcessMetaSchema,
+	absenceStaffId: z.uuid(),
+	absenceStaffName: z.string().min(1),
+	startDate: JstDateStringOutputSchema,
+	endDate: JstDateStringOutputSchema,
+	affectedShifts: z.array(AffectedShiftWithCandidatesSchema),
+	summary: z.string().min(1),
+});
+export type StaffAbsenceProcessResult = z.infer<
+	typeof StaffAbsenceProcessResultSchema
 >;
 
 export const SuggestShiftAdjustmentsOutputSchema = z.object({

--- a/src/models/valueObjects/jstDate.test.ts
+++ b/src/models/valueObjects/jstDate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createJstDateStringSchema } from './jstDate';
+
+describe('createJstDateStringSchema', () => {
+	const schema = createJstDateStringSchema({
+		formatMessage: '日付はYYYY-MM-DD形式で指定してください',
+		invalidDateMessage: '存在する日付を指定してください',
+	});
+
+	it('形式不正は formatMessage のみを 1 件返す', () => {
+		const result = schema.safeParse('2026/02/01');
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toHaveLength(1);
+			expect(result.error.issues[0]?.message).toBe(
+				'日付はYYYY-MM-DD形式で指定してください',
+			);
+		}
+	});
+
+	it('形式が正しくても実在しない日付は invalidDateMessage のみを 1 件返す', () => {
+		const result = schema.safeParse('2026-02-31');
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toHaveLength(1);
+			expect(result.error.issues[0]?.message).toBe(
+				'存在する日付を指定してください',
+			);
+		}
+	});
+});

--- a/src/models/valueObjects/jstDate.ts
+++ b/src/models/valueObjects/jstDate.ts
@@ -50,7 +50,7 @@ export const createJstDateStringSchema = (
 	return z.string().superRefine((value, ctx) => {
 		if (!JST_DATE_REGEX.test(value)) {
 			ctx.addIssue({
-				code: 'custom',
+				code: z.ZodIssueCode.custom,
 				message: formatMessage,
 			});
 			return;
@@ -58,7 +58,7 @@ export const createJstDateStringSchema = (
 
 		if (!isValidJstDateString(value)) {
 			ctx.addIssue({
-				code: 'custom',
+				code: z.ZodIssueCode.custom,
 				message: invalidDateMessage,
 			});
 		}

--- a/src/models/valueObjects/jstDate.ts
+++ b/src/models/valueObjects/jstDate.ts
@@ -1,5 +1,59 @@
 import { parseJstDateString } from '@/utils/date';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import utc from 'dayjs/plugin/utc';
 import { z } from 'zod';
+
+dayjs.extend(customParseFormat);
+dayjs.extend(utc);
+
+export const JST_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+type JstDateValidationMessages = {
+	formatMessage?: string;
+	invalidDateMessage?: string;
+};
+
+const DEFAULT_JST_DATE_FORMAT_MESSAGE =
+	'Invalid date format. Expected YYYY-MM-DD';
+const DEFAULT_JST_DATE_INVALID_MESSAGE = 'Invalid date';
+
+/**
+ * 日付文字列が実在する日付かどうかを検証する
+ * UTC 固定で解析することで、環境のタイムゾーンに依存しない判定を行う
+ */
+export const isValidJstDateString = (dateStr: string): boolean => {
+	const parsed = dayjs.utc(dateStr, 'YYYY-MM-DD', true);
+	return parsed.isValid() && parsed.format('YYYY-MM-DD') === dateStr;
+};
+
+/**
+ * 2つの日付文字列の日数差を計算する（終了日 - 開始日 + 1）
+ */
+export const getInclusiveJstDateRangeDays = (
+	startDate: string,
+	endDate: string,
+): number => {
+	const start = dayjs.utc(startDate, 'YYYY-MM-DD', true);
+	const end = dayjs.utc(endDate, 'YYYY-MM-DD', true);
+	return end.diff(start, 'day') + 1;
+};
+
+export const createJstDateStringSchema = (
+	messages: JstDateValidationMessages = {},
+) => {
+	const formatMessage =
+		messages.formatMessage ?? DEFAULT_JST_DATE_FORMAT_MESSAGE;
+	const invalidDateMessage =
+		messages.invalidDateMessage ?? DEFAULT_JST_DATE_INVALID_MESSAGE;
+
+	return z
+		.string()
+		.regex(JST_DATE_REGEX, formatMessage)
+		.refine(isValidJstDateString, invalidDateMessage);
+};
+
+export const JstDateStringSchema = createJstDateStringSchema();
 
 /**
  * YYYY-MM-DD 形式の文字列を JST として解釈し Date に変換するスキーマ
@@ -7,10 +61,9 @@ import { z } from 'zod';
  *
  * 訪問介護の業務は日本時間で行われるため、日付は常に JST として解釈する
  */
-export const JstDateSchema = z
-	.string()
-	.regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format. Expected YYYY-MM-DD')
-	.transform((str) => parseJstDateString(str));
+export const JstDateSchema = JstDateStringSchema.transform((str) =>
+	parseJstDateString(str),
+);
 
 export type JstDate = z.infer<typeof JstDateSchema>;
 
@@ -18,14 +71,14 @@ export type JstDate = z.infer<typeof JstDateSchema>;
  * Date または YYYY-MM-DD 形式の文字列を受け付け、JST として Date に変換するスキーマ
  * フォームからは Date が、API からは文字列が来る可能性があるため両対応
  */
-export const JstDateInputSchema = z
-	.union([
-		z.date(),
-		z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format'),
-	])
-	.transform((val) => {
+export const createJstDateInputSchema = (
+	messages: JstDateValidationMessages = {},
+) =>
+	z.union([z.date(), createJstDateStringSchema(messages)]).transform((val) => {
 		if (val instanceof Date) return val;
 		return parseJstDateString(val);
 	});
+
+export const JstDateInputSchema = createJstDateInputSchema();
 
 export type JstDateInput = z.infer<typeof JstDateInputSchema>;

--- a/src/models/valueObjects/jstDate.ts
+++ b/src/models/valueObjects/jstDate.ts
@@ -47,10 +47,22 @@ export const createJstDateStringSchema = (
 	const invalidDateMessage =
 		messages.invalidDateMessage ?? DEFAULT_JST_DATE_INVALID_MESSAGE;
 
-	return z
-		.string()
-		.regex(JST_DATE_REGEX, formatMessage)
-		.refine(isValidJstDateString, invalidDateMessage);
+	return z.string().superRefine((value, ctx) => {
+		if (!JST_DATE_REGEX.test(value)) {
+			ctx.addIssue({
+				code: 'custom',
+				message: formatMessage,
+			});
+			return;
+		}
+
+		if (!isValidJstDateString(value)) {
+			ctx.addIssue({
+				code: 'custom',
+				message: invalidDateMessage,
+			});
+		}
+	});
 };
 
 export const JstDateStringSchema = createJstDateStringSchema();


### PR DESCRIPTION
## 概要
- `processStaffAbsence` の timeout 時に partial result を返す契約を PR 全体で整備
- tool の `outputSchema` と schema/service のバリデーション契約を揃え、日付検証を shared 化
- `StaffAbsenceProcessMetaSchema` を強化し、`timedOut=false` のときは `processedCount===totalCount` を保証

## 変更内容
- `processStaffAbsence` に `outputSchema` を追加し、返却契約を `StaffAbsenceProcessResultSchema` に固定
- `StaffAbsence` の日付 validation を `jstDate` に集約し、tool/schema/service で同じ日本語メッセージ・範囲制約を利用
- `StaffAbsenceProcessMetaSchema` に partial result / complete result の整合性チェックを追加
- 関連テストを更新して、存在しない日付・partial result 契約・tool 出力契約をカバー

## テスト
- `pnpm vitest run src/backend/tools/processStaffAbsence.test.ts src/models/shiftAdjustmentActionSchemas.test.ts src/backend/services/shiftAdjustmentSuggestionService.test.ts`
- `pnpm typecheck`

Closes #97
