### PR TITLE
feat: tool callingで提案を返す（Phase2 PR-A: サーバ）

### DIFF
--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -10,6 +10,9 @@ const {
 	mockTool,
 	mockGetUser,
 	mockSupabaseFrom,
+	mockShiftSelect,
+	mockShiftEq,
+	mockShiftMaybeSingle,
 	mockCreateSearchAvailableHelpersTool,
 	mockCreateProcessStaffAbsenceTool,
 	mockCreateSearchStaffsTool,
@@ -22,6 +25,9 @@ const {
 	mockTool: vi.fn((definition: unknown) => definition),
 	mockGetUser: vi.fn(),
 	mockSupabaseFrom: vi.fn(),
+	mockShiftSelect: vi.fn(),
+	mockShiftEq: vi.fn(),
+	mockShiftMaybeSingle: vi.fn(),
 	mockCreateSearchAvailableHelpersTool: vi.fn(),
 	mockCreateProcessStaffAbsenceTool: vi.fn(),
 	mockCreateSearchStaffsTool: vi.fn(),
@@ -91,7 +97,24 @@ describe('POST /api/chat/shift-adjustment', () => {
 			return { maybeSingle: mockStaffMaybeSingle };
 		});
 		mockStaffSelect.mockReturnValue({ eq: mockStaffEq });
-		mockSupabaseFrom.mockReturnValue({ select: mockStaffSelect });
+
+		mockShiftMaybeSingle.mockResolvedValue({
+			data: { id: TEST_IDS.SCHEDULE_1 },
+			error: null,
+		});
+		mockShiftEq.mockReturnValue({ maybeSingle: mockShiftMaybeSingle });
+		mockShiftSelect.mockReturnValue({ eq: mockShiftEq });
+
+		mockSupabaseFrom.mockImplementation((table: string) => {
+			if (table === 'staffs') {
+				return { select: mockStaffSelect };
+			}
+			if (table === 'shifts') {
+				return { select: mockShiftSelect };
+			}
+
+			throw new Error('Unexpected table');
+		});
 
 		// Tool モックを返す
 		mockCreateSearchAvailableHelpersTool.mockReturnValue({
@@ -230,6 +253,47 @@ describe('POST /api/chat/shift-adjustment', () => {
 		expect(mockStreamText).toHaveBeenCalledWith(
 			expect.objectContaining({
 				system: expect.stringContaining(
+					'assistant の本文に JSON を直接書かず、必ず proposeShiftChange ツールを呼び出して返す',
+				),
+			}),
+		);
+	});
+
+	it('x-ai-response-format: uimessage かつ context.shifts が空でも UIMessage で返し、proposeShiftChange 関連指示は含めない', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'x-ai-response-format': 'uimessage',
+			},
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: '提案してください' }],
+				context: { shifts: [] },
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		expect(mockToUIMessageStreamResponse).toHaveBeenCalledTimes(1);
+		expect(mockToTextStreamResponse).not.toHaveBeenCalled();
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				tools: expect.not.objectContaining({
+					proposeShiftChange: expect.anything(),
+				}),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(
+					'proposeShiftChange ツールは利用できません',
+				),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.not.stringContaining(
 					'assistant の本文に JSON を直接書かず、必ず proposeShiftChange ツールを呼び出して返す',
 				),
 			}),
@@ -759,6 +823,18 @@ describe('POST /api/chat/shift-adjustment', () => {
 			},
 			body: JSON.stringify({
 				messages: [{ role: 'user', content: '提案してください' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+							date: '2026-03-16',
+							startTime: '09:00',
+							endTime: '10:00',
+						},
+					],
+				},
 			}),
 		});
 
@@ -805,6 +881,18 @@ describe('POST /api/chat/shift-adjustment', () => {
 			},
 			body: JSON.stringify({
 				messages: [{ role: 'user', content: '調整案を出して' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+							date: '2026-03-16',
+							startTime: '09:00',
+							endTime: '10:00',
+						},
+					],
+				},
 			}),
 		});
 
