### PR TITLE
[Issue #122 Phase3] 提案表示値ロジックの追加と AdjustmentChatDialog の staffOptions 移行

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.stories.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.stories.tsx
@@ -12,7 +12,20 @@ const meta = {
 	tags: ['autodocs'],
 	args: {
 		onClose: fn(),
-		staffIdsAllowlist: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],
+		staffOptions: [
+			{
+				id: TEST_IDS.STAFF_1,
+				name: '山田太郎',
+				role: 'helper',
+				serviceTypeIds: [TEST_IDS.SERVICE_TYPE_1],
+			},
+			{
+				id: TEST_IDS.STAFF_2,
+				name: '鈴木花子',
+				role: 'helper',
+				serviceTypeIds: [TEST_IDS.SERVICE_TYPE_1],
+			},
+		],
 	},
 } satisfies Meta<typeof AdjustmentChatDialog>;
 

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
@@ -22,6 +22,21 @@ const shiftContext = {
 	endTime: '11:00',
 };
 
+const staffOptions = [
+	{
+		id: TEST_IDS.STAFF_1,
+		name: '山田太郎',
+		role: 'helper' as const,
+		serviceTypeIds: [TEST_IDS.SERVICE_TYPE_1],
+	},
+	{
+		id: TEST_IDS.STAFF_2,
+		name: '鈴木花子',
+		role: 'helper' as const,
+		serviceTypeIds: [TEST_IDS.SERVICE_TYPE_1],
+	},
+];
+
 // デフォルトのモック状態を生成（AI SDK v6 API）
 const createMockUseChatReturn = (overrides: Record<string, unknown> = {}) => ({
 	messages: [],
@@ -57,7 +72,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={false}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -68,7 +83,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -82,7 +97,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -129,7 +144,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -150,7 +165,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -164,7 +179,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -183,7 +198,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -202,7 +217,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -222,7 +237,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={onClose}
 			/>,
 		);
@@ -246,7 +261,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -269,7 +284,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -312,7 +327,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -354,7 +369,7 @@ describe('AdjustmentChatDialog', () => {
 			<AdjustmentChatDialog
 				isOpen={true}
 				shiftContext={shiftContext}
-				staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+				staffOptions={staffOptions}
 				onClose={vi.fn()}
 			/>,
 		);
@@ -408,7 +423,7 @@ describe('AdjustmentChatDialog', () => {
 				<AdjustmentChatDialog
 					isOpen={true}
 					shiftContext={shiftContext}
-					staffIdsAllowlist={[TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]}
+					staffOptions={staffOptions}
 					onClose={vi.fn()}
 				/>,
 			);

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
 import { useMemo } from 'react';
 import { ChatInput } from './ChatInput';
 import { ChatMessageList } from './ChatMessageList';
@@ -10,14 +11,14 @@ import { useAdjustmentChat } from './useAdjustmentChat';
 type AdjustmentChatDialogProps = {
 	isOpen: boolean;
 	shiftContext: ShiftContext;
-	staffIdsAllowlist: string[];
+	staffOptions: StaffPickerOption[];
 	onClose: () => void;
 };
 
 export const AdjustmentChatDialog = ({
 	isOpen,
 	shiftContext,
-	staffIdsAllowlist,
+	staffOptions,
 	onClose,
 }: AdjustmentChatDialogProps) => {
 	const { messages, isStreaming, error, sendMessage, stop } = useAdjustmentChat(
@@ -42,11 +43,13 @@ export const AdjustmentChatDialog = ({
 			return null;
 		}
 
+		const staffIdsAllowlist = staffOptions.map((staffOption) => staffOption.id);
+
 		return parseProposal(latestAssistantMessage.content, {
 			shiftIds: [shiftContext.id],
 			staffIds: staffIdsAllowlist,
 		});
-	}, [messages, shiftContext.id, staffIdsAllowlist]);
+	}, [messages, shiftContext.id, staffOptions]);
 
 	const handleClose = () => {
 		stop(); // ストリーミング中止

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -27,6 +27,11 @@ export const AdjustmentChatDialog = ({
 		},
 	);
 
+	const staffIdsAllowlist = useMemo(
+		() => staffOptions.map((staffOption) => staffOption.id),
+		[staffOptions],
+	);
+
 	const detectedProposal = useMemo(() => {
 		let latestAssistantMessage: (typeof messages)[number] | null = null;
 
@@ -43,13 +48,11 @@ export const AdjustmentChatDialog = ({
 			return null;
 		}
 
-		const staffIdsAllowlist = staffOptions.map((staffOption) => staffOption.id);
-
 		return parseProposal(latestAssistantMessage.content, {
 			shiftIds: [shiftContext.id],
 			staffIds: staffIdsAllowlist,
 		});
-	}, [messages, shiftContext.id, staffOptions]);
+	}, [messages, shiftContext.id, staffIdsAllowlist]);
 
 	const handleClose = () => {
 		stop(); // ストリーミング中止

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/buildProposalDisplayValues.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/buildProposalDisplayValues.test.ts
@@ -1,0 +1,105 @@
+import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import { TEST_IDS, createTestId } from '@/test/helpers/testIds';
+import { describe, expect, it } from 'vitest';
+import { buildProposalDisplayValues } from './buildProposalDisplayValues';
+
+const shiftContext = {
+	id: TEST_IDS.SCHEDULE_1,
+	clientId: TEST_IDS.CLIENT_1,
+	serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+	clientName: '田中太郎',
+	staffName: '山田太郎',
+	date: '2026-02-24',
+	startTime: '10:00',
+	endTime: '11:00',
+};
+
+const staffOptions: StaffPickerOption[] = [
+	{
+		id: TEST_IDS.STAFF_1,
+		name: '山田太郎',
+		role: 'helper',
+		serviceTypeIds: [TEST_IDS.SERVICE_TYPE_1],
+	},
+	{
+		id: TEST_IDS.STAFF_2,
+		name: '鈴木花子',
+		role: 'helper',
+		serviceTypeIds: [TEST_IDS.SERVICE_TYPE_1],
+	},
+];
+
+describe('buildProposalDisplayValues', () => {
+	it('change_shift_staff でスタッフ名を解決する', () => {
+		const result = buildProposalDisplayValues({
+			proposal: {
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			},
+			shiftContext,
+			staffOptions,
+		});
+
+		expect(result).toEqual({
+			beforeValue: '山田太郎',
+			afterValue: '鈴木花子',
+		});
+	});
+
+	it('update_shift_time は JST の HH:mm〜HH:mm で返す', () => {
+		const result = buildProposalDisplayValues({
+			proposal: {
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: '2026-02-24T00:30:00Z',
+				endAt: '2026-02-24T02:00:00Z',
+			},
+			shiftContext,
+			staffOptions,
+		});
+
+		expect(result).toEqual({
+			beforeValue: '10:00〜11:00',
+			afterValue: '09:30〜11:00',
+		});
+	});
+
+	it('change_shift_staff で staffOptions にない場合は toStaffId をフォールバック表示する', () => {
+		const unknownStaffId = createTestId();
+		const result = buildProposalDisplayValues({
+			proposal: {
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: unknownStaffId,
+			},
+			shiftContext,
+			staffOptions,
+		});
+
+		expect(result).toEqual({
+			beforeValue: '山田太郎',
+			afterValue: unknownStaffId,
+		});
+	});
+
+	it('shiftContext.staffName が undefined の場合は 未割当 を返す', () => {
+		const result = buildProposalDisplayValues({
+			proposal: {
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			},
+			shiftContext: {
+				...shiftContext,
+				staffName: undefined,
+			},
+			staffOptions,
+		});
+
+		expect(result).toEqual({
+			beforeValue: '未割当',
+			afterValue: '鈴木花子',
+		});
+	});
+});

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/buildProposalDisplayValues.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/buildProposalDisplayValues.ts
@@ -1,0 +1,35 @@
+import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import type { AiChatMutationProposal } from '@/models/aiChatMutationProposal';
+import { toJstTimeStr } from '@/utils/date';
+import type { ShiftContext } from './useAdjustmentChat';
+
+type BuildProposalDisplayValuesInput = {
+	proposal: AiChatMutationProposal;
+	shiftContext: Pick<ShiftContext, 'staffName' | 'startTime' | 'endTime'>;
+	staffOptions: StaffPickerOption[];
+};
+
+export const buildProposalDisplayValues = ({
+	proposal,
+	shiftContext,
+	staffOptions,
+}: BuildProposalDisplayValuesInput): {
+	beforeValue: string;
+	afterValue: string;
+} => {
+	if (proposal.type === 'change_shift_staff') {
+		const nextStaffName =
+			staffOptions.find((staffOption) => staffOption.id === proposal.toStaffId)
+				?.name ?? proposal.toStaffId;
+
+		return {
+			beforeValue: shiftContext.staffName ?? '未割当',
+			afterValue: nextStaffName,
+		};
+	}
+
+	return {
+		beforeValue: `${shiftContext.startTime}〜${shiftContext.endTime}`,
+		afterValue: `${toJstTimeStr(new Date(proposal.startAt))}〜${toJstTimeStr(new Date(proposal.endAt))}`,
+	};
+};

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/buildProposalDisplayValues.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/buildProposalDisplayValues.ts
@@ -28,8 +28,11 @@ export const buildProposalDisplayValues = ({
 		};
 	}
 
+	const startDate = new Date(proposal.startAt);
+	const endDate = new Date(proposal.endAt);
+
 	return {
 		beforeValue: `${shiftContext.startTime}〜${shiftContext.endTime}`,
-		afterValue: `${toJstTimeStr(new Date(proposal.startAt))}〜${toJstTimeStr(new Date(proposal.endAt))}`,
+		afterValue: `${toJstTimeStr(startDate)}〜${toJstTimeStr(endDate)}`,
 	};
 };

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/index.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/index.ts
@@ -1,4 +1,5 @@
 export { AdjustmentChatDialog } from './AdjustmentChatDialog';
+export { buildProposalDisplayValues } from './buildProposalDisplayValues';
 export { ChatInput } from './ChatInput';
 export { ChatMessageList } from './ChatMessageList';
 export { useAdjustmentChat } from './useAdjustmentChat';

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.memo.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.memo.test.tsx
@@ -10,7 +10,7 @@ import {
 
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
-const capturedStaffIdsAllowlist: string[][] = [];
+const capturedStaffOptions: string[][] = [];
 
 vi.mock('next/navigation', () => ({
 	useRouter: () => ({
@@ -30,20 +30,22 @@ vi.mock('@/app/actions/weeklySchedules', () => ({
 vi.mock('../AdjustmentChatDialog', () => ({
 	AdjustmentChatDialog: ({
 		isOpen,
-		staffIdsAllowlist,
+		staffOptions,
 	}: {
 		isOpen: boolean;
-		staffIdsAllowlist: string[];
+		staffOptions: Array<{ id: string }>;
 	}) => {
 		if (!isOpen) {
 			return null;
 		}
-		capturedStaffIdsAllowlist.push(staffIdsAllowlist);
+		capturedStaffOptions.push(
+			staffOptions.map((staffOption) => staffOption.id),
+		);
 		return <div role="dialog">シフト調整チャット</div>;
 	},
 }));
 
-describe('WeeklySchedulePage staffIdsAllowlist', () => {
+describe('WeeklySchedulePage staffOptions', () => {
 	const weekStartDate = new Date('2026-01-19T00:00:00');
 
 	const sampleShifts: ShiftDisplayRow[] = [
@@ -84,23 +86,29 @@ describe('WeeklySchedulePage staffIdsAllowlist', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		capturedStaffIdsAllowlist.length = 0;
+		capturedStaffOptions.length = 0;
 	});
 
-	it('再レンダー時に staffIdsAllowlist の参照が変わらない', async () => {
+	it('再レンダー時もダイアログへ同じスタッフID一覧が渡る', async () => {
 		const user = userEvent.setup();
 		render(<WeeklySchedulePage {...defaultProps} />);
 
 		await user.click(screen.getByRole('button', { name: 'AIに相談' }));
 		expect(screen.getByRole('dialog')).toBeInTheDocument();
-		expect(capturedStaffIdsAllowlist).toHaveLength(1);
-		const firstAllowlist = capturedStaffIdsAllowlist[0];
+		expect(capturedStaffOptions).toHaveLength(1);
+		expect(capturedStaffOptions[0]).toEqual([
+			TEST_IDS.STAFF_1,
+			TEST_IDS.STAFF_2,
+		]);
 
 		await user.click(
 			screen.getByRole('button', { name: '利用者別グリッド表示' }),
 		);
 
-		expect(capturedStaffIdsAllowlist).toHaveLength(2);
-		expect(capturedStaffIdsAllowlist[1]).toBe(firstAllowlist);
+		expect(capturedStaffOptions).toHaveLength(2);
+		expect(capturedStaffOptions[1]).toEqual([
+			TEST_IDS.STAFF_1,
+			TEST_IDS.STAFF_2,
+		]);
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.memo.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.memo.test.tsx
@@ -10,7 +10,7 @@ import {
 
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
-const capturedStaffOptions: string[][] = [];
+const capturedStaffIds: string[][] = [];
 
 vi.mock('next/navigation', () => ({
 	useRouter: () => ({
@@ -38,9 +38,7 @@ vi.mock('../AdjustmentChatDialog', () => ({
 		if (!isOpen) {
 			return null;
 		}
-		capturedStaffOptions.push(
-			staffOptions.map((staffOption) => staffOption.id),
-		);
+		capturedStaffIds.push(staffOptions.map((staffOption) => staffOption.id));
 		return <div role="dialog">シフト調整チャット</div>;
 	},
 }));
@@ -86,7 +84,7 @@ describe('WeeklySchedulePage staffOptions', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
-		capturedStaffOptions.length = 0;
+		capturedStaffIds.length = 0;
 	});
 
 	it('再レンダー時もダイアログへ同じスタッフID一覧が渡る', async () => {
@@ -95,20 +93,14 @@ describe('WeeklySchedulePage staffOptions', () => {
 
 		await user.click(screen.getByRole('button', { name: 'AIに相談' }));
 		expect(screen.getByRole('dialog')).toBeInTheDocument();
-		expect(capturedStaffOptions).toHaveLength(1);
-		expect(capturedStaffOptions[0]).toEqual([
-			TEST_IDS.STAFF_1,
-			TEST_IDS.STAFF_2,
-		]);
+		expect(capturedStaffIds).toHaveLength(1);
+		expect(capturedStaffIds[0]).toEqual([TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]);
 
 		await user.click(
 			screen.getByRole('button', { name: '利用者別グリッド表示' }),
 		);
 
-		expect(capturedStaffOptions).toHaveLength(2);
-		expect(capturedStaffOptions[1]).toEqual([
-			TEST_IDS.STAFF_1,
-			TEST_IDS.STAFF_2,
-		]);
+		expect(capturedStaffIds).toHaveLength(2);
+		expect(capturedStaffIds[1]).toEqual([TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]);
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
@@ -5,7 +5,7 @@ import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/
 import { ServiceTypeLabels } from '@/models/valueObjects/serviceTypeId';
 import { formatJstDateString, getJstDateOnly } from '@/utils/date';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { AdjustmentChatDialog } from '../AdjustmentChatDialog';
 import type { ShiftContext } from '../AdjustmentChatDialog/useAdjustmentChat';
 import {
@@ -301,10 +301,6 @@ export const WeeklySchedulePage = ({
 	};
 
 	const hasShifts = initialShifts.length > 0;
-	const staffIdsAllowlist = useMemo(
-		() => staffOptions.map((staffOption) => staffOption.id),
-		[staffOptions],
-	);
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -421,7 +417,7 @@ export const WeeklySchedulePage = ({
 				<AdjustmentChatDialog
 					isOpen={!!chatDialogShift}
 					shiftContext={createShiftContext(chatDialogShift)}
-					staffIdsAllowlist={staffIdsAllowlist}
+					staffOptions={staffOptions}
 					onClose={() => setChatDialogShift(null)}
 				/>
 			)}


### PR DESCRIPTION
## 概要

Issue #122 の Phase3 実装です。ProposalConfirmCard にわたす「変更前/変更後」の表示文字列を生成するロジックを追加し、AdjustmentChatDialog の props を `staffOptions` ベースに整理しました。**Phase4（提案UI統合・Confirm実行）は本PRに含みません。**

Refs #122

---

## 変更内容

### 新規追加

| ファイル | 説明 |
|---|---|
| `buildProposalDisplayValues.ts` | proposal の種別（`change_shift_staff` / 時間変更）に応じて `beforeValue` / `afterValue` 文字列を生成するピュア関数 |
| `buildProposalDisplayValues.test.ts` | 上記のユニットテスト（各種別・スタッフ名未解決フォールバックを含む） |

### 変更

| ファイル | 説明 |
|---|---|
| `AdjustmentChatDialog.tsx` | props に `staffOptions: StaffPickerOption[]` を追加し、`buildProposalDisplayValues` の呼び出し基盤を整備 |
| `AdjustmentChatDialog.test.tsx` | `staffOptions` prop を渡すよう更新 |
| `AdjustmentChatDialog.stories.tsx` | `staffOptions` prop を渡すよう更新 |
| `WeeklySchedulePage.tsx` | `staffOptions` を AdjustmentChatDialog に渡す呼び出し元変更 |
| `WeeklySchedulePage.memo.test.tsx` | 上記に追従したテスト更新 |
| `index.ts` | `buildProposalDisplayValues` をエクスポート追加 |

---

## Phase スコープ整理

| Phase | 内容 | PR |
|---|---|---|
| Phase1 | ProposalConfirmCard コンポーネント追加 | #128 |
| Phase2 | proposal 検出・parse ロジック追加 | #126 等 |
| **Phase3** | **buildProposalDisplayValues 追加・staffOptions 移行（本PR）** | 本PR |
| Phase4 | AdjustmentChatDialog への ProposalConfirmCard 統合・Confirm 実行 | 未着手 |

---

## テスト

```
Test Files  172 passed | 1 skipped (173)
     Tests  1294 passed | 1 skipped (1295)
```

---

## チェックリスト

- [x] `buildProposalDisplayValues` のユニットテスト追加
- [x] `staffOptions` prop の型定義・呼び出し元への追従
- [x] Storybook / コンポーネントテストの更新
- [x] CI（vitest）グリーン確認
- [ ] Phase4: ProposalConfirmCard との統合（別PR予定）