### PR TITLE
fix: シフト調整チャットの対象シフト参照を強化

### DIFF
--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -426,6 +426,93 @@ describe('POST /api/chat/shift-adjustment', () => {
 		);
 	});
 
+	it('context.shifts.date が YYYY-MM-DD 形式でない場合は 400 エラーを返す', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: '調整してください' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_2,
+							staffName: 'スタッフA',
+							clientName: '利用者B',
+							date: '2025/01/20',
+							startTime: '09:00',
+							endTime: '11:00',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(400);
+		expect(mockStreamText).not.toHaveBeenCalled();
+	});
+
+	it('context.shifts.startTime/endTime が HH:mm 形式でない場合は 400 エラーを返す', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: '調整してください' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_2,
+							staffName: 'スタッフA',
+							clientName: '利用者B',
+							date: '2025-01-20',
+							startTime: '9:00',
+							endTime: '11:0',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(400);
+		expect(mockStreamText).not.toHaveBeenCalled();
+	});
+
+	it('context.shifts.startTime が endTime 以上の場合は 400 エラーを返す', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: '調整してください' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_2,
+							staffName: 'スタッフA',
+							clientName: '利用者B',
+							date: '2025-01-20',
+							startTime: '11:00',
+							endTime: '10:00',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(400);
+		expect(mockStreamText).not.toHaveBeenCalled();
+	});
+
 	it('単一シフトでは日時/サービス/利用者の確認質問不要の指示を system に含める', async () => {
 		const request = new Request('http://localhost/api/chat/shift-adjustment', {
 			method: 'POST',

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -426,6 +426,152 @@ describe('POST /api/chat/shift-adjustment', () => {
 		);
 	});
 
+	it('単一シフトでは日時/サービス/利用者の確認質問不要の指示を system に含める', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: 'このシフトの代替を探して' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_2,
+							staffName: 'スタッフA',
+							clientName: '利用者B',
+							date: '2025-01-20',
+							startTime: '09:00',
+							endTime: '11:00',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(
+					'このシフトを対象として扱い、日時・サービス内容・利用者の追加確認は行わないでください',
+				),
+			}),
+		);
+	});
+
+	it('serviceTypeId が physical-care のとき表示名「身体介護」を system に含める', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: '詳細を確認して' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_2,
+							staffName: 'スタッフA',
+							clientName: '利用者B',
+							date: '2025-01-20',
+							startTime: '09:00',
+							endTime: '11:00',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(
+					`身体介護（serviceTypeId: ${TEST_IDS.SERVICE_TYPE_2}）`,
+				),
+			}),
+		);
+	});
+
+	it('SYSTEM_PROMPT にサービス種別IDと表示名の対応表を含める', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: 'テスト' }],
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining('サービス種別IDと表示名の対応'),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining('life-support: 生活支援'),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining('physical-care: 身体介護'),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining('commute-support: 通院サポート'),
+			}),
+		);
+	});
+
+	it('複数シフトの場合は単一シフト向けの確認不要指示を含めない', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: '対象を調整して' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+							staffName: 'スタッフA',
+							clientName: '利用者B',
+							date: '2025-01-20',
+							startTime: '09:00',
+							endTime: '11:00',
+						},
+						{
+							id: TEST_IDS.SCHEDULE_2,
+							clientId: TEST_IDS.CLIENT_2,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_2,
+							staffName: 'スタッフC',
+							clientName: '利用者D',
+							date: '2025-01-21',
+							startTime: '10:00',
+							endTime: '12:00',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		const streamTextCall = mockStreamText.mock.calls[0]?.[0];
+		expect(streamTextCall.system).not.toContain(
+			'このシフトを対象として扱い、日時・サービス内容・利用者の追加確認は行わないでください',
+		);
+	});
+
 	it('GEMINI_API_KEY が未設定の場合は 500 エラーを返す', async () => {
 		// 環境変数を一時的にクリア
 		const originalKey = process.env.GEMINI_API_KEY;

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -455,6 +455,35 @@ describe('POST /api/chat/shift-adjustment', () => {
 		expect(mockStreamText).not.toHaveBeenCalled();
 	});
 
+	it('context.shifts.date が存在しない日付の場合は 400 エラーを返す', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: '調整してください' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_2,
+							staffName: 'スタッフA',
+							clientName: '利用者B',
+							date: '2025-02-31',
+							startTime: '09:00',
+							endTime: '11:00',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(400);
+		expect(mockStreamText).not.toHaveBeenCalled();
+	});
+
 	it('context.shifts.startTime/endTime が HH:mm 形式でない場合は 400 エラーを返す', async () => {
 		const request = new Request('http://localhost/api/chat/shift-adjustment', {
 			method: 'POST',

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -420,7 +420,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 		expect(mockStreamText).toHaveBeenCalledWith(
 			expect.objectContaining({
 				system: expect.stringContaining(
-					'コンテキストに clientId と serviceTypeId が含まれている',
+					'対象シフトが1件に特定できる場合（context.shifts が1件）',
 				),
 			}),
 		);

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -567,6 +567,9 @@ describe('POST /api/chat/shift-adjustment', () => {
 
 		expect(response.status).toBe(200);
 		const streamTextCall = mockStreamText.mock.calls[0]?.[0];
+		expect(streamTextCall.system).toContain(
+			'どのシフトを対象にするかをユーザーに確認してください',
+		);
 		expect(streamTextCall.system).not.toContain(
 			'このシフトを対象として扱い、日時・サービス内容・利用者の追加確認は行わないでください',
 		);

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -81,16 +81,39 @@ const extractContent = (msg: z.infer<typeof ChatMessageSchema>): string => {
 	return textFromParts || msg.content || '';
 };
 
-const ShiftContextItemSchema = z.object({
-	id: z.string().uuid(),
-	clientId: z.string().uuid(),
-	serviceTypeId: ServiceTypeIdSchema,
-	staffName: z.string().optional(),
-	clientName: z.string().optional(),
-	date: z.string(),
-	startTime: z.string(),
-	endTime: z.string(),
-});
+const SHIFT_CONTEXT_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const SHIFT_CONTEXT_TIME_REGEX = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+const toMinutesFromTime = (time: string): number => {
+	const [hour, minute] = time.split(':').map(Number);
+	return hour * 60 + minute;
+};
+
+const ShiftContextItemSchema = z
+	.object({
+		id: z.string().uuid(),
+		clientId: z.string().uuid(),
+		serviceTypeId: ServiceTypeIdSchema,
+		staffName: z.string().optional(),
+		clientName: z.string().optional(),
+		date: z.string().regex(SHIFT_CONTEXT_DATE_REGEX, {
+			message: 'date must be in YYYY-MM-DD format',
+		}),
+		startTime: z.string().regex(SHIFT_CONTEXT_TIME_REGEX, {
+			message: 'startTime must be in HH:mm format',
+		}),
+		endTime: z.string().regex(SHIFT_CONTEXT_TIME_REGEX, {
+			message: 'endTime must be in HH:mm format',
+		}),
+	})
+	.refine(
+		(shift) =>
+			toMinutesFromTime(shift.startTime) < toMinutesFromTime(shift.endTime),
+		{
+			message: 'startTime must be earlier than endTime',
+			path: ['endTime'],
+		},
+	);
 
 const ChatRequestSchema = z.object({
 	messages: z.array(ChatMessageSchema).min(1).max(50),

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -131,7 +131,8 @@ ${SERVICE_TYPE_LABELS_PROMPT}
     - 例: { date: "2024-04-01", startTime: { hour: 9, minute: 0 }, endTime: { hour: 10, minute: 0 } }
   - clientId を指定する場合は、必ず対応する serviceTypeId（サービス種別ID）も一緒に指定してください
     - 例: { clientId: "<利用者ID>", serviceTypeId: "<サービス種別ID>" }
-  - シフトコンテキストに clientId と serviceTypeId が含まれている場合は、ユーザーに確認せずその値を直接ツール呼び出しに使用してください
+  - 対象シフトが1件に特定できる場合（context.shifts が1件）は、ユーザーに確認せず clientId / serviceTypeId を直接ツール呼び出しに使用してください
+  - 対象シフトが複数ある場合は、どのシフトを対象にするかをユーザーに確認してからツールを呼び出してください
 - processStaffAbsence: スタッフの欠勤を登録し、影響シフトと代替候補を取得します
   - スタッフが休みになった場合に使用してください
   - staffId（UUID）、startDate、endDate（YYYY-MM-DD）を指定します
@@ -172,7 +173,8 @@ const buildContextPrompt = (context: ChatRequest['context']): string => {
 - このシフトを対象として扱い、日時・サービス内容・利用者の追加確認は行わないでください。
 - context.shifts[0] の date / clientId / serviceTypeId をそのまま tool 入力に使用してください。
 - startTime / endTime は文字列（例: "09:00"）を { hour, minute } オブジェクトに変換して tool 入力してください。
-  例: "09:00" → { hour: 9, minute: 0 }、"10:30" → { hour: 10, minute: 30 }`
+  例: "09:00" → { hour: 9, minute: 0 }、"10:30" → { hour: 10, minute: 30 }
+- ユーザーが代替ヘルパーの提案・空きヘルパーの探索を求めている場合は、追加質問なしで即座に searchAvailableHelpers を呼び出してください。`
 			: `
 
 ## 対象シフトの確認（重要）

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -170,7 +170,9 @@ const buildContextPrompt = (context: ChatRequest['context']): string => {
 ## 対象シフトの扱い（重要）
 - context.shifts[0] が今回の対象シフトです。
 - このシフトを対象として扱い、日時・サービス内容・利用者の追加確認は行わないでください。
-- context.shifts[0] の date / startTime / endTime / clientId / serviceTypeId をそのまま tool 入力に使用してください。`
+- context.shifts[0] の date / clientId / serviceTypeId をそのまま tool 入力に使用してください。
+- startTime / endTime は文字列（例: "09:00"）を { hour, minute } オブジェクトに変換して tool 入力してください。
+  例: "09:00" → { hour: 9, minute: 0 }、"10:30" → { hour: 10, minute: 30 }`
 			: `
 
 ## 対象シフトの確認（重要）

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -1,7 +1,10 @@
 import { createProcessStaffAbsenceTool } from '@/backend/tools/processStaffAbsence';
 import { createSearchAvailableHelpersTool } from '@/backend/tools/searchAvailableHelpers';
 import { createSearchStaffsTool } from '@/backend/tools/searchStaffs';
-import { ServiceTypeIdSchema } from '@/models/valueObjects/serviceTypeId';
+import {
+	ServiceTypeIdSchema,
+	ServiceTypeLabels,
+} from '@/models/valueObjects/serviceTypeId';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { stepCountIs, streamText } from 'ai';
@@ -101,6 +104,10 @@ const ChatRequestSchema = z.object({
 export type ChatMessage = z.infer<typeof ChatMessageSchema>;
 export type ChatRequest = z.infer<typeof ChatRequestSchema>;
 
+const SERVICE_TYPE_LABELS_PROMPT = Object.entries(ServiceTypeLabels)
+	.map(([serviceTypeId, label]) => `- ${serviceTypeId}: ${label}`)
+	.join('\n');
+
 const SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサポートするAIアシスタントです。
 
 ## あなたの役割
@@ -113,6 +120,9 @@ const SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサ
 2. 影響を受けるシフトを特定する
 3. 実行可能な調整案を提示する
 4. 各案のメリット・デメリットを説明する
+
+## サービス種別IDと表示名の対応
+${SERVICE_TYPE_LABELS_PROMPT}
 
 ## 利用可能なツール
 - searchAvailableHelpers: 指定した日時に空きのあるヘルパーを検索できます
@@ -147,12 +157,29 @@ const buildContextPrompt = (context: ChatRequest['context']): string => {
 		return '';
 	}
 
-	const shiftLines = context.shifts.map(
-		(s) =>
-			`- ${s.date} ${s.startTime}〜${s.endTime}: ${s.clientName ?? '(利用者不明)'} / ${s.staffName ?? '(未割当)'} (clientId: ${s.clientId}, serviceTypeId: ${s.serviceTypeId})`,
-	);
+	const shiftLines = context.shifts.map((s) => {
+		const serviceTypeLabel = ServiceTypeLabels[s.serviceTypeId];
 
-	return `\n\n## 現在のシフト情報\n${shiftLines.join('\n')}`;
+		return `- ${s.date} ${s.startTime}〜${s.endTime}: ${s.clientName ?? '(利用者不明)'} / ${s.staffName ?? '(未割当)'} (${serviceTypeLabel}（serviceTypeId: ${s.serviceTypeId}）, clientId: ${s.clientId})`;
+	});
+
+	const shiftSelectionPrompt =
+		context.shifts.length === 1
+			? `
+
+## 対象シフトの扱い（重要）
+- context.shifts[0] が今回の対象シフトです。
+- このシフトを対象として扱い、日時・サービス内容・利用者の追加確認は行わないでください。
+- context.shifts[0] の date / startTime / endTime / clientId / serviceTypeId をそのまま tool 入力に使用してください。`
+			: `
+
+## 対象シフトの確認（重要）
+- context.shifts に複数シフトがあるため、どのシフトを対象にするかをユーザーに確認してください。`;
+
+	return `
+
+## 現在のシフト情報
+${shiftLines.join('\n')}${shiftSelectionPrompt}`;
 };
 
 export const POST = async (request: Request): Promise<Response> => {

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -1,6 +1,7 @@
 import { createProcessStaffAbsenceTool } from '@/backend/tools/processStaffAbsence';
 import { createSearchAvailableHelpersTool } from '@/backend/tools/searchAvailableHelpers';
 import { createSearchStaffsTool } from '@/backend/tools/searchStaffs';
+import { createJstDateStringSchema } from '@/models/valueObjects/jstDate';
 import {
 	ServiceTypeIdSchema,
 	ServiceTypeLabels,
@@ -81,7 +82,6 @@ const extractContent = (msg: z.infer<typeof ChatMessageSchema>): string => {
 	return textFromParts || msg.content || '';
 };
 
-const SHIFT_CONTEXT_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const SHIFT_CONTEXT_TIME_REGEX = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 
 const toMinutesFromTime = (time: string): number => {
@@ -96,8 +96,9 @@ const ShiftContextItemSchema = z
 		serviceTypeId: ServiceTypeIdSchema,
 		staffName: z.string().optional(),
 		clientName: z.string().optional(),
-		date: z.string().regex(SHIFT_CONTEXT_DATE_REGEX, {
-			message: 'date must be in YYYY-MM-DD format',
+		date: createJstDateStringSchema({
+			formatMessage: 'date must be in YYYY-MM-DD format',
+			invalidDateMessage: 'date must be a valid date',
 		}),
 		startTime: z.string().regex(SHIFT_CONTEXT_TIME_REGEX, {
 			message: 'startTime must be in HH:mm format',


### PR DESCRIPTION
## 概要

選択済み対象シフトがあるのに AI が日時・サービス内容を聞き返してしまう問題を修正します。

Closes #116

---

## 症状

UI 上でシフトを選択済みの状態でチャットを開いても、AI が選択シフトの情報（日時・利用者・serviceTypeId）を前提にできず、「必要な日時・サービス内容を教えてください」と聞き返していました。

## 対応内容

### system prompt / context prompt の強化

| 対応 | 詳細 |
|---|---|
| 単一シフト時の確認抑制 | context.shifts が 1 件かつ date/startTime/endTime/serviceTypeId が揃っている場合、AI は確認なしで `searchAvailableHelpers` を呼び出すよう明示 |
| ServiceTypeLabels 対応表の提示 | `life-support` → 生活支援、`physical-care` → 身体介護、`commute-support` → 通院サポートの対応を system prompt に埋め込み、AI の serviceTypeId 誤解を防止 |
| 表示名の併記 | context prompt でシフト情報を表示する際に `serviceTypeId (表示名)` 形式で出力し、AI が迷わず tool 入力できるよう改善 |
| 複数シフト時の確認誘導 | context.shifts が複数ある場合のみ「どのシフトが対象か」確認するよう指示を追加 |

## テスト

```
pnpm test:ut --run
```

全ユニットテスト（複数シフト時の確認指示検証を含む）が通過。

---

## Checklist

- [x] 単一シフト選択時に追加質問なしで `searchAvailableHelpers` が呼ばれる
- [x] 複数シフト時のみ対象シフトを確認する
- [x] serviceTypeId と表示名の対応をプロンプトに明示
- [x] ユニットテスト追加・通過済み