@@ -857,6 +945,18 @@ describe('POST /api/chat/shift-adjustment', () => {
 			},
 			body: JSON.stringify({
 				messages: [{ role: 'user', content: '未確定時の対応を確認したい' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+							date: '2026-03-16',
+							startTime: '09:00',
+							endTime: '10:00',
+						},
+					],
+				},
 			}),
 		});
 
@@ -888,6 +988,18 @@ describe('POST /api/chat/shift-adjustment', () => {
 			},
 			body: JSON.stringify({
 				messages: [{ role: 'user', content: '対応を完了して' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+							date: '2026-03-16',
+							startTime: '09:00',
+							endTime: '10:00',
+						},
+					],
+				},
 			}),
 		});
 
@@ -1291,6 +1403,65 @@ describe('POST /api/chat/shift-adjustment', () => {
 					toStaffId: TEST_IDS.STAFF_1,
 				},
 			});
+
+			expect(mockSupabaseFrom).toHaveBeenCalledWith('shifts');
+			expect(mockShiftSelect).toHaveBeenCalledWith('id');
+			expect(mockShiftEq).toHaveBeenCalledWith('id', TEST_IDS.SCHEDULE_1);
+		});
+
+		it('proposeShiftChange tool は shift がDBに存在しない場合エラーを返す', async () => {
+			mockShiftMaybeSingle.mockResolvedValue({ data: null, error: null });
+
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '提案して' }],
+						context: {
+							shifts: [
+								{
+									id: TEST_IDS.SCHEDULE_1,
+									clientId: TEST_IDS.CLIENT_1,
+									serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+									date: '2025-01-20',
+									startTime: '09:00',
+									endTime: '10:00',
+								},
+							],
+						},
+					}),
+				},
+			);
+
+			await POST(request);
+
+			const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+				tools?: {
+					proposeShiftChange?: {
+						execute?: (input: {
+							type: 'change_shift_staff';
+							shiftId: string;
+							toStaffId: string;
+						}) => Promise<unknown>;
+					};
+				};
+			};
+
+			const execute = streamTextCall.tools?.proposeShiftChange?.execute;
+			await expect(
+				execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+				}),
+			).rejects.toThrow(
+				'指定されたシフトを確認できませんでした。対象シフトを確認して再度お試しください。',
+			);
 		});
 
 		it('スタッフが見つからない場合は 404 エラーを返す', async () => {

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -259,7 +259,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 		);
 	});
 
