### PR TITLE
test: ShiftService の日時依存テストを安定化

### DIFF
--- a/src/backend/services/shiftService.test.ts
+++ b/src/backend/services/shiftService.test.ts
@@ -1153,6 +1153,15 @@ describe('ShiftService', () => {
 	});
 
 	describe('assignStaffWithCascadeUnassign', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-03-01T00:00:00+09:00'));
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
 		it('should throw 400 when newStaffId is already assigned to target shift', async () => {
 			const userId = createTestId();
 			const shiftId = TEST_IDS.SCHEDULE_1;
@@ -1521,7 +1530,6 @@ describe('ShiftService', () => {
 		});
 
 		it('should throw 400 when assigning past shift', async () => {
-			vi.useFakeTimers();
 			vi.setSystemTime(new Date('2026-02-22T00:00:00+09:00'));
 
 			const userId = createTestId();
@@ -1558,8 +1566,6 @@ describe('ShiftService', () => {
 					message: 'Cannot change staff for past shift',
 				}),
 			);
-
-			vi.useRealTimers();
 		});
 
 		it('should throw service error with details when cascade unassign partially fails', async () => {


### PR DESCRIPTION
## なぜ必要か

`assignStaffWithCascadeUnassign` のテストは「過去のシフトには削除フラグを立てる」という仕様を検証しているが、テストデータの日付が **テスト実行日よりも過去になると「未来のシフト」として扱われなくなり**、アサーションが失敗するフレーキーなテストになっていた。

## 何をしたか

- `assignStaffWithCascadeUnassign` describe ブロックに Vitest の **fake timers** を導入
- `vi.setSystemTime` で systemTime を **2026-03-01T00:00:00+09:00** に固定
- `beforeEach` で `vi.useFakeTimers`、`afterEach` で `vi.useRealTimers` を呼び出しタイマーリークを防止
- テストデータの日付はそのままで、`Date.now()` / `new Date()` が常に固定値を返すようにしたことで判定が安定

## 影響範囲

- **テストコードのみ**（`src/backend/services/shiftService.test.ts`）
- プロダクションコードへの変更なし
- 変更行数: +9 / -3（合計 12 行）

## 関連

- フレーキーテスト修正のため、Issue なし