### PR TITLE
[Issue #122 Phase4] ProposalConfirmCard の AdjustmentChatDialog 統合

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
@@ -6,9 +6,14 @@ import { AdjustmentChatDialog } from './AdjustmentChatDialog';
 
 // Vercel AI SDK useChat のモック
 const mockUseChat = vi.fn();
+const mockUseProposalExecution = vi.fn();
 
 vi.mock('@ai-sdk/react', () => ({
 	useChat: () => mockUseChat(),
+}));
+
+vi.mock('./useProposalExecution', () => ({
+	useProposalExecution: (options: unknown) => mockUseProposalExecution(options),
 }));
 
 const shiftContext = {
@@ -48,16 +53,34 @@ const createMockUseChatReturn = (overrides: Record<string, unknown> = {}) => ({
 	...overrides,
 });
 
+const createProposalMessage = (proposalJson: string) => ({
+	id: 'assistant-1',
+	role: 'assistant',
+	parts: [
+		{
+			type: 'text',
+			text: `提案です
+\`\`\`json
+${proposalJson}
+\`\`\``,
+		},
+	],
+});
+
 describe('AdjustmentChatDialog', () => {
 	let mockSendMessage: Mock;
 	let mockStop: Mock;
 	let mockSetMessages: Mock;
+	let mockExecuteProposal: Mock;
+	let mockDismissProposal: Mock;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockSendMessage = vi.fn();
 		mockStop = vi.fn();
 		mockSetMessages = vi.fn();
+		mockExecuteProposal = vi.fn();
+		mockDismissProposal = vi.fn();
 		mockUseChat.mockReturnValue(
 			createMockUseChatReturn({
 				sendMessage: mockSendMessage,
@@ -65,6 +88,11 @@ describe('AdjustmentChatDialog', () => {
 				setMessages: mockSetMessages,
 			}),
 		);
+		mockUseProposalExecution.mockReturnValue({
+			isExecuting: false,
+			execute: mockExecuteProposal,
+			dismiss: mockDismissProposal,
+		});
 	});
 
 	it('ダイアログが開閉する', () => {
@@ -294,28 +322,16 @@ describe('AdjustmentChatDialog', () => {
 		).toBeInTheDocument();
 	});
 
-	it('assistant の最新メッセージに提案 JSON があると案内を表示する', () => {
+	it('assistant の最新メッセージに提案 JSON があると ProposalConfirmCard を表示する', () => {
 		mockUseChat.mockReturnValue(
 			createMockUseChatReturn({
 				messages: [
-					{
-						id: '2',
-						role: 'assistant',
-						parts: [
-							{
-								type: 'text',
-								text: `提案です
-\`\`\`json
-{
+					createProposalMessage(`{
   "type": "update_shift_time",
   "shiftId": "${TEST_IDS.SCHEDULE_1}",
   "startAt": "2026-02-24T10:00:00+09:00",
   "endAt": "2026-02-24T11:00:00+09:00"
-}
-\`\`\``,
-							},
-						],
-					},
+}`),
 				],
 				sendMessage: mockSendMessage,
 				stop: mockStop,
@@ -332,32 +348,22 @@ describe('AdjustmentChatDialog', () => {
 			/>,
 		);
 
+		expect(screen.getByText('時間変更')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: '確定' })).toBeInTheDocument();
 		expect(
-			screen.getByText('提案を検出しました（確定は次のステップで行います）'),
+			screen.getByRole('button', { name: 'キャンセル' }),
 		).toBeInTheDocument();
 	});
 
-	it('change_shift_staff の提案 JSON があると案内を表示する', () => {
+	it('change_shift_staff の提案 JSON があると担当者変更カードを表示する', () => {
 		mockUseChat.mockReturnValue(
 			createMockUseChatReturn({
 				messages: [
-					{
-						id: '2',
-						role: 'assistant',
-						parts: [
-							{
-								type: 'text',
-								text: `担当者変更案です
-\`\`\`json
-{
+					createProposalMessage(`{
   "type": "change_shift_staff",
   "shiftId": "${TEST_IDS.SCHEDULE_1}",
   "toStaffId": "${TEST_IDS.STAFF_2}"
-}
-\`\`\``,
-							},
-						],
-					},
+}`),
 				],
 				sendMessage: mockSendMessage,
 				stop: mockStop,
@@ -374,9 +380,147 @@ describe('AdjustmentChatDialog', () => {
 			/>,
 		);
 
-		expect(
-			screen.getByText('提案を検出しました（確定は次のステップで行います）'),
-		).toBeInTheDocument();
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
+		expect(screen.getByText('山田太郎')).toBeInTheDocument();
+		expect(screen.getByText('鈴木花子')).toBeInTheDocument();
+	});
+
+	it('確定ボタン押下で execute が呼ばれる', async () => {
+		const user = userEvent.setup();
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createProposalMessage(`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: '確定' }));
+
+		expect(mockExecuteProposal).toHaveBeenCalledTimes(1);
+	});
+
+	it('キャンセル押下でカードが非表示になる', async () => {
+		type UseProposalExecutionOptions = {
+			onDismiss?: () => void;
+		};
+		const user = userEvent.setup();
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createProposalMessage(`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+		mockUseProposalExecution.mockImplementation(
+			(options: UseProposalExecutionOptions) => ({
+				isExecuting: false,
+				execute: mockExecuteProposal,
+				dismiss: () => {
+					options.onDismiss?.();
+					mockDismissProposal();
+				},
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+		expect(mockDismissProposal).toHaveBeenCalledTimes(1);
+		expect(screen.queryByText('担当者変更')).not.toBeInTheDocument();
+	});
+
+	it('isStreaming=true のとき確定ボタンが disabled になる', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				status: 'streaming',
+				messages: [
+					createProposalMessage(`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByRole('button', { name: '確定' })).toBeDisabled();
+	});
+
+	it('isExecuting=true のとき確定ボタンが disabled になる', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createProposalMessage(`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+		mockUseProposalExecution.mockReturnValue({
+			isExecuting: true,
+			execute: mockExecuteProposal,
+			dismiss: mockDismissProposal,
+		});
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByRole('button', { name: '確定' })).toBeDisabled();
 	});
 
 	it('detectedProposal の算出で reverse を呼ばずに最新 assistant を検出できる', () => {
@@ -390,23 +534,11 @@ describe('AdjustmentChatDialog', () => {
 			mockUseChat.mockReturnValue(
 				createMockUseChatReturn({
 					messages: [
-						{
-							id: 'assistant-1',
-							role: 'assistant',
-							parts: [
-								{
-									type: 'text',
-									text: `提案です
-\`\`\`json
-{
+						createProposalMessage(`{
   "type": "change_shift_staff",
   "shiftId": "${TEST_IDS.SCHEDULE_1}",
   "toStaffId": "${TEST_IDS.STAFF_2}"
-}
-\`\`\``,
-								},
-							],
-						},
+}`),
 						{
 							id: 'user-1',
 							role: 'user',
@@ -428,9 +560,7 @@ describe('AdjustmentChatDialog', () => {
 				/>,
 			);
 
-			expect(
-				screen.getByText('提案を検出しました（確定は次のステップで行います）'),
-			).toBeInTheDocument();
+			expect(screen.getByText('担当者変更')).toBeInTheDocument();
 		} finally {
 			reverseSpy.mockRestore();
 		}

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
@@ -355,6 +355,44 @@ describe('AdjustmentChatDialog', () => {
 		).toBeInTheDocument();
 	});
 
+	it('最新 assistant に proposal がない場合は過去 proposal を表示しない', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createProposalMessage(`{
+  \"type\": \"change_shift_staff\",
+  \"shiftId\": \"${TEST_IDS.SCHEDULE_1}\",
+  \"toStaffId\": \"${TEST_IDS.STAFF_2}\"
+}`),
+					{
+						id: 'assistant-2',
+						role: 'assistant',
+						parts: [
+							{ type: 'text', text: '確認しました。追加情報をください。' },
+						],
+					},
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.queryByText('担当者変更')).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: '確定' }),
+		).not.toBeInTheDocument();
+	});
+
 	it('change_shift_staff の提案 JSON があると担当者変更カードを表示する', () => {
 		mockUseChat.mockReturnValue(
 			createMockUseChatReturn({
@@ -521,6 +559,46 @@ describe('AdjustmentChatDialog', () => {
 		);
 
 		expect(screen.getByRole('button', { name: '確定' })).toBeDisabled();
+	});
+
+	it('isExecuting=true のときキャンセルボタンが disabled で押下しても dismiss されない', async () => {
+		const user = userEvent.setup();
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createProposalMessage(`{
+  \"type\": \"change_shift_staff\",
+  \"shiftId\": \"${TEST_IDS.SCHEDULE_1}\",
+  \"toStaffId\": \"${TEST_IDS.STAFF_2}\"
+}`),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+		mockUseProposalExecution.mockReturnValue({
+			isExecuting: true,
+			execute: mockExecuteProposal,
+			dismiss: mockDismissProposal,
+		});
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		const dismissButton = screen.getByRole('button', { name: 'キャンセル' });
+		expect(dismissButton).toBeDisabled();
+
+		await user.click(dismissButton);
+
+		expect(mockDismissProposal).not.toHaveBeenCalled();
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
 	});
 
 	it('detectedProposal の算出で reverse を呼ばずに最新 assistant を検出できる', () => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
+import { buildProposalDisplayValues } from './buildProposalDisplayValues';
 import { ChatInput } from './ChatInput';
 import { ChatMessageList } from './ChatMessageList';
 import { parseProposal } from './parseProposal';
+import { ProposalConfirmCard } from './ProposalConfirmCard';
 import type { ShiftContext } from './useAdjustmentChat';
 import { useAdjustmentChat } from './useAdjustmentChat';
+import { useProposalExecution } from './useProposalExecution';
 
 type AdjustmentChatDialogProps = {
 	isOpen: boolean;
@@ -31,6 +34,13 @@ export const AdjustmentChatDialog = ({
 		() => staffOptions.map((staffOption) => staffOption.id),
 		[staffOptions],
 	);
+	const allowlist = useMemo(
+		() => ({
+			shiftIds: [shiftContext.id],
+			staffIds: staffIdsAllowlist,
+		}),
+		[shiftContext.id, staffIdsAllowlist],
+	);
 
 	const detectedProposal = useMemo(() => {
 		let latestAssistantMessage: (typeof messages)[number] | null = null;
@@ -48,11 +58,36 @@ export const AdjustmentChatDialog = ({
 			return null;
 		}
 
-		return parseProposal(latestAssistantMessage.content, {
-			shiftIds: [shiftContext.id],
-			staffIds: staffIdsAllowlist,
+		return parseProposal(latestAssistantMessage.content, allowlist);
+	}, [messages, allowlist]);
+
+	const proposalDisplayValues = useMemo(() => {
+		if (!detectedProposal) {
+			return null;
+		}
+
+		return buildProposalDisplayValues({
+			proposal: detectedProposal,
+			shiftContext,
+			staffOptions,
 		});
-	}, [messages, shiftContext.id, staffIdsAllowlist]);
+	}, [detectedProposal, shiftContext, staffOptions]);
+
+	const proposalKey = useMemo(
+		() => (detectedProposal ? JSON.stringify(detectedProposal) : null),
+		[detectedProposal],
+	);
+	const [dismissedProposalKey, setDismissedProposalKey] = useState<
+		string | null
+	>(null);
+	const isDismissed =
+		proposalKey !== null && proposalKey === dismissedProposalKey;
+
+	const { execute, dismiss, isExecuting } = useProposalExecution({
+		proposal: detectedProposal,
+		allowlist,
+		onDismiss: () => setDismissedProposalKey(proposalKey),
+	});
 
 	const handleClose = () => {
 		stop(); // ストリーミング中止
@@ -106,9 +141,17 @@ export const AdjustmentChatDialog = ({
 				{error && <div className="m-4 alert alert-error">{error}</div>}
 
 				{/* 提案検出表示 */}
-				{detectedProposal && (
-					<div className="mx-4 mt-4 rounded-md border border-info/30 bg-info/10 px-3 py-2 text-xs text-info-content">
-						提案を検出しました（確定は次のステップで行います）
+				{detectedProposal && !isDismissed && proposalDisplayValues && (
+					<div className="mx-4 mt-4">
+						<ProposalConfirmCard
+							proposal={detectedProposal}
+							beforeValue={proposalDisplayValues.beforeValue}
+							afterValue={proposalDisplayValues.afterValue}
+							isStreaming={isStreaming}
+							isExecuting={isExecuting}
+							onConfirm={execute}
+							onDismiss={dismiss}
+						/>
 					</div>
 				)}
 

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -18,24 +18,40 @@ type AdjustmentChatDialogProps = {
 	onClose: () => void;
 };
 
-/** 最新の assistant メッセージから proposal を検出する（complexity 分離）*/
+/**
+ * 末尾側で最初に見つかる assistant メッセージ 1 件だけを対象に proposal を検出する。
+ * 最新 assistant に proposal が無い場合は null を返し、過去提案へはフォールバックしない。
+ */
 const findLatestProposal = (
 	messages: Array<{ id: string; role: string; content: string }>,
 	allowlist: Parameters<typeof parseProposal>[1],
 ) => {
+	let latestAssistantMessage: {
+		id: string;
+		role: string;
+		content: string;
+	} | null = null;
+
 	for (let index = messages.length - 1; index >= 0; index -= 1) {
 		const message = messages[index];
 
-		if (message.role === 'assistant' && message.content) {
-			const proposal = parseProposal(message.content, allowlist);
-
-			if (proposal) {
-				return { messageId: message.id, proposal };
-			}
+		if (message.role === 'assistant') {
+			latestAssistantMessage = message;
+			break;
 		}
 	}
 
-	return null;
+	if (!latestAssistantMessage?.content) {
+		return null;
+	}
+
+	const proposal = parseProposal(latestAssistantMessage.content, allowlist);
+
+	if (!proposal) {
+		return null;
+	}
+
+	return { messageId: latestAssistantMessage.id, proposal };
 };
 
 export const AdjustmentChatDialog = ({

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -18,6 +18,26 @@ type AdjustmentChatDialogProps = {
 	onClose: () => void;
 };
 
+/** 最新の assistant メッセージから proposal を検出する（complexity 分離）*/
+const findLatestProposal = (
+	messages: Array<{ id: string; role: string; content: string }>,
+	allowlist: Parameters<typeof parseProposal>[1],
+) => {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+
+		if (message.role === 'assistant' && message.content) {
+			const proposal = parseProposal(message.content, allowlist);
+
+			if (proposal) {
+				return { messageId: message.id, proposal };
+			}
+		}
+	}
+
+	return null;
+};
+
 export const AdjustmentChatDialog = ({
 	isOpen,
 	shiftContext,
@@ -42,23 +62,15 @@ export const AdjustmentChatDialog = ({
 		[shiftContext.id, staffIdsAllowlist],
 	);
 
-	const detectedProposal = useMemo(() => {
-		let latestAssistantMessage: (typeof messages)[number] | null = null;
+	/** 最新の assistant メッセージ（id + parsed proposal）を返す */
+	const { detectedProposal, proposalKey } = useMemo(() => {
+		const result = findLatestProposal(messages, allowlist);
 
-		for (let index = messages.length - 1; index >= 0; index -= 1) {
-			const message = messages[index];
-
-			if (message.role === 'assistant') {
-				latestAssistantMessage = message;
-				break;
-			}
-		}
-
-		if (!latestAssistantMessage?.content) {
-			return null;
-		}
-
-		return parseProposal(latestAssistantMessage.content, allowlist);
+		return {
+			detectedProposal: result ? result.proposal : null,
+			// dismiss キーは「この assistant メッセージの id」で安定管理する
+			proposalKey: result ? result.messageId : null,
+		};
 	}, [messages, allowlist]);
 
 	const proposalDisplayValues = useMemo(() => {
@@ -72,11 +84,6 @@ export const AdjustmentChatDialog = ({
 			staffOptions,
 		});
 	}, [detectedProposal, shiftContext, staffOptions]);
-
-	const proposalKey = useMemo(
-		() => (detectedProposal ? JSON.stringify(detectedProposal) : null),
-		[detectedProposal],
-	);
 	const [dismissedProposalKey, setDismissedProposalKey] = useState<
 		string | null
 	>(null);

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.test.tsx
@@ -68,6 +68,21 @@ describe('ProposalConfirmCard', () => {
 		expect(screen.getByRole('button', { name: '確定' })).toBeDisabled();
 	});
 
+	it('executing 中は キャンセル ボタンも disabled になる', () => {
+		render(
+			<ProposalConfirmCard
+				proposal={createUpdateTimeProposal()}
+				beforeValue="10:00-11:00"
+				afterValue="11:00-12:00"
+				isExecuting={true}
+				onConfirm={vi.fn()}
+				onDismiss={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByRole('button', { name: 'キャンセル' })).toBeDisabled();
+	});
+
 	it('確定 / キャンセル クリックで callback が呼ばれる', async () => {
 		const user = userEvent.setup();
 		const onConfirm = vi.fn();

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalConfirmCard/ProposalConfirmCard.tsx
@@ -31,6 +31,7 @@ export const ProposalConfirmCard = ({
 	onDismiss,
 }: ProposalConfirmCardProps) => {
 	const isConfirmDisabled = isStreaming || isExecuting;
+	const isDismissDisabled = isExecuting;
 
 	return (
 		<div className="rounded-lg border border-info/30 bg-base-100 p-4">
@@ -56,6 +57,7 @@ export const ProposalConfirmCard = ({
 					type="button"
 					className="btn btn-ghost btn-sm"
 					onClick={onDismiss}
+					disabled={isDismissDisabled}
 				>
 					キャンセル
 				</button>


### PR DESCRIPTION
## 概要

Issue #122（確認UI: チャット内で proposal を差分表示 → Confirm → 実行 → 結果表示）の Phase4 実装です。
Phase1〜3 で実装した `ProposalConfirmCard` / `useProposalExecution` / 提案表示値ロジックを `AdjustmentChatDialog` に統合し、UIを完成させます。

Closes #122

---

## 変更内容

### `AdjustmentChatDialog.tsx` (+51 / -8)

- **ProposalConfirmCard 統合**: assistant メッセージから proposal が検出された場合、チャット内に `ProposalConfirmCard` を表示するよう組み込み
- **Confirm / Dismiss 接続**: `useProposalExecution` の `execute` / `dismiss` を Confirm・Dismiss ボタンに接続
- **Before/After 生成**: proposal データから差分表示用の before/after 値を生成して `ProposalConfirmCard` に渡す
- **disabled 制御**: ストリーミング中 / 実行中は Confirm ボタンを無効化し、二重送信を防止

### `AdjustmentChatDialog.test.tsx` (+181 / -51)

- 上記統合に対応するユニットテストを追加・更新
  - proposal 検出時の `ProposalConfirmCard` 表示
  - Confirm / Dismiss 操作のハンドリング
  - streaming 中 / execute 中の disabled 状態

---

## テスト

```bash
pnpm vitest run src/app/admin/weekly-schedules/_components/AdjustmentChatDialog
```

---

## レビュー前提

- Phase1 (#128), Phase2 (#129), Phase3 (#131) はすべて develop にマージ済み
- ブロッカーなし（Go レビュー済み）