-	it('x-ai-response-format: uimessage かつ context.shifts が空でも UIMessage で返し、proposeShiftChange 関連指示は含めない', async () => {
+	it('x-ai-response-format: uimessage かつ context.shifts が空なら、JSONコードブロック必須ではなく質問を促す指示を使う', async () => {
 		const request = new Request('http://localhost/api/chat/shift-adjustment', {
 			method: 'POST',
 			headers: {
@@ -287,14 +287,21 @@ describe('POST /api/chat/shift-adjustment', () => {
 		expect(mockStreamText).toHaveBeenCalledWith(
 			expect.objectContaining({
 				system: expect.stringContaining(
-					'proposeShiftChange ツールは利用できません',
+					'assistant 本文に JSON やコードブロックを出力してはならない',
 				),
 			}),
 		);
 		expect(mockStreamText).toHaveBeenCalledWith(
 			expect.objectContaining({
 				system: expect.not.stringContaining(
-					'assistant の本文に JSON を直接書かず、必ず proposeShiftChange ツールを呼び出して返す',
+					'必ず assistant メッセージ内に 1 つの json コードブロックを含める',
+				),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(
+					'必要な情報をユーザーに質問して対象シフトを特定する',
 				),
 			}),
 		);

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -1464,6 +1464,72 @@ describe('POST /api/chat/shift-adjustment', () => {
 			);
 		});
 
+		it('proposeShiftChange tool は shift 取得エラー時にログを残して汎用エラーを返す', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+			mockShiftMaybeSingle.mockResolvedValue({
+				data: null,
+				error: { message: 'network error' },
+			});
+
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '提案して' }],
+						context: {
+							shifts: [
+								{
+									id: TEST_IDS.SCHEDULE_1,
+									clientId: TEST_IDS.CLIENT_1,
+									serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+									date: '2025-01-20',
+									startTime: '09:00',
+									endTime: '10:00',
+								},
+							],
+						},
+					}),
+				},
+			);
+
+			await POST(request);
+
+			const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+				tools?: {
+					proposeShiftChange?: {
+						execute?: (input: {
+							type: 'change_shift_staff';
+							shiftId: string;
+							toStaffId: string;
+						}) => Promise<unknown>;
+					};
+				};
+			};
+
+			const execute = streamTextCall.tools?.proposeShiftChange?.execute;
+			await expect(
+				execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+				}),
+			).rejects.toThrow(
+				'対象シフトの確認中にエラーが発生しました。時間をおいて再度お試しください。',
+			);
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				'Failed to verify shift in proposeShiftChange tool',
+				expect.objectContaining({ message: 'network error' }),
+			);
+			consoleErrorSpy.mockRestore();
+		});
+
 		it('スタッフが見つからない場合は 404 エラーを返す', async () => {
 			mockStaffMaybeSingle.mockResolvedValue({
 				data: null,

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -488,6 +488,35 @@ describe('POST /api/chat/shift-adjustment', () => {
 		expect(mockStreamText).not.toHaveBeenCalled();
 	});
 
+	it('non-text part の JSON サイズが上限を超える場合は 400 エラーを返す', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [
+					{
+						role: 'assistant',
+						parts: [
+							{
+								type: 'tool-searchStaffs',
+								toolCallId: 'call_too_large',
+								state: 'output-available',
+								output: {
+									payload: 'x'.repeat(20001),
+								},
+							},
+						],
+					},
+				],
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(400);
+		expect(mockStreamText).not.toHaveBeenCalled();
+	});
+
 	it('messages が空の場合は 400 エラーを返す', async () => {
 		const request = new Request('http://localhost/api/chat/shift-adjustment', {
 			method: 'POST',

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -16,6 +16,7 @@ import { z } from 'zod';
 // AI SDK v6 の UIMessage 形式（parts 配列）をサポート
 const CHAT_MESSAGE_CONTENT_MAX_LENGTH = 10000;
 const CHAT_MESSAGE_PARTS_MAX_COUNT = 50;
+const NON_TEXT_PART_JSON_MAX_LENGTH = 20000;
 
 const TextPartSchema = z.object({
 	type: z.literal('text'),
@@ -29,7 +30,13 @@ const NonTextPartSchema = z
 	.passthrough()
 	.refine((part) => part.type !== 'text', {
 		message: "Part type must not be 'text'",
-	});
+	})
+	.refine(
+		(part) => JSON.stringify(part).length <= NON_TEXT_PART_JSON_MAX_LENGTH,
+		{
+			message: `Non-text part JSON size must be at most ${NON_TEXT_PART_JSON_MAX_LENGTH} characters`,
+		},
+	);
 
 const MessagePartSchema = z.union([TextPartSchema, NonTextPartSchema]);
 

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -281,11 +281,20 @@ const createProposeShiftChangeTool = (
 				);
 			}
 
-			const { data: shiftData } = await supabase
+			const { data: shiftData, error: shiftError } = await supabase
 				.from('shifts')
 				.select('id')
 				.eq('id', proposal.shiftId)
 				.maybeSingle<{ id: string }>();
+			if (shiftError) {
+				console.error(
+					'Failed to verify shift in proposeShiftChange tool',
+					shiftError,
+				);
+				throw new Error(
+					'対象シフトの確認中にエラーが発生しました。時間をおいて再度お試しください。',
+				);
+			}
 
 			if (!shiftData) {
 				throw new Error(

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -156,6 +156,12 @@ const PROPOSAL_TOOL_PROMPT = `
 - 対象シフト（shiftId）が特定でき、シフト変更の提案を提示する段階では、proposeShiftChange の呼び出し（ツール実行）は必須であり、省略してはならない
 - ただし対象シフト（shiftId）が未特定など情報不足時は、proposeShiftChange を無理に呼び出さず、必要な確認質問のみを行ってよい
 - proposeShiftChange 呼び出し後は、まだ未確定であることを明示し、UI の確定操作（例: 確定ボタン）で確定するよう案内する`;
+const UI_MESSAGE_NO_PROPOSAL_PROMPT = `
+- proposeShiftChange ツールは利用できません
+- assistant 本文に JSON やコードブロックを出力してはならない
+- シフト変更の提案を行う前に、必要な情報をユーザーに質問して対象シフトを特定する
+- 対象シフト（shiftId）が未特定など情報不足時は、必要な確認質問のみを行う
+- proposeShiftChange が使えない前提で、確定操作前の候補案は自然文で簡潔に説明する`;
 
 const BASE_SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサポートするAIアシスタントです。
 
@@ -219,9 +225,16 @@ const SUCCESS_ASSERTION_PROMPT = `
 日本語で丁寧に対応してください。`;
 
 // UIMessage モードか否かに応じてシステムプロンプトを切り替える
-const buildSystemPromptBase = (useProposalTool: boolean): string =>
+const buildSystemPromptBase = (
+	useUIMessageStream: boolean,
+	useProposalTool: boolean,
+): string =>
 	BASE_SYSTEM_PROMPT +
-	(useProposalTool ? PROPOSAL_TOOL_PROMPT : LEGACY_PROPOSAL_TOOL_PROMPT) +
+	(useProposalTool
+		? PROPOSAL_TOOL_PROMPT
+		: useUIMessageStream
+			? UI_MESSAGE_NO_PROPOSAL_PROMPT
+			: LEGACY_PROPOSAL_TOOL_PROMPT) +
 	COMMON_CONSTRAINTS_PROMPT +
 	(useProposalTool
 		? `
@@ -482,7 +495,8 @@ const resolveStreamMode = (
 		useUIMessageStream,
 		useProposalTool,
 		systemPrompt:
-			buildSystemPromptBase(useProposalTool) + buildContextPrompt(context),
+			buildSystemPromptBase(useUIMessageStream, useProposalTool) +
+			buildContextPrompt(context),
 	};
 };
 

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -26,7 +26,7 @@ const NonTextPartSchema = z
 	.object({
 		type: z.string().min(1),
 	})
-	.strip()
+	.passthrough()
 	.refine((part) => part.type !== 'text', {
 		message: "Part type must not be 'text'",
 	});
@@ -51,7 +51,7 @@ const ChatMessageSchema = z
 			}
 
 			const totalTextLength = message.parts.reduce((sum, part) => {
-				if (part.type !== 'text' || !('text' in part)) {
+				if (part.type !== 'text' || typeof part.text !== 'string') {
 					return sum;
 				}
 
@@ -266,6 +266,7 @@ ${shiftLines.join('\n')}${shiftSelectionPrompt}`;
 };
 
 const createProposeShiftChangeTool = (
+	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
 	shifts: Array<{ id: string }> | undefined,
 ) => {
 	const allowlistedShiftIds = new Set((shifts ?? []).map((shift) => shift.id));
@@ -277,6 +278,18 @@ const createProposeShiftChangeTool = (
 			if (!allowlistedShiftIds.has(proposal.shiftId)) {
 				throw new Error(
 					'シフトIDが不正です。候補に含まれているシフトから選択してください。',
+				);
+			}
+
+			const { data: shiftData } = await supabase
+				.from('shifts')
+				.select('id')
+				.eq('id', proposal.shiftId)
+				.maybeSingle<{ id: string }>();
+
+			if (!shiftData) {
+				throw new Error(
+					'指定されたシフトを確認できませんでした。対象シフトを確認して再度お試しください。',
 				);
 			}
 
@@ -295,6 +308,85 @@ const normalizeMessages = (
 type AdminStaffResult =
 	| { ok: true; staffData: { office_id: string; role: 'admin' | 'helper' } }
 	| { ok: false; response: Response };
+
+type ParseChatRequestResult =
+	| { ok: true; data: ChatRequest }
+	| { ok: false; response: Response };
+
+type AuthenticatedUserResult =
+	| {
+			ok: true;
+			supabase: Awaited<ReturnType<typeof createSupabaseClient>>;
+			user: { id: string };
+	  }
+	| { ok: false; response: Response };
+
+const getAuthenticatedUser = async (): Promise<AuthenticatedUserResult> => {
+	const supabase = await createSupabaseClient();
+	const {
+		data: { user },
+		error: authError,
+	} = await supabase.auth.getUser();
+
+	if (authError || !user) {
+		return {
+			ok: false,
+			response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+		};
+	}
+
+	return { ok: true, supabase, user: { id: user.id } };
+};
+
+type ApiKeyResult =
+	| { ok: true; apiKey: string }
+	| { ok: false; response: Response };
+
+const getApiKey = (): ApiKeyResult => {
+	const apiKey = process.env.GEMINI_API_KEY;
+	if (!apiKey) {
+		console.error('GEMINI_API_KEY is not configured');
+		return {
+			ok: false,
+			response: NextResponse.json(
+				{ error: 'AI service is not configured' },
+				{ status: 500 },
+			),
+		};
+	}
+
+	return { ok: true, apiKey };
+};
+
+const parseChatRequest = async (
+	request: Request,
+): Promise<ParseChatRequestResult> => {
+	const body = await request.json().catch(() => null);
+
+	if (!body) {
+		return {
+			ok: false,
+			response: NextResponse.json(
+				{ error: 'Invalid JSON in request body' },
+				{ status: 400 },
+			),
+		};
+	}
+
+	const parseResult = ChatRequestSchema.safeParse(body);
+
+	if (!parseResult.success) {
+		return {
+			ok: false,
+			response: NextResponse.json(
+				{ error: 'Invalid request', issues: parseResult.error.issues },
+				{ status: 400 },
+			),
+		};
+	}
+
+	return { ok: true, data: parseResult.data };
+};
 
 const fetchAdminStaff = async (
 	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
@@ -338,6 +430,7 @@ const fetchAdminStaff = async (
 };
 
 const buildTools = (
+	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
 	baseTools: {
 		searchAvailableHelpers: ReturnType<typeof createSearchAvailableHelpersTool>;
 		processStaffAbsence: ReturnType<typeof createProcessStaffAbsenceTool>;
@@ -356,117 +449,115 @@ const buildTools = (
 
 	return {
 		...baseTools,
-		proposeShiftChange: createProposeShiftChangeTool(shiftList),
+		proposeShiftChange: createProposeShiftChangeTool(supabase, shiftList),
 	};
+};
+
+const resolveStreamMode = (
+	request: Request,
+	context: ChatRequest['context'],
+) => {
+	const useUIMessageStream =
+		request.headers.get('x-ai-response-format') === 'uimessage';
+	const useProposalTool =
+		useUIMessageStream && (context?.shifts?.length ?? 0) > 0;
+
+	return {
+		useUIMessageStream,
+		useProposalTool,
+		systemPrompt:
+			buildSystemPromptBase(useProposalTool) + buildContextPrompt(context),
+	};
+};
+
+const toChatResponse = (
+	result: {
+		toUIMessageStreamResponse: () => Response;
+		toTextStreamResponse: () => Response;
+	},
+	useUIMessageStream: boolean,
+): Response => {
+	if (useUIMessageStream) {
+		return result.toUIMessageStreamResponse();
+	}
+
+	return result.toTextStreamResponse();
+};
+
+const handlePost = async (request: Request): Promise<Response> => {
+	const authResult = await getAuthenticatedUser();
+	if (!authResult.ok) {
+		return authResult.response;
+	}
+	const { supabase, user } = authResult;
+
+	const parsedRequest = await parseChatRequest(request);
+	if (!parsedRequest.ok) {
+		return parsedRequest.response;
+	}
+
+	const { messages, context } = parsedRequest.data;
+
+	const apiKeyResult = getApiKey();
+	if (!apiKeyResult.ok) {
+		return apiKeyResult.response;
+	}
+	const { apiKey } = apiKeyResult;
+
+	const staffResult = await fetchAdminStaff(supabase, user.id);
+	if (!staffResult.ok) {
+		return staffResult.response;
+	}
+	const { staffData } = staffResult;
+
+	const { useUIMessageStream, useProposalTool, systemPrompt } =
+		resolveStreamMode(request, context);
+
+	const google = createGoogleGenerativeAI({ apiKey });
+	const searchAvailableHelpersTool = createSearchAvailableHelpersTool({
+		supabase,
+		officeId: staffData.office_id,
+	});
+	const processStaffAbsenceTool = createProcessStaffAbsenceTool({
+		supabase,
+		userId: user.id,
+	});
+	const searchStaffsTool = createSearchStaffsTool({
+		supabase,
+		officeId: staffData.office_id,
+	});
+	const tools = buildTools(
+		supabase,
+		{
+			searchAvailableHelpers: searchAvailableHelpersTool,
+			processStaffAbsence: processStaffAbsenceTool,
+			searchStaffs: searchStaffsTool,
+		},
+		context?.shifts,
+		useProposalTool,
+	);
+
+	const modelMessages = await convertToModelMessages(
+		normalizeMessages(messages),
+		{
+			tools,
+		},
+	);
+
+	const result = streamText({
+		model: google('gemini-2.5-flash'),
+		system: systemPrompt,
+		messages: modelMessages,
+		tools,
+		stopWhen: stepCountIs(5),
+	});
+
+	return toChatResponse(result, useUIMessageStream);
 };
 
 export const POST = async (request: Request): Promise<Response> => {
 	try {
-		// 認証チェック
-		const supabase = await createSupabaseClient();
-		const {
-			data: { user },
-			error: authError,
-		} = await supabase.auth.getUser();
-
-		if (authError || !user) {
-			return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-		}
-
-		const body = await request.json().catch(() => null);
-
-		if (!body) {
-			return NextResponse.json(
-				{ error: 'Invalid JSON in request body' },
-				{ status: 400 },
-			);
-		}
-
-		const parseResult = ChatRequestSchema.safeParse(body);
-
-		if (!parseResult.success) {
-			return NextResponse.json(
-				{ error: 'Invalid request', issues: parseResult.error.issues },
-				{ status: 400 },
-			);
-		}
-
-		const { messages, context } = parseResult.data;
-
-		const apiKey = process.env.GEMINI_API_KEY;
-		if (!apiKey) {
-			console.error('GEMINI_API_KEY is not configured');
-			return NextResponse.json(
-				{ error: 'AI service is not configured' },
-				{ status: 500 },
-			);
-		}
-
-		// スタッフの office_id と role を取得 & 認可チェック
-		const staffResult = await fetchAdminStaff(supabase, user.id);
-		if (!staffResult.ok) {
-			return staffResult.response;
-		}
-		const { staffData } = staffResult;
-
-		// UIMessage モード判定: クライアントが UIMessage ストリームに対応している場合のみ
-		// proposeShiftChange ツールを有効にし、UIMessage ストリームで返す。
-		// 既存の TextStreamChatTransport 互換クライアントはヘッダーを送らないため、
-		// ヘッダーなし時は JSON コードブロック形式のレガシー動作を維持する。
-		// x-ai-response-format: uimessage ヘッダーで UIMessage ストリーム形式を要求
-		// （proposeShiftChange ツールの有無はさらに context.shifts の有無で決まる）
-		const useUIMessageStream =
-			request.headers.get('x-ai-response-format') === 'uimessage';
-
-		const systemPrompt =
-			buildSystemPromptBase(useUIMessageStream) + buildContextPrompt(context);
-
-		// GEMINI_API_KEY を使用して Google AI プロバイダーを初期化
-		const google = createGoogleGenerativeAI({ apiKey });
-
-		// Tool を作成
-		const searchAvailableHelpersTool = createSearchAvailableHelpersTool({
-			supabase,
-			officeId: staffData.office_id,
-		});
-		const processStaffAbsenceTool = createProcessStaffAbsenceTool({
-			supabase,
-			userId: user.id,
-		});
-		const searchStaffsTool = createSearchStaffsTool({
-			supabase,
-			officeId: staffData.office_id,
-		});
-		const tools = buildTools(
-			{
-				searchAvailableHelpers: searchAvailableHelpersTool,
-				processStaffAbsence: processStaffAbsenceTool,
-				searchStaffs: searchStaffsTool,
-			},
-			context?.shifts,
-			useUIMessageStream,
-		);
-
-		const modelMessages = await convertToModelMessages(
-			normalizeMessages(messages),
-			{
-				tools,
-			},
-		);
-
-		const result = streamText({
-			model: google('gemini-2.5-flash'),
-			system: systemPrompt,
-			messages: modelMessages,
-			tools,
-			stopWhen: stepCountIs(5),
-		});
-
-		if (useUIMessageStream) {
-			return result.toUIMessageStreamResponse();
-		}
-
-		return result.toTextStreamResponse();
+		return await handlePost(request);
 	} catch (error) {
 		console.error('Chat API error:', error);
 		// 内部エラーの詳細はクライアントに露出しない


### PR DESCRIPTION
## 概要

AIチャットAPIにおいて、シフト変更提案を従来の JSON コードブロック埋め込みから **tool calling（proposeShiftChange ツール）** 経由で返すように変更します。

本 PR はサーバ側（APIルート）のみの変更です。クライアント側（UIの提案カード表示等）は追随 PR（PR-B）で対応予定。

Refs #143
Refs #141

---

## 変更内容（サーバ側のみ）

### 新規追加
- **`proposeShiftChange` ツール**: `AiChatMutationProposalSchema` を `inputSchema` として使用し、シフト変更提案を tool result として返す
  - `shiftId` の allowlist バリデーション（context.shifts に含まれる値のみ許可）
  - `createProposeShiftChangeTool` ヘルパー関数として分離

### 変更
- **メッセージ変換**: `messages.map` による手動変換 → `convertToModelMessages` 使用（`normalizeMessages` ヘルパーで parts 正規化）
- **レスポンス形式**: `toTextStreamResponse()` → `toUIMessageStreamResponse()`（tool result を含む UI ストリーム）
- **ステップ上限**: `stepCountIs(3)` → `stepCountIs(5)`（tool calling の往復回数を考慮）
- **システムプロンプト**: proposeShiftChange ツール利用ルール・制約に更新

### 削除
- `extractContent` ヘルパー関数（`convertToModelMessages` が代替）
- システムプロンプトの JSON コードブロック埋め込みルール

### リファクタリング
- `fetchAdminStaff` ヘルパー関数に認可チェックを分離（POST の cyclomatic complexity 削減）

### テスト
- 43 ユニットテスト全通過

---

## クライアント側の残作業（PR-B で対応）

- `useUIMessageStreamResponse` / `toUIMessageStreamResponse` に対応したクライアント実装
- tool result からの提案データ取得・表示ロジックの更新
- 提案カード表示コンポーネントの更新