### PR TITLE
[Issue #122 Phase1] ProposalConfirmCard コンポーネントの追加

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.stories.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.stories.tsx
@@ -1,0 +1,59 @@
+import { TEST_IDS } from '@/test/helpers/testIds';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { fn } from 'storybook/test';
+import { ProposalConfirmCard } from './ProposalConfirmCard';
+
+const meta = {
+	title: 'Admin/WeeklySchedules/AdjustmentChatDialog/ProposalConfirmCard',
+	component: ProposalConfirmCard,
+	tags: ['autodocs'],
+	args: {
+		onConfirm: fn(),
+		onDismiss: fn(),
+	},
+} satisfies Meta<typeof ProposalConfirmCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ChangeShiftStaff: Story = {
+	args: {
+		proposal: {
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '担当者の急病のため',
+		},
+		beforeValue: '山田 太郎',
+		afterValue: '佐藤 花子',
+	},
+};
+
+export const ChangeShiftStaffStreaming: Story = {
+	args: {
+		proposal: {
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '担当者の急病のため',
+		},
+		beforeValue: '山田 太郎',
+		afterValue: '佐藤 花子',
+		isStreaming: true,
+	},
+};
+
+export const UpdateShiftTimeExecuting: Story = {
+	args: {
+		proposal: {
+			type: 'update_shift_time',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			startAt: '2026-02-24T11:00:00+09:00',
+			endAt: '2026-02-24T12:00:00+09:00',
+			reason: '利用者都合のため',
+		},
+		beforeValue: '2026/02/24 10:00-11:00',
+		afterValue: '2026/02/24 11:00-12:00',
+		isExecuting: true,
+	},
+};

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.test.tsx
@@ -1,7 +1,7 @@
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import { ProposalConfirmCard } from './ProposalConfirmCard';
 
 const createChangeStaffProposal = () => ({
@@ -20,6 +20,17 @@ const createUpdateTimeProposal = () => ({
 });
 
 describe('ProposalConfirmCard', () => {
+	it('onConfirm / onDismiss は async 関数を受け取れる型になっている', () => {
+		type Props = React.ComponentProps<typeof ProposalConfirmCard>;
+
+		expectTypeOf<Props['onConfirm']>().toEqualTypeOf<
+			() => void | Promise<void>
+		>();
+		expectTypeOf<Props['onDismiss']>().toEqualTypeOf<
+			() => void | Promise<void>
+		>();
+	});
+
 	it('streaming 中は Confirm ボタンが disabled になり、クリックしても onConfirm が呼ばれない', async () => {
 		const user = userEvent.setup();
 		const onConfirm = vi.fn();

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.test.tsx
@@ -35,7 +35,7 @@ describe('ProposalConfirmCard', () => {
 			/>,
 		);
 
-		const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+		const confirmButton = screen.getByRole('button', { name: '確定' });
 		expect(confirmButton).toBeDisabled();
 
 		await user.click(confirmButton);
@@ -54,10 +54,10 @@ describe('ProposalConfirmCard', () => {
 			/>,
 		);
 
-		expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+		expect(screen.getByRole('button', { name: '確定' })).toBeDisabled();
 	});
 
-	it('Confirm / Dismiss クリックで callback が呼ばれる', async () => {
+	it('確定 / キャンセル クリックで callback が呼ばれる', async () => {
 		const user = userEvent.setup();
 		const onConfirm = vi.fn();
 		const onDismiss = vi.fn();
@@ -72,14 +72,14 @@ describe('ProposalConfirmCard', () => {
 			/>,
 		);
 
-		await user.click(screen.getByRole('button', { name: 'Confirm' }));
-		await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+		await user.click(screen.getByRole('button', { name: '確定' }));
+		await user.click(screen.getByRole('button', { name: 'キャンセル' }));
 
 		expect(onConfirm).toHaveBeenCalledTimes(1);
 		expect(onDismiss).toHaveBeenCalledTimes(1);
 	});
 
-	it('change_shift_staff の Before / After と reason を表示する', () => {
+	it('change_shift_staff の 変更前 / 変更後 と 理由 を表示する', () => {
 		render(
 			<ProposalConfirmCard
 				proposal={createChangeStaffProposal()}
@@ -91,10 +91,11 @@ describe('ProposalConfirmCard', () => {
 		);
 
 		expect(screen.getByText('担当者変更')).toBeInTheDocument();
-		expect(screen.getByText('Before')).toBeInTheDocument();
-		expect(screen.getByText('After')).toBeInTheDocument();
+		expect(screen.getByText('変更前')).toBeInTheDocument();
+		expect(screen.getByText('変更後')).toBeInTheDocument();
 		expect(screen.getByText('山田 太郎')).toBeInTheDocument();
 		expect(screen.getByText('佐藤 花子')).toBeInTheDocument();
+		expect(screen.getByText('理由')).toBeInTheDocument();
 		expect(screen.getByText('担当者の急病のため')).toBeInTheDocument();
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.test.tsx
@@ -1,0 +1,100 @@
+import { TEST_IDS } from '@/test/helpers/testIds';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ProposalConfirmCard } from './ProposalConfirmCard';
+
+const createChangeStaffProposal = () => ({
+	type: 'change_shift_staff' as const,
+	shiftId: TEST_IDS.SCHEDULE_1,
+	toStaffId: TEST_IDS.STAFF_2,
+	reason: '担当者の急病のため',
+});
+
+const createUpdateTimeProposal = () => ({
+	type: 'update_shift_time' as const,
+	shiftId: TEST_IDS.SCHEDULE_1,
+	startAt: '2026-02-24T11:00:00+09:00',
+	endAt: '2026-02-24T12:00:00+09:00',
+	reason: '利用者都合のため',
+});
+
+describe('ProposalConfirmCard', () => {
+	it('streaming 中は Confirm ボタンが disabled になり、クリックしても onConfirm が呼ばれない', async () => {
+		const user = userEvent.setup();
+		const onConfirm = vi.fn();
+
+		render(
+			<ProposalConfirmCard
+				proposal={createChangeStaffProposal()}
+				beforeValue="山田 太郎"
+				afterValue="佐藤 花子"
+				isStreaming={true}
+				onConfirm={onConfirm}
+				onDismiss={vi.fn()}
+			/>,
+		);
+
+		const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+		expect(confirmButton).toBeDisabled();
+
+		await user.click(confirmButton);
+		expect(onConfirm).not.toHaveBeenCalled();
+	});
+
+	it('executing 中は Confirm ボタンが disabled になる', () => {
+		render(
+			<ProposalConfirmCard
+				proposal={createUpdateTimeProposal()}
+				beforeValue="10:00-11:00"
+				afterValue="11:00-12:00"
+				isExecuting={true}
+				onConfirm={vi.fn()}
+				onDismiss={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+	});
+
+	it('Confirm / Dismiss クリックで callback が呼ばれる', async () => {
+		const user = userEvent.setup();
+		const onConfirm = vi.fn();
+		const onDismiss = vi.fn();
+
+		render(
+			<ProposalConfirmCard
+				proposal={createChangeStaffProposal()}
+				beforeValue="山田 太郎"
+				afterValue="佐藤 花子"
+				onConfirm={onConfirm}
+				onDismiss={onDismiss}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Confirm' }));
+		await user.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+		expect(onConfirm).toHaveBeenCalledTimes(1);
+		expect(onDismiss).toHaveBeenCalledTimes(1);
+	});
+
+	it('change_shift_staff の Before / After と reason を表示する', () => {
+		render(
+			<ProposalConfirmCard
+				proposal={createChangeStaffProposal()}
+				beforeValue="山田 太郎"
+				afterValue="佐藤 花子"
+				onConfirm={vi.fn()}
+				onDismiss={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
+		expect(screen.getByText('Before')).toBeInTheDocument();
+		expect(screen.getByText('After')).toBeInTheDocument();
+		expect(screen.getByText('山田 太郎')).toBeInTheDocument();
+		expect(screen.getByText('佐藤 花子')).toBeInTheDocument();
+		expect(screen.getByText('担当者の急病のため')).toBeInTheDocument();
+	});
+});

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
@@ -1,0 +1,73 @@
+import type { AiChatMutationProposal } from '@/models/aiChatMutationProposal';
+
+type ProposalConfirmCardProps = {
+	proposal: AiChatMutationProposal;
+	beforeValue: string;
+	afterValue: string;
+	isStreaming?: boolean;
+	isExecuting?: boolean;
+	onConfirm: () => void;
+	onDismiss: () => void;
+};
+
+const getOperationLabel = (
+	proposalType: AiChatMutationProposal['type'],
+): string => {
+	switch (proposalType) {
+		case 'change_shift_staff':
+			return '担当者変更';
+		case 'update_shift_time':
+			return '時間変更';
+	}
+};
+
+export const ProposalConfirmCard = ({
+	proposal,
+	beforeValue,
+	afterValue,
+	isStreaming = false,
+	isExecuting = false,
+	onConfirm,
+	onDismiss,
+}: ProposalConfirmCardProps) => {
+	const isConfirmDisabled = isStreaming || isExecuting;
+
+	return (
+		<div className="rounded-lg border border-info/30 bg-base-100 p-4">
+			<p className="text-sm font-semibold text-info">
+				{getOperationLabel(proposal.type)}
+			</p>
+			<div className="mt-3 space-y-2 text-sm">
+				<div className="grid grid-cols-[56px_1fr] gap-x-2">
+					<span className="text-base-content/70">Before</span>
+					<span className="font-medium">{beforeValue}</span>
+				</div>
+				<div className="grid grid-cols-[56px_1fr] gap-x-2">
+					<span className="text-base-content/70">After</span>
+					<span className="font-medium">{afterValue}</span>
+				</div>
+				<div className="grid grid-cols-[56px_1fr] gap-x-2">
+					<span className="text-base-content/70">Reason</span>
+					<span>{proposal.reason ?? '（理由なし）'}</span>
+				</div>
+			</div>
+			<div className="mt-4 flex justify-end gap-2">
+				<button
+					type="button"
+					className="btn btn-ghost btn-sm"
+					onClick={onDismiss}
+				>
+					Dismiss
+				</button>
+				<button
+					type="button"
+					className="btn btn-sm btn-primary"
+					onClick={onConfirm}
+					disabled={isConfirmDisabled}
+				>
+					Confirm
+				</button>
+			</div>
+		</div>
+	);
+};

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
@@ -6,8 +6,8 @@ type ProposalConfirmCardProps = {
 	afterValue: string;
 	isStreaming?: boolean;
 	isExecuting?: boolean;
-	onConfirm: () => void;
-	onDismiss: () => void;
+	onConfirm: () => void | Promise<void>;
+	onDismiss: () => void | Promise<void>;
 };
 
 const getOperationLabel = (

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
@@ -13,12 +13,12 @@ type ProposalConfirmCardProps = {
 const getOperationLabel = (
 	proposalType: AiChatMutationProposal['type'],
 ): string => {
-	switch (proposalType) {
-		case 'change_shift_staff':
-			return '担当者変更';
-		case 'update_shift_time':
-			return '時間変更';
-	}
+	const operationLabelMap = {
+		change_shift_staff: '担当者変更',
+		update_shift_time: '時間変更',
+	} satisfies Record<AiChatMutationProposal['type'], string>;
+
+	return operationLabelMap[proposalType];
 };
 
 export const ProposalConfirmCard = ({

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
@@ -39,15 +39,15 @@ export const ProposalConfirmCard = ({
 			</p>
 			<div className="mt-3 space-y-2 text-sm">
 				<div className="grid grid-cols-[56px_1fr] gap-x-2">
-					<span className="text-base-content/70">Before</span>
+					<span className="text-base-content/70">変更前</span>
 					<span className="font-medium">{beforeValue}</span>
 				</div>
 				<div className="grid grid-cols-[56px_1fr] gap-x-2">
-					<span className="text-base-content/70">After</span>
+					<span className="text-base-content/70">変更後</span>
 					<span className="font-medium">{afterValue}</span>
 				</div>
 				<div className="grid grid-cols-[56px_1fr] gap-x-2">
-					<span className="text-base-content/70">Reason</span>
+					<span className="text-base-content/70">理由</span>
 					<span>{proposal.reason ?? '（理由なし）'}</span>
 				</div>
 			</div>
@@ -57,7 +57,7 @@ export const ProposalConfirmCard = ({
 					className="btn btn-ghost btn-sm"
 					onClick={onDismiss}
 				>
-					Dismiss
+					キャンセル
 				</button>
 				<button
 					type="button"
@@ -65,7 +65,7 @@ export const ProposalConfirmCard = ({
 					onClick={onConfirm}
 					disabled={isConfirmDisabled}
 				>
-					Confirm
+					確定
 				</button>
 			</div>
 		</div>

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/index.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/index.ts
@@ -1,0 +1,1 @@
+export { ProposalConfirmCard } from './ProposalConfirmCard';


### PR DESCRIPTION
## 概要

Issue #122 の Phase1 として、チャット内でAIプロポーザルを確認・確定するための `ProposalConfirmCard` コンポーネントを新規追加します。

Refs #122

---

## 変更内容

| ファイル | 種別 | 内容 |
|---|---|---|
| `ProposalConfirmCard.tsx` | 新規追加 | プロポーザル確認UIコンポーネント本体 |
| `ProposalConfirmCard.test.tsx` | 新規追加 | ユニットテスト |
| `ProposalConfirmCard.stories.tsx` | 新規追加 | Storybook ストーリー（通常・streaming・executing各ケース） |
| `index.ts` | 新規追加 | バレルエクスポート |

### 主な実装内容

- proposal の概要・Before/After 差分を表示するカード UI
- **Confirm ボタンの無効化制御**
  - `isStreaming` が `true` の間は無効化（ストリーミング完了待ち）
  - `isExecuting` が `true` の間は無効化（二重送信防止）
- Storybook に streaming 中ケースを追加

---

## テスト実行結果

```
pnpm test:ut --run
114 passed | 1 skipped
```

---

## 今後のフェーズ予定

| フェーズ | 内容 |
|---|---|
| Phase 2 | `useProposalExecution` フックの実装（server action 呼び出し・成功/失敗ハンドリング） |
| Phase 3 | AdjustmentChatDialog への `ProposalConfirmCard` 統合 |