### PR TITLE
[Issue #122 Phase2] useProposalExecution フックの実装

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.test.tsx
@@ -1,0 +1,194 @@
+import type { ActionResult } from '@/app/actions/utils/actionResult';
+import type {
+	AiChatMutationProposal,
+	ExecuteAiChatMutationResult,
+	ProposalAllowlist,
+} from '@/models/aiChatMutationProposal';
+import { TEST_IDS } from '@/test/helpers/testIds';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	CONFLICT_ERROR_MESSAGE,
+	DEFAULT_ERROR_MESSAGE,
+	useProposalExecution,
+} from './useProposalExecution';
+
+const executeAiChatMutationActionMock = vi.hoisted(() => vi.fn());
+const handleActionResultMock = vi.hoisted(() => vi.fn());
+const refreshMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/app/actions/aiChatMutation', () => ({
+	executeAiChatMutationAction: executeAiChatMutationActionMock,
+}));
+
+vi.mock('@/hooks/useActionResultHandler', () => ({
+	useActionResultHandler: () => ({
+		handleActionResult: handleActionResultMock,
+	}),
+}));
+
+vi.mock('next/navigation', () => ({
+	useRouter: () => ({
+		refresh: refreshMock,
+	}),
+}));
+
+const proposal: AiChatMutationProposal = {
+	type: 'change_shift_staff',
+	shiftId: TEST_IDS.SCHEDULE_1,
+	toStaffId: TEST_IDS.STAFF_2,
+};
+
+const allowlist: ProposalAllowlist = {
+	shiftIds: [TEST_IDS.SCHEDULE_1],
+	staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],
+};
+
+const createResult = (
+	overrides: Partial<ActionResult<ExecuteAiChatMutationResult>>,
+): ActionResult<ExecuteAiChatMutationResult> => ({
+	data: {
+		type: 'change_shift_staff',
+		shiftId: TEST_IDS.SCHEDULE_1,
+		officeId: TEST_IDS.OFFICE_1,
+	},
+	error: null,
+	status: 200,
+	...overrides,
+});
+
+const createDeferred = <T,>() => {
+	let resolve: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return {
+		promise,
+		resolve: resolve!,
+	};
+};
+
+describe('useProposalExecution', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		handleActionResultMock.mockImplementation((result, options) => {
+			if (result.error) {
+				options?.onError?.(result.error, result);
+				return false;
+			}
+			options?.onSuccess?.(result.data ?? null);
+			return true;
+		});
+	});
+
+	it('成功時にrefreshとonSuccessが呼ばれ、isExecutingが切り替わる', async () => {
+		const onSuccess = vi.fn();
+		const deferred =
+			createDeferred<ActionResult<ExecuteAiChatMutationResult>>();
+		executeAiChatMutationActionMock.mockReturnValue(deferred.promise);
+
+		const { result } = renderHook(() =>
+			useProposalExecution({ proposal, allowlist, onSuccess }),
+		);
+
+		act(() => {
+			void result.current.execute();
+		});
+
+		await waitFor(() => {
+			expect(result.current.isExecuting).toBe(true);
+		});
+
+		deferred.resolve(createResult({}));
+
+		await waitFor(() => {
+			expect(result.current.isExecuting).toBe(false);
+		});
+
+		expect(executeAiChatMutationActionMock).toHaveBeenCalledWith({
+			proposal,
+			allowlist,
+		});
+		expect(refreshMock).toHaveBeenCalledTimes(1);
+		expect(onSuccess).toHaveBeenCalledWith({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			officeId: TEST_IDS.OFFICE_1,
+		});
+	});
+
+	it('500エラー時はrefreshしない', async () => {
+		executeAiChatMutationActionMock.mockResolvedValue(
+			createResult({ data: null, error: 'Internal Server Error', status: 500 }),
+		);
+
+		const { result } = renderHook(() =>
+			useProposalExecution({ proposal, allowlist }),
+		);
+
+		await act(async () => {
+			await result.current.execute();
+		});
+
+		expect(refreshMock).not.toHaveBeenCalled();
+		expect(handleActionResultMock).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 500 }),
+			expect.objectContaining({ errorMessage: DEFAULT_ERROR_MESSAGE }),
+		);
+	});
+
+	it('409エラー時は専用メッセージを渡す', async () => {
+		executeAiChatMutationActionMock.mockResolvedValue(
+			createResult({ data: null, error: 'Conflict', status: 409 }),
+		);
+
+		const { result } = renderHook(() =>
+			useProposalExecution({ proposal, allowlist }),
+		);
+
+		await act(async () => {
+			await result.current.execute();
+		});
+
+		expect(handleActionResultMock).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 409 }),
+			expect.objectContaining({ errorMessage: CONFLICT_ERROR_MESSAGE }),
+		);
+	});
+
+	it('実行中の二重送信を防止する', async () => {
+		const deferred =
+			createDeferred<ActionResult<ExecuteAiChatMutationResult>>();
+		executeAiChatMutationActionMock.mockReturnValue(deferred.promise);
+
+		const { result } = renderHook(() =>
+			useProposalExecution({ proposal, allowlist }),
+		);
+
+		act(() => {
+			void result.current.execute();
+			void result.current.execute();
+		});
+
+		expect(executeAiChatMutationActionMock).toHaveBeenCalledTimes(1);
+
+		deferred.resolve(createResult({}));
+		await waitFor(() => {
+			expect(result.current.isExecuting).toBe(false);
+		});
+	});
+
+	it('proposalがnullならno-op', async () => {
+		const { result } = renderHook(() =>
+			useProposalExecution({ proposal: null, allowlist }),
+		);
+
+		await act(async () => {
+			await result.current.execute();
+		});
+
+		expect(executeAiChatMutationActionMock).not.toHaveBeenCalled();
+		expect(handleActionResultMock).not.toHaveBeenCalled();
+		expect(result.current.isExecuting).toBe(false);
+	});
+});

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.test.tsx
@@ -156,6 +156,28 @@ describe('useProposalExecution', () => {
 		);
 	});
 
