### PR TITLE
feat: AIチャットの proposal 確定実行機能を実装

### DIFF
--- a/src/app/actions/aiChatMutation.test.ts
+++ b/src/app/actions/aiChatMutation.test.ts
@@ -1,0 +1,211 @@
+import { AiOperationLogService } from '@/backend/services/aiOperationLogService';
+import { ServiceError, ShiftService } from '@/backend/services/shiftService';
+import { TEST_IDS } from '@/test/helpers/testIds';
+import { createSupabaseClient } from '@/utils/supabase/server';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { executeAiChatMutationAction } from './aiChatMutation';
+
+vi.mock('@/utils/supabase/server');
+vi.mock('@/backend/services/shiftService', async () => {
+	const actual = await vi.importActual<
+		typeof import('@/backend/services/shiftService')
+	>('@/backend/services/shiftService');
+	return {
+		...actual,
+		ShiftService: vi.fn(),
+	};
+});
+vi.mock('@/backend/services/aiOperationLogService', async () => {
+	const actual = await vi.importActual<
+		typeof import('@/backend/services/aiOperationLogService')
+	>('@/backend/services/aiOperationLogService');
+	return {
+		...actual,
+		AiOperationLogService: vi.fn(),
+	};
+});
+
+const mockSupabase = {
+	auth: {
+		getUser: vi.fn(),
+	},
+};
+
+const createMockShiftService = () => ({
+	executeAiChatMutationProposal: vi.fn(),
+	findActorOfficeId: vi.fn(),
+});
+
+const createMockAiOperationLogService = () => ({
+	logSilently: vi.fn(),
+});
+
+type MockShiftService = ReturnType<typeof createMockShiftService>;
+type MockAiOperationLogService = ReturnType<
+	typeof createMockAiOperationLogService
+>;
+
+let mockShiftService: MockShiftService;
+let mockAiOperationLogService: MockAiOperationLogService;
+
+const validInput = {
+	proposal: {
+		type: 'change_shift_staff' as const,
+		shiftId: TEST_IDS.SCHEDULE_1,
+		toStaffId: TEST_IDS.STAFF_2,
+		reason: '担当者変更',
+	},
+	allowlist: {
+		shiftIds: [TEST_IDS.SCHEDULE_1],
+		staffIds: [TEST_IDS.STAFF_2],
+	},
+};
+
+const mockAuthUser = (userId: string) => {
+	mockSupabase.auth.getUser.mockResolvedValue({
+		data: { user: { id: userId } },
+		error: null,
+	});
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockShiftService = createMockShiftService();
+	mockAiOperationLogService = createMockAiOperationLogService();
+	(createSupabaseClient as Mock).mockResolvedValue(mockSupabase);
+	(ShiftService as unknown as Mock).mockImplementation(function () {
+		return mockShiftService;
+	});
+	(AiOperationLogService as unknown as Mock).mockImplementation(function () {
+		return mockAiOperationLogService;
+	});
+});
+
+describe('executeAiChatMutationAction', () => {
+	it('未認証は401を返し、ログは記録しない', async () => {
+		mockSupabase.auth.getUser.mockResolvedValue({
+			data: { user: null },
+			error: null,
+		});
+
+		const result = await executeAiChatMutationAction(validInput);
+
+		expect(result).toEqual({ data: null, error: 'Unauthorized', status: 401 });
+		expect(
+			mockShiftService.executeAiChatMutationProposal,
+		).not.toHaveBeenCalled();
+		expect(mockAiOperationLogService.logSilently).not.toHaveBeenCalled();
+	});
+
+	it('入力バリデーションエラーは400を返す', async () => {
+		mockAuthUser(TEST_IDS.USER_1);
+
+		const result = await executeAiChatMutationAction({
+			...validInput,
+			proposal: {
+				...validInput.proposal,
+				shiftId: 'invalid-uuid',
+			},
+		});
+
+		expect(result.status).toBe(400);
+		expect(result.error).toBe('Validation failed');
+		expect(
+			mockShiftService.executeAiChatMutationProposal,
+		).not.toHaveBeenCalled();
+		expect(mockAiOperationLogService.logSilently).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ status: 403, message: 'Forbidden' },
+		{ status: 400, message: 'Proposal target shift is not allowed' },
+		{ status: 409, message: 'Client has conflicting shift' },
+	])('ServiceError(%s)を伝播する', async ({ status, message }) => {
+		mockAuthUser(TEST_IDS.USER_1);
+		mockShiftService.findActorOfficeId.mockResolvedValue(TEST_IDS.OFFICE_1);
+		mockShiftService.executeAiChatMutationProposal.mockRejectedValue(
+			new ServiceError(status, message, { reason: 'details' }),
+		);
+
+		const result = await executeAiChatMutationAction(validInput);
+
+		expect(result.status).toBe(status);
+		expect(result.error).toBe(message);
+		if (status === 403) {
+			expect(mockAiOperationLogService.logSilently).not.toHaveBeenCalled();
+		} else {
+			expect(mockAiOperationLogService.logSilently).toHaveBeenCalledTimes(1);
+		}
+	});
+
+	it('成功時はlogSilentlyを呼び出す', async () => {
+		mockAuthUser(TEST_IDS.USER_1);
+		mockShiftService.findActorOfficeId.mockResolvedValue(TEST_IDS.OFFICE_1);
+		mockShiftService.executeAiChatMutationProposal.mockResolvedValue({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			officeId: TEST_IDS.OFFICE_1,
+		});
+
+		const result = await executeAiChatMutationAction(validInput);
+
+		expect(result).toEqual({
+			data: {
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				officeId: TEST_IDS.OFFICE_1,
+			},
+			error: null,
+			status: 200,
+		});
+		expect(mockAiOperationLogService.logSilently).toHaveBeenCalledTimes(1);
+		expect(mockAiOperationLogService.logSilently).toHaveBeenCalledWith(
+			expect.objectContaining({
+				office_id: TEST_IDS.OFFICE_1,
+				actor_user_id: TEST_IDS.USER_1,
+				operation_type: 'change_shift_staff',
+				result: { status: 'success' },
+			}),
+		);
+	});
+
+	it('失敗時(400)はlogSilentlyを呼び出す', async () => {
+		mockAuthUser(TEST_IDS.USER_1);
+		mockShiftService.findActorOfficeId.mockResolvedValue(TEST_IDS.OFFICE_1);
+		mockShiftService.executeAiChatMutationProposal.mockRejectedValue(
+			new ServiceError(400, 'Proposal target staff is not allowed', {
+				reason: 'forbidden staff',
+			}),
+		);
+
+		const result = await executeAiChatMutationAction(validInput);
+
+		expect(result.status).toBe(400);
+		expect(result.error).toBe('Proposal target staff is not allowed');
+		expect(mockAiOperationLogService.logSilently).toHaveBeenCalledTimes(1);
+		expect(mockAiOperationLogService.logSilently).toHaveBeenCalledWith(
+			expect.objectContaining({
+				office_id: TEST_IDS.OFFICE_1,
+				result: {
+					status: 'error',
+					error: 'Proposal target staff is not allowed',
+					errorStatus: 400,
+				},
+			}),
+		);
+	});
+
+	it('ServiceError(403)ではlogSilentlyを呼び出さない', async () => {
+		mockAuthUser(TEST_IDS.USER_1);
+		mockShiftService.findActorOfficeId.mockResolvedValue(TEST_IDS.OFFICE_1);
+		mockShiftService.executeAiChatMutationProposal.mockRejectedValue(
+			new ServiceError(403, 'Forbidden'),
+		);
+
+		const result = await executeAiChatMutationAction(validInput);
+
+		expect(result.status).toBe(403);
+		expect(result.error).toBe('Forbidden');
+		expect(mockAiOperationLogService.logSilently).not.toHaveBeenCalled();
+	});
+});

