### PR TITLE
fix: 提案確定後にカードを自動で閉じる

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
@@ -1,3 +1,4 @@
+import type { ExecuteAiChatMutationResult } from '@/models/aiChatMutationProposal';
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -456,7 +457,7 @@ describe('AdjustmentChatDialog', () => {
 
 	it('確定成功時にカードが非表示になる', async () => {
 		type UseProposalExecutionOptions = {
-			onSuccess?: () => void;
+			onSuccess?: (data: ExecuteAiChatMutationResult | null) => void;
 		};
 		const user = userEvent.setup();
 		mockUseChat.mockReturnValue(
@@ -477,7 +478,7 @@ describe('AdjustmentChatDialog', () => {
 			(options: UseProposalExecutionOptions) => ({
 				isExecuting: false,
 				execute: async () => {
-					options.onSuccess?.();
+					options.onSuccess?.(null);
 					mockExecuteProposal();
 				},
 				dismiss: mockDismissProposal,

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
@@ -454,6 +454,55 @@ describe('AdjustmentChatDialog', () => {
 		expect(mockExecuteProposal).toHaveBeenCalledTimes(1);
 	});
 
+	it('確定成功時にカードが非表示になる', async () => {
+		type UseProposalExecutionOptions = {
+			onSuccess?: () => void;
+		};
+		const user = userEvent.setup();
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createProposalMessage(`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+		mockUseProposalExecution.mockImplementation(
+			(options: UseProposalExecutionOptions) => ({
+				isExecuting: false,
+				execute: async () => {
+					options.onSuccess?.();
+					mockExecuteProposal();
+				},
+				dismiss: mockDismissProposal,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: '確定' }));
+
+		expect(mockExecuteProposal).toHaveBeenCalledTimes(1);
+		await waitFor(() => {
+			expect(screen.queryByText('担当者変更')).not.toBeInTheDocument();
+		});
+	});
+
 	it('キャンセル押下でカードが非表示になる', async () => {
 		type UseProposalExecutionOptions = {
 			onDismiss?: () => void;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -109,6 +109,7 @@ export const AdjustmentChatDialog = ({
 	const { execute, dismiss, isExecuting } = useProposalExecution({
 		proposal: detectedProposal,
 		allowlist,
+		onSuccess: () => setDismissedProposalKey(proposalKey),
 		onDismiss: () => setDismissedProposalKey(proposalKey),
 	});
 


### PR DESCRIPTION
## 概要

提案の確定操作が成功した後、提案カード（`ProposalConfirmCard`）を非表示にするよう修正します。
※ダイアログ（`AdjustmentChatDialog`）自体を閉じる変更ではありません。

Refs #134

## 何が直るか

確定ボタンを押して処理が成功しても、カードが開いたまま残っていた問題を修正します。
確定後にカードが非表示になることで、操作が完了したことを画面上で明確に伝えられます。

## なぜ必要か

確定後もカードが表示されたままだと、ユーザーが「本当に確定されたのか？」と混乱する原因になっていました。
カードを非表示にすることで視覚的なフィードバックが得られ、混乱を減らします。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `AdjustmentChatDialog.tsx` | 確定成功時に提案カード（`ProposalConfirmCard`）を非表示にするよう修正（`dismissedProposalKey` を更新、ダイアログ自体は閉じません） |
| `AdjustmentChatDialog.test.tsx` | 確定成功後にカードが非表示になることを検証するテストを追加 |

## テスト

```
pnpm test:ut --run
```

- Test Files: 116 passed | 1 skipped (117)
- Tests: 1112 passed | 1 skipped (1113)

## 次フェーズについて

SYSTEM_PROMPT側で「確定しました」等の断言表現を制御するフェーズは、別PRで対応予定です。