+	it('Actionが例外をthrowしてもデフォルトエラートーストを表示しisExecutingを戻す', async () => {
+		executeAiChatMutationActionMock.mockRejectedValue(new Error('Unexpected'));
+
+		const { result } = renderHook(() =>
+			useProposalExecution({ proposal, allowlist }),
+		);
+
+		await act(async () => {
+			await result.current.execute();
+		});
+
+		expect(handleActionResultMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: null,
+				error: DEFAULT_ERROR_MESSAGE,
+				status: 500,
+			}),
+			expect.objectContaining({ errorMessage: DEFAULT_ERROR_MESSAGE }),
+		);
+		expect(result.current.isExecuting).toBe(false);
+	});
+
 	it('実行中の二重送信を防止する', async () => {
 		const deferred =
 			createDeferred<ActionResult<ExecuteAiChatMutationResult>>();

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.test.tsx
@@ -213,4 +213,17 @@ describe('useProposalExecution', () => {
 		expect(handleActionResultMock).not.toHaveBeenCalled();
 		expect(result.current.isExecuting).toBe(false);
 	});
+
+	it('dismissでonDismissが呼ばれる', () => {
+		const onDismiss = vi.fn();
+		const { result } = renderHook(() =>
+			useProposalExecution({ proposal, allowlist, onDismiss }),
+		);
+
+		act(() => {
+			result.current.dismiss();
+		});
+
+		expect(onDismiss).toHaveBeenCalledTimes(1);
+	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.ts
@@ -64,6 +64,17 @@ export const useProposalExecution = ({
 					onSuccess?.(data);
 				},
 			});
+		} catch {
+			handleActionResult(
+				{
+					data: null,
+					error: DEFAULT_ERROR_MESSAGE,
+					status: 500,
+				},
+				{
+					errorMessage: DEFAULT_ERROR_MESSAGE,
+				},
+			);
 		} finally {
 			isExecutingRef.current = false;
 			setIsExecuting(false);

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalExecution.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { executeAiChatMutationAction } from '@/app/actions/aiChatMutation';
+import { useActionResultHandler } from '@/hooks/useActionResultHandler';
+import type {
+	AiChatMutationProposal,
+	ExecuteAiChatMutationResult,
+	ProposalAllowlist,
+} from '@/models/aiChatMutationProposal';
+import { useRouter } from 'next/navigation';
+import { useCallback, useRef, useState } from 'react';
+
+export const SUCCESS_MESSAGE = '提案を適用しました';
+export const DEFAULT_ERROR_MESSAGE = '提案の適用に失敗しました';
+export const CONFLICT_ERROR_MESSAGE =
+	'シフトが競合しているため提案を適用できません。最新の状態を確認してください。';
+
+type UseProposalExecutionOptions = {
+	proposal: AiChatMutationProposal | null;
+	allowlist: ProposalAllowlist;
+	onSuccess?: (data: ExecuteAiChatMutationResult | null) => void;
+	onDismiss?: () => void;
+};
+
+type UseProposalExecutionReturn = {
+	isExecuting: boolean;
+	execute: () => Promise<void>;
+	dismiss: () => void;
+};
+
+export const useProposalExecution = ({
+	proposal,
+	allowlist,
+	onSuccess,
+	onDismiss,
+}: UseProposalExecutionOptions): UseProposalExecutionReturn => {
+	const [isExecuting, setIsExecuting] = useState(false);
+	const isExecutingRef = useRef(false);
+	const router = useRouter();
+	const { handleActionResult } = useActionResultHandler();
+
+	const execute = useCallback(async () => {
+		if (!proposal || isExecutingRef.current) {
+			return;
+		}
+
+		isExecutingRef.current = true;
+		setIsExecuting(true);
+
+		try {
+			const result = await executeAiChatMutationAction({
+				proposal,
+				allowlist,
+			});
+
+			handleActionResult(result, {
+				successMessage: SUCCESS_MESSAGE,
+				errorMessage:
+					result.status === 409
+						? CONFLICT_ERROR_MESSAGE
+						: DEFAULT_ERROR_MESSAGE,
+				onSuccess: (data) => {
+					router.refresh();
+					onSuccess?.(data);
+				},
+			});
+		} finally {
+			isExecutingRef.current = false;
+			setIsExecuting(false);
+		}
+	}, [allowlist, handleActionResult, onSuccess, proposal, router]);
+
+	const dismiss = useCallback(() => {
+		onDismiss?.();
+	}, [onDismiss]);
+
+	return {
+		isExecuting,
+		execute,
+		dismiss,
+	};
+};


### PR DESCRIPTION
## 概要

Issue #122 Phase2 として、提案の実行ロジックをカプセル化する `useProposalExecution` カスタムフックを追加します。

Refs #122

## 変更内容

### 追加ファイル

| ファイル | 内容 |
|---|---|
| `useProposalExecution.ts` | 提案実行フック本体 |
| `useProposalExecution.test.tsx` | ユニットテスト（5ケース） |

### 実装ポイント

- **フック追加** (`useProposalExecution`): `executeAiChatMutationAction` を呼び出し、成功時に `router.refresh()` と `onSuccess` コールバックを実行する
- **409 専用エラーメッセージ**: HTTP 409（競合）の場合は `CONFLICT_ERROR_MESSAGE`、それ以外は `DEFAULT_ERROR_MESSAGE` を `handleActionResult` に渡す
- **二重送信防止**: `useRef` による `isExecutingRef` で同期的に二重呼び出しをガード（`useState` の非同期性に依存しない設計）
- **dismiss**: `onDismiss` コールバックを呼び出す `dismiss` 関数を提供

### UT ケース（5件）

1. 成功時に `refresh` と `onSuccess` が呼ばれ、`isExecuting` が切り替わる
2. 500 エラー時は `refresh` しない・`DEFAULT_ERROR_MESSAGE` を使用
3. 409 エラー時は `CONFLICT_ERROR_MESSAGE` を使用
4. 実行中の二重送信を防止する
5. `proposal` が `null` なら no-op

## テスト

```
pnpm test:ut --run
```

## 関連 Issue / Phase

- Phase 1（ProposalConfirmCard）: #128（マージ済み）
- Phase 2（本 PR）: useProposalExecution フック
- 元 Issue: #122