--- a/src/app/actions/aiChatMutation.ts
+++ b/src/app/actions/aiChatMutation.ts
@@ -1,0 +1,94 @@
+'use server';
+
+import { AiOperationLogService } from '@/backend/services/aiOperationLogService';
+import { ServiceError, ShiftService } from '@/backend/services/shiftService';
+import type { ExecuteAiChatMutationResult } from '@/models/aiChatMutationProposal';
+import {
+	ExecuteAiChatMutationInputSchema,
+	ExecuteAiChatMutationResultSchema,
+} from '@/models/aiChatMutationProposal';
+import { createSupabaseClient } from '@/utils/supabase/server';
+import {
+	ActionResult,
+	errorResult,
+	logServerError,
+	successResult,
+} from './utils/actionResult';
+
+const getAuthUser = async () => {
+	const supabase = await createSupabaseClient();
+	const {
+		data: { user },
+		error,
+	} = await supabase.auth.getUser();
+	return { supabase, user, error } as const;
+};
+
+const shouldSkipAuditLog = (status: number): boolean =>
+	status === 401 || status === 403;
+
+export const executeAiChatMutationAction = async (
+	input: unknown,
+): Promise<ActionResult<ExecuteAiChatMutationResult>> => {
+	const { supabase, user, error } = await getAuthUser();
+	if (error || !user) return errorResult('Unauthorized', 401);
+
+	const parsedInput = ExecuteAiChatMutationInputSchema.safeParse(input);
+	if (!parsedInput.success) {
+		return errorResult('Validation failed', 400, parsedInput.error.flatten());
+	}
+
+	const service = new ShiftService(supabase);
+	const aiOperationLogService = new AiOperationLogService();
+	const actorOfficeId = await service.findActorOfficeId(user.id);
+
+	try {
+		const result = await service.executeAiChatMutationProposal(
+			user.id,
+			parsedInput.data.proposal,
+			parsedInput.data.allowlist,
+		);
+
+		await aiOperationLogService.logSilently({
+			office_id: result.officeId,
+			actor_user_id: user.id,
+			operation_type: result.type,
+			targets: {
+				shiftId: result.shiftId,
+			},
+			proposal: parsedInput.data.proposal,
+			request: parsedInput.data,
+			result: { status: 'success' },
+		});
+
+		return successResult(ExecuteAiChatMutationResultSchema.parse(result));
+	} catch (error) {
+		if (error instanceof ServiceError) {
+			if (!shouldSkipAuditLog(error.status) && actorOfficeId) {
+				await aiOperationLogService.logSilently({
+					office_id: actorOfficeId,
+					actor_user_id: user.id,
+					operation_type: parsedInput.data.proposal.type,
+					targets: {
+						shiftId: parsedInput.data.proposal.shiftId,
+					},
+					proposal: parsedInput.data.proposal,
+					request: parsedInput.data,
+					result: {
+						status: 'error',
+						error: error.message,
+						errorStatus: error.status,
+					},
+				});
+			}
+
+			if (error.status >= 500) {
+				logServerError(error);
+				return errorResult(error.message, error.status);
+			}
+			return errorResult(error.message, error.status, error.details);
+		}
+		logServerError(error);
+		throw error;
+	}
+};

--- a/src/app/actions/aiChatMutation.ts
+++ b/src/app/actions/aiChatMutation.ts
@@ -40,7 +40,6 @@ export const executeAiChatMutationAction = async (
 
 	const service = new ShiftService(supabase);
 	const aiOperationLogService = new AiOperationLogService();
-	const actorOfficeId = await service.findActorOfficeId(user.id);
 
 	try {
 		const result = await service.executeAiChatMutationProposal(
@@ -64,7 +63,11 @@ export const executeAiChatMutationAction = async (
 		return successResult(ExecuteAiChatMutationResultSchema.parse(result));
 	} catch (error) {
 		if (error instanceof ServiceError) {
-			if (!shouldSkipAuditLog(error.status) && actorOfficeId) {
+			const actorOfficeId = !shouldSkipAuditLog(error.status)
+				? await service.findActorOfficeId(user.id).catch(() => null)
+				: null;
+
+			if (actorOfficeId) {
 				await aiOperationLogService.logSilently({
 					office_id: actorOfficeId,
 					actor_user_id: user.id,

--- a/src/backend/services/shiftService.test.ts
+++ b/src/backend/services/shiftService.test.ts
@@ -2655,4 +2655,246 @@ describe('ShiftService', () => {
 			);
 		});
 	});
+
+	describe('executeAiChatMutationProposal', () => {
+		const userId = TEST_IDS.USER_1;
+		const shiftId = TEST_IDS.SCHEDULE_1;
+		const toStaffId = TEST_IDS.STAFF_2;
+		const adminStaff = createTestStaff({
+			auth_user_id: userId,
+			office_id: TEST_IDS.OFFICE_1,
+			role: 'admin',
+		});
+		const targetShift = createTestShift({
+			id: shiftId,
+			client_id: TEST_IDS.CLIENT_1,
+			service_type_id: 'physical-care',
+			staff_id: TEST_IDS.STAFF_1,
+			date: new Date('2030-05-10T00:00:00+09:00'),
+			time: {
+				start: { hour: 10, minute: 0 },
+				end: { hour: 11, minute: 0 },
+			},
+		});
+		const targetClient = createTestServiceUser({
+			id: TEST_IDS.CLIENT_1,
+			office_id: TEST_IDS.OFFICE_1,
+		});
+
+		it('should throw 403 for non-admin user', async () => {
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(
+				createTestStaff({ role: 'helper' }),
+			);
+
+			await expect(
+				service.executeAiChatMutationProposal(
+					userId,
+					{
+						type: 'update_shift_time',
+						shiftId,
+						startAt: '2030-05-10T10:00:00+09:00',
+						endAt: '2030-05-10T11:00:00+09:00',
+					},
+					{ shiftIds: [shiftId] },
+				),
+			).rejects.toThrow(
+				expect.objectContaining({ status: 403, message: 'Forbidden' }),
+			);
+		});
+
+		it('should throw 400 when proposal shiftId is not in allowlist', async () => {
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(adminStaff);
+
+			await expect(
+				service.executeAiChatMutationProposal(
+					userId,
+					{
+						type: 'update_shift_time',
+						shiftId,
+						startAt: '2030-05-10T10:30:00+09:00',
+						endAt: '2030-05-10T11:30:00+09:00',
+					},
+					{ shiftIds: [TEST_IDS.SCHEDULE_2] },
+				),
+			).rejects.toThrow(
+				expect.objectContaining({
+					status: 400,
+					message: 'Proposal target shift is not allowed',
+				}),
+			);
+		});
+
+		it('should throw 400 when toStaffId is not in allowlist for change_shift_staff', async () => {
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(adminStaff);
+			mockShiftRepo.findById.mockResolvedValueOnce(targetShift);
+			mockServiceUserRepo.findById.mockResolvedValueOnce(targetClient);
+
+			await expect(
+				service.executeAiChatMutationProposal(
+					userId,
+					{
+						type: 'change_shift_staff',
+						shiftId,
+						toStaffId,
+						reason: 'ヘルパー変更',
+					},
+					{ shiftIds: [shiftId], staffIds: [TEST_IDS.STAFF_3] },
+				),
+			).rejects.toThrow(
+				expect.objectContaining({
+					status: 400,
+					message: 'Proposal target staff is not allowed',
+				}),
+			);
+		});
+
+		it('should throw 409 when change_shift_staff causes staff conflict', async () => {
+			const candidateStaff = createTestStaff({
+				id: toStaffId,
+				office_id: TEST_IDS.OFFICE_1,
+				role: 'helper',
+			});
+			const candidateWithAbilities: StaffWithServiceTypes = {
+				...candidateStaff,
+				service_type_ids: ['physical-care'],
+			};
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(adminStaff);
+			mockShiftRepo.findById.mockResolvedValueOnce(targetShift);
+			mockServiceUserRepo.findById.mockResolvedValueOnce(targetClient);
+			mockStaffRepo.findById.mockResolvedValueOnce(candidateStaff);
+			mockStaffRepo.listByOffice.mockResolvedValueOnce([
+				candidateWithAbilities,
+			]);
+			mockShiftRepo.findStaffConflictingShifts.mockResolvedValueOnce([
+				createTestShift({ id: TEST_IDS.SCHEDULE_2 }),
+			]);
+
+			await expect(
+				service.executeAiChatMutationProposal(
+					userId,
+					{
+						type: 'change_shift_staff',
+						shiftId,
+						toStaffId,
+						reason: 'ヘルパー変更',
+					},
+					{ shiftIds: [shiftId], staffIds: [toStaffId] },
+				),
+			).rejects.toThrow(
+				expect.objectContaining({
+					status: 409,
+					message: 'Staff has conflicting shift',
+				}),
+			);
+		});
+
+		it('should throw 409 when update_shift_time causes client conflict', async () => {
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(adminStaff);
+			mockShiftRepo.findById.mockResolvedValueOnce({
+				...targetShift,
+				staff_id: null,
+				is_unassigned: true,
+			});
+			mockServiceUserRepo.findById.mockResolvedValueOnce(targetClient);
+			mockShiftRepo.findClientConflictingShifts.mockResolvedValueOnce([
+				createTestShift({ id: TEST_IDS.SCHEDULE_2 }),
+			]);
+
+			await expect(
+				service.executeAiChatMutationProposal(
+					userId,
+					{
+						type: 'update_shift_time',
+						shiftId,
+						startAt: '2030-05-11T10:00:00+09:00',
+						endAt: '2030-05-11T11:00:00+09:00',
+						reason: '日時変更',
+					},
+					{ shiftIds: [shiftId] },
+				),
+			).rejects.toThrow(
+				expect.objectContaining({
+					status: 409,
+					message: 'Client has conflicting shift',
+				}),
+			);
+		});
+
+		it('should return success result for change_shift_staff proposal (UC1)', async () => {
+			const candidateStaff = createTestStaff({
+				id: toStaffId,
+				office_id: TEST_IDS.OFFICE_1,
+				role: 'helper',
+			});
+			const candidateWithAbilities: StaffWithServiceTypes = {
+				...candidateStaff,
+				service_type_ids: ['physical-care'],
+			};
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(adminStaff);
+			mockShiftRepo.findById.mockResolvedValueOnce(targetShift);
+			mockServiceUserRepo.findById.mockResolvedValueOnce(targetClient);
+			mockStaffRepo.findById.mockResolvedValueOnce(candidateStaff);
+			mockStaffRepo.listByOffice.mockResolvedValueOnce([
+				candidateWithAbilities,
+			]);
+			mockShiftRepo.findStaffConflictingShifts.mockResolvedValueOnce([]);
+
+			const result = await service.executeAiChatMutationProposal(
+				userId,
+				{
+					type: 'change_shift_staff',
+					shiftId,
+					toStaffId,
+					reason: 'ヘルパー変更',
+				},
+				{ shiftIds: [shiftId], staffIds: [toStaffId] },
+			);
+
+			expect(mockShiftRepo.updateStaffAssignment).toHaveBeenCalledWith(
+				shiftId,
+				toStaffId,
+				'ヘルパー変更',
+			);
+			expect(result).toEqual({
+				type: 'change_shift_staff',
+				shiftId,
+				officeId: TEST_IDS.OFFICE_1,
+			});
+		});
+
+		it('should return success result for update_shift_time proposal (UC2)', async () => {
+			mockStaffRepo.findByAuthUserId.mockResolvedValueOnce(adminStaff);
+			mockShiftRepo.findById.mockResolvedValueOnce({
+				...targetShift,
+				staff_id: null,
+				is_unassigned: true,
+			});
+			mockServiceUserRepo.findById.mockResolvedValueOnce(targetClient);
+			mockShiftRepo.findClientConflictingShifts.mockResolvedValueOnce([]);
+
+			const result = await service.executeAiChatMutationProposal(
+				userId,
+				{
+					type: 'update_shift_time',
+					shiftId,
+					startAt: '2030-05-11T10:00:00+09:00',
+					endAt: '2030-05-11T11:00:00+09:00',
+					reason: '日時変更',
+				},
+				{ shiftIds: [shiftId] },
+			);
+
+			expect(mockShiftRepo.updateShiftSchedule).toHaveBeenCalledWith(shiftId, {
+				startTime: new Date('2030-05-11T10:00:00+09:00'),
+				endTime: new Date('2030-05-11T11:00:00+09:00'),
+				staffId: null,
+				notes: '日時変更',
+			});
+			expect(result).toEqual({
+				type: 'update_shift_time',
+				shiftId,
+				officeId: TEST_IDS.OFFICE_1,
+			});
+		});
+	});
 });

--- a/src/backend/services/shiftService.ts
+++ b/src/backend/services/shiftService.ts
@@ -3,6 +3,11 @@ import { ServiceUserRepository } from '@/backend/repositories/serviceUserReposit
 import { ShiftRepository } from '@/backend/repositories/shiftRepository';
 import { StaffRepository } from '@/backend/repositories/staffRepository';
 import { Database } from '@/backend/types/supabase';
+import {
+	type AiChatMutationProposal,
+	type ExecuteAiChatMutationResult,
+	type ProposalAllowlist,
+} from '@/models/aiChatMutationProposal';
 import { Shift } from '@/models/shift';
 import {
 	AssignStaffWithCascadeOutput,
@@ -89,6 +94,11 @@ export class ShiftService {
 		if (!staff) throw new ServiceError(404, 'Staff not found');
 		if (staff.role !== 'admin') throw new ServiceError(403, 'Forbidden');
 		return staff;
+	}
+
+	async findActorOfficeId(userId: string): Promise<string | null> {
+		const staff = await this.staffRepository.findByAuthUserId(userId);
+		return staff?.office_id ?? null;
 	}
 
 	/**
@@ -329,6 +339,148 @@ export class ShiftService {
 
 		await this.shiftRepository.create(shift);
 		return shift;
+	}
+
+	async executeAiChatMutationProposal(
+		userId: string,
+		proposal: AiChatMutationProposal,
+		allowlist: ProposalAllowlist,
+	): Promise<ExecuteAiChatMutationResult> {
+		const adminStaff = await this.getAdminStaff(userId);
+
+		if (!allowlist.shiftIds.includes(proposal.shiftId)) {
+			throw new ServiceError(400, 'Proposal target shift is not allowed');
+		}
+
+		const shift = await this.shiftRepository.findById(proposal.shiftId);
+		if (!shift) throw new ServiceError(404, 'Shift not found');
+
+		this.ensureShiftUpdatable(shift);
+		await this.ensureShiftInAdminOffice(adminStaff.office_id, shift);
+
+		if (proposal.type === 'change_shift_staff') {
+			return this.executeChangeShiftStaffProposal({
+				proposal,
+				allowlist,
+				adminOfficeId: adminStaff.office_id,
+				shift,
+			});
+		}
+
+		return this.executeUpdateShiftTimeProposal({
+			proposal,
+			adminOfficeId: adminStaff.office_id,
+			shift,
+		});
+	}
+
+	private async executeChangeShiftStaffProposal(params: {
+		proposal: Extract<AiChatMutationProposal, { type: 'change_shift_staff' }>;
+		allowlist: ProposalAllowlist;
+		adminOfficeId: string;
+		shift: Shift;
+	}): Promise<ExecuteAiChatMutationResult> {
+		if (!params.allowlist.staffIds?.includes(params.proposal.toStaffId)) {
+			throw new ServiceError(400, 'Proposal target staff is not allowed');
+		}
+
+		const targetWindow = this.buildShiftDateWindow(params.shift);
+		this.ensureNotChangingStaffForPastShift(targetWindow.start);
+
+		if (params.shift.staff_id === params.proposal.toStaffId) {
+			throw new ServiceError(
+				400,
+				'New staff is already assigned to this shift',
+			);
+		}
+
+		await this.ensureStaffAssignableForShift({
+			newStaffId: params.proposal.toStaffId,
+			adminOfficeId: params.adminOfficeId,
+			serviceTypeId: params.shift.service_type_id,
+		});
+
+		await this.ensureNoStaffConflicts({
+			staffId: params.proposal.toStaffId,
+			startTime: targetWindow.start,
+			endTime: targetWindow.end,
+			officeId: params.adminOfficeId,
+			excludeShiftId: params.shift.id,
+		});
+
+		await this.shiftRepository.updateStaffAssignment(
+			params.shift.id,
+			params.proposal.toStaffId,
+			params.proposal.reason,
+		);
+
+		return {
+			type: params.proposal.type,
+			shiftId: params.shift.id,
+			officeId: params.adminOfficeId,
+		};
+	}
+
+	private async executeUpdateShiftTimeProposal(params: {
+		proposal: Extract<AiChatMutationProposal, { type: 'update_shift_time' }>;
+		adminOfficeId: string;
+		shift: Shift;
+	}): Promise<ExecuteAiChatMutationResult> {
+		const newStartTime = new Date(params.proposal.startAt);
+		const newEndTime = new Date(params.proposal.endAt);
+		if (
+			Number.isNaN(newStartTime.getTime()) ||
+			Number.isNaN(newEndTime.getTime())
+		) {
+			throw new ServiceError(400, 'Invalid datetime');
+		}
+
+		this.ensureEndAfterStart(newStartTime, newEndTime);
+		this.ensureSameDayDatetimeRange(newStartTime, newEndTime);
+		this.ensureDateWithinShiftAdjustmentRange(params.shift.date, newStartTime);
+
+		const currentWindow = this.buildShiftDateWindow(params.shift);
+		if (
+			this.hasScheduleChanged({
+				currentStartTime: currentWindow.start,
+				currentEndTime: currentWindow.end,
+				newStartTime,
+				newEndTime,
+			})
+		) {
+			this.ensureNotMovingToPast(newStartTime);
+		}
+
+		await this.ensureNoClientConflicts({
+			clientId: params.shift.client_id,
+			startTime: newStartTime,
+			endTime: newEndTime,
+			officeId: params.adminOfficeId,
+			excludeShiftId: params.shift.id,
+		});
+
+		if (params.shift.staff_id) {
+			await this.ensureNoStaffConflicts({
+				staffId: params.shift.staff_id,
+				startTime: newStartTime,
+				endTime: newEndTime,
+				officeId: params.adminOfficeId,
+				excludeShiftId: params.shift.id,
+			});
+		}
+
+		await this.shiftRepository.updateShiftSchedule(params.shift.id, {
+			startTime: newStartTime,
+			endTime: newEndTime,
+			staffId: params.shift.staff_id ?? null,
+			notes: params.proposal.reason,
+		});
+
+		return {
+			type: params.proposal.type,
+			shiftId: params.shift.id,
+			officeId: params.adminOfficeId,
+		};
 	}
 
 	private ensureShiftUpdatable(shift: Shift) {

--- a/src/models/aiChatMutationProposal.test.ts
+++ b/src/models/aiChatMutationProposal.test.ts
@@ -4,6 +4,7 @@ import {
 	ALLOWLIST_MAX_SHIFT_IDS,
 	ALLOWLIST_MAX_STAFF_IDS,
 	AiChatMutationProposalSchema,
+	ExecuteAiChatMutationInputSchema,
 	ProposalAllowlistSchema,
 } from './aiChatMutationProposal';
 
@@ -148,5 +149,56 @@ describe('ProposalAllowlistSchema', () => {
 		});
 
 		expect(result.success).toBe(false);
+	});
+});
+
+describe('ExecuteAiChatMutationInputSchema', () => {
+	it('change_shift_staff で allowlist.staffIds が undefined の場合はエラー', () => {
+		const result = ExecuteAiChatMutationInputSchema.safeParse({
+			proposal: {
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			},
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+			},
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						path: ['allowlist', 'staffIds'],
+					}),
+				]),
+			);
+		}
+	});
+
+	it('change_shift_staff で allowlist.staffIds が空配列の場合はエラー', () => {
+		const result = ExecuteAiChatMutationInputSchema.safeParse({
+			proposal: {
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			},
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+				staffIds: [],
+			},
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						path: ['allowlist', 'staffIds'],
+					}),
+				]),
+			);
+		}
 	});
 });

--- a/src/models/aiChatMutationProposal.test.ts
+++ b/src/models/aiChatMutationProposal.test.ts
@@ -1,6 +1,11 @@
-import { TEST_IDS } from '@/test/helpers/testIds';
+import { TEST_IDS, createTestId } from '@/test/helpers/testIds';
 import { describe, expect, it } from 'vitest';
-import { AiChatMutationProposalSchema } from './aiChatMutationProposal';
+import {
+	ALLOWLIST_MAX_SHIFT_IDS,
+	ALLOWLIST_MAX_STAFF_IDS,
+	AiChatMutationProposalSchema,
+	ProposalAllowlistSchema,
+} from './aiChatMutationProposal';
 
 describe('AiChatMutationProposalSchema', () => {
 	it('change_shift_staff proposal を受け入れる', () => {
@@ -108,6 +113,38 @@ describe('AiChatMutationProposalSchema', () => {
 		const result = AiChatMutationProposalSchema.safeParse({
 			type: 'unsupported_type',
 			shiftId: TEST_IDS.SCHEDULE_1,
+		});
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('ProposalAllowlistSchema', () => {
+	it('shiftIds が空配列の場合はエラー', () => {
+		const result = ProposalAllowlistSchema.safeParse({
+			shiftIds: [],
+			staffIds: [TEST_IDS.STAFF_1],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it('shiftIds が上限を超える場合はエラー', () => {
+		const result = ProposalAllowlistSchema.safeParse({
+			shiftIds: Array.from({ length: ALLOWLIST_MAX_SHIFT_IDS + 1 }, () =>
+				createTestId(),
+			),
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it('staffIds が上限を超える場合はエラー', () => {
+		const result = ProposalAllowlistSchema.safeParse({
+			shiftIds: [TEST_IDS.SCHEDULE_1],
+			staffIds: Array.from({ length: ALLOWLIST_MAX_STAFF_IDS + 1 }, () =>
+				createTestId(),
+			),
 		});
 
 		expect(result.success).toBe(false);

--- a/src/models/aiChatMutationProposal.ts
+++ b/src/models/aiChatMutationProposal.ts
@@ -46,10 +46,31 @@ export const ProposalAllowlistSchema = z.object({
 	staffIds: z.array(z.uuid()).optional(),
 });
 
-export const ExecuteAiChatMutationInputSchema = z.object({
-	proposal: AiChatMutationProposalSchema,
-	allowlist: ProposalAllowlistSchema,
-});
+export const ExecuteAiChatMutationInputSchema = z
+	.object({
+		proposal: AiChatMutationProposalSchema,
+		allowlist: ProposalAllowlistSchema,
+	})
+	.superRefine((input, ctx) => {
+		if (input.proposal.type === 'change_shift_staff') {
+			if (input.allowlist.staffIds === undefined) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: 'allowlist.staffIds is required',
+					path: ['allowlist', 'staffIds'],
+				});
+				return;
+			}
+
+			if (input.allowlist.staffIds.length === 0) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: 'allowlist.staffIds must not be empty',
+					path: ['allowlist', 'staffIds'],
+				});
+			}
+		}
+	});
 
 export const ExecuteAiChatMutationResultSchema = z.object({
 	type: AiChatMutationProposalTypeSchema,

--- a/src/models/aiChatMutationProposal.ts
+++ b/src/models/aiChatMutationProposal.ts
@@ -41,6 +41,32 @@ export const AiChatMutationProposalSchema = z.discriminatedUnion('type', [
 	UpdateShiftTimeProposalSchema,
 ]);
 
+export const ProposalAllowlistSchema = z.object({
+	shiftIds: z.array(z.uuid()),
+	staffIds: z.array(z.uuid()).optional(),
+});
+
+export const ExecuteAiChatMutationInputSchema = z.object({
+	proposal: AiChatMutationProposalSchema,
+	allowlist: ProposalAllowlistSchema,
+});
+
+export const ExecuteAiChatMutationResultSchema = z.object({
+	type: AiChatMutationProposalTypeSchema,
+	shiftId: z.uuid(),
+	officeId: z.uuid(),
+});
+
 export type AiChatMutationProposal = z.infer<
 	typeof AiChatMutationProposalSchema
+>;
+
+export type ProposalAllowlist = z.infer<typeof ProposalAllowlistSchema>;
+
+export type ExecuteAiChatMutationInput = z.infer<
+	typeof ExecuteAiChatMutationInputSchema
+>;
+
+export type ExecuteAiChatMutationResult = z.infer<
+	typeof ExecuteAiChatMutationResultSchema
 >;

--- a/src/models/aiChatMutationProposal.ts
+++ b/src/models/aiChatMutationProposal.ts
@@ -9,6 +9,9 @@ export const AiChatMutationProposalTypeSchema = z.enum(
 	AI_CHAT_MUTATION_PROPOSAL_TYPES,
 );
 
+export const ALLOWLIST_MAX_SHIFT_IDS = 200;
+export const ALLOWLIST_MAX_STAFF_IDS = 500;
+
 const ChangeShiftStaffProposalSchema = z.object({
 	type: z.literal('change_shift_staff'),
 	shiftId: z.uuid(),
@@ -42,8 +45,8 @@ export const AiChatMutationProposalSchema = z.discriminatedUnion('type', [
 ]);
 
 export const ProposalAllowlistSchema = z.object({
-	shiftIds: z.array(z.uuid()),
-	staffIds: z.array(z.uuid()).optional(),
+	shiftIds: z.array(z.uuid()).min(1).max(ALLOWLIST_MAX_SHIFT_IDS),
+	staffIds: z.array(z.uuid()).max(ALLOWLIST_MAX_STAFF_IDS).optional(),
 });
 
 export const ExecuteAiChatMutationInputSchema = z


### PR DESCRIPTION
AIチャットのプロポーザル確定実行（管理者のみ）機能を実装します。

## 変更内容
- AIチャットの proposal 確定実行機能の実装
- allowlist の強制
- 競合時のエラーレスポンス（409 Conflict）
- 監査ログの記録（401/403 エラーはスキップ）

Closes #121