### PR TITLE
feat(#145) PR-B1: UIMessage transport化 + tool-result からの proposal 抽出（下地）

### DIFF
--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -8,6 +8,9 @@ vi.mock('ai', () => ({
 	TextStreamChatTransport: class MockTextStreamChatTransport {
 		constructor() {}
 	},
+	DefaultChatTransport: class MockDefaultChatTransport {
+		constructor() {}
+	},
 }));
 
 // @ai-sdk/react のモック（Storybook環境でのESM互換性問題を回避）

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -1,9 +1,17 @@
 import { TEST_IDS } from '@/test/helpers/testIds';
 import type { UIMessage } from 'ai';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { extractProposalFromParts } from './extractProposalFromParts';
 
 describe('extractProposalFromParts', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	const allowlist = {
 		shiftIds: [TEST_IDS.SCHEDULE_1],
 		staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -1,0 +1,125 @@
+import { TEST_IDS } from '@/test/helpers/testIds';
+import type { UIMessage } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { extractProposalFromParts } from './extractProposalFromParts';
+
+describe('extractProposalFromParts', () => {
+	const allowlist = {
+		shiftIds: [TEST_IDS.SCHEDULE_1],
+		staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],
+	};
+
+	const createDynamicToolPart = (
+		output: unknown,
+	): UIMessage['parts'][number] => ({
+		type: 'dynamic-tool',
+		toolName: 'proposeShiftChange',
+		toolCallId: 'call_1',
+		state: 'output-available',
+		input: {},
+		output,
+	});
+
+	it('change_shift_staff の tool output から proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createDynamicToolPart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: '欠勤対応',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '欠勤対応',
+		});
+	});
+
+	it('update_shift_time の tool output から proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createDynamicToolPart({
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: '2026-03-16T09:00:00+09:00',
+				endAt: '2026-03-16T10:00:00+09:00',
+				reason: '利用者都合',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'update_shift_time',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			startAt: '2026-03-16T09:00:00+09:00',
+			endAt: '2026-03-16T10:00:00+09:00',
+			reason: '利用者都合',
+		});
+	});
+
+	it('tool パートが無い場合は null', () => {
+		const parts: UIMessage['parts'] = [{ type: 'text', text: '提案なし' }];
+
+		expect(extractProposalFromParts(parts, allowlist)).toBeNull();
+	});
+
+	it('state が output-available でない場合は null', () => {
+		const parts: UIMessage['parts'] = [
+			{
+				type: 'dynamic-tool',
+				toolName: 'proposeShiftChange',
+				toolCallId: 'call_1',
+				state: 'input-available',
+				input: {
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+				},
+			},
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toBeNull();
+	});
+
+	it('schema 不一致の output は null', () => {
+		const parts: UIMessage['parts'] = [
+			createDynamicToolPart({
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: 'invalid-date',
+				endAt: '2026-03-16T10:00:00+09:00',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toBeNull();
+	});
+
+	it('allowlist にない shiftId は null', () => {
+		const parts: UIMessage['parts'] = [
+			createDynamicToolPart({
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_2,
+				startAt: '2026-03-16T09:00:00+09:00',
+				endAt: '2026-03-16T10:00:00+09:00',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toBeNull();
+	});
+
+	it('allowlist にない toStaffId は null', () => {
+		const parts: UIMessage['parts'] = [
+			createDynamicToolPart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_4,
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toBeNull();
+	});
+
+	it('parts が空配列の場合は null', () => {
+		expect(extractProposalFromParts([], allowlist)).toBeNull();
+	});
+});

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -20,9 +20,19 @@ describe('extractProposalFromParts', () => {
 		output,
 	});
 
+	const createProposeShiftChangePart = (
+		output: unknown,
+	): UIMessage['parts'][number] => ({
+		type: 'tool-proposeShiftChange',
+		toolCallId: 'call_1',
+		state: 'output-available',
+		input: {},
+		output,
+	});
+
 	it('change_shift_staff の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_2,
@@ -40,7 +50,7 @@ describe('extractProposalFromParts', () => {
 
 	it('update_shift_time の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -67,8 +77,7 @@ describe('extractProposalFromParts', () => {
 	it('state が output-available でない場合は null', () => {
 		const parts: UIMessage['parts'] = [
 			{
-				type: 'dynamic-tool',
-				toolName: 'proposeShiftChange',
+				type: 'tool-proposeShiftChange',
 				toolCallId: 'call_1',
 				state: 'input-available',
 				input: {
@@ -83,7 +92,7 @@ describe('extractProposalFromParts', () => {
 
 	it('schema 不一致の output は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: 'invalid-date',
@@ -96,7 +105,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない shiftId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_2,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -109,7 +118,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない toStaffId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_4,
@@ -121,5 +130,45 @@ describe('extractProposalFromParts', () => {
 
 	it('parts が空配列の場合は null', () => {
 		expect(extractProposalFromParts([], allowlist)).toBeNull();
+	});
+
+	it('text と別ツールが混在していても proposeShiftChange を優先して返す', () => {
+		const parts: UIMessage['parts'] = [
+			{ type: 'text', text: '候補を確認中です。' },
+			{
+				type: 'tool-searchStaffs',
+				toolCallId: 'call_search_1',
+				state: 'output-available',
+				input: { name: '佐藤' },
+				output: { staffs: [] },
+			},
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+		});
+	});
+
+	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
+		const parts: UIMessage['parts'] = [
+			createDynamicToolPart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -156,6 +156,54 @@ describe('extractProposalFromParts', () => {
 		});
 	});
 
+	it('1つ目の tool-proposeShiftChange が schema NG でも 2つ目が OK なら proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: 'invalid-date',
+				endAt: '2026-03-16T10:00:00+09:00',
+			}),
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: '修正済み提案',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '修正済み提案',
+		});
+	});
+
+	it('1つ目の tool-proposeShiftChange が allowlist NG でも 2つ目が OK なら proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_4,
+				reason: 'allowlist 外のスタッフ',
+			}),
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: 'allowlist 内のスタッフ',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: 'allowlist 内のスタッフ',
+		});
+	});
+
 	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
 		const parts: UIMessage['parts'] = [
 			createDynamicToolPart({

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -45,12 +45,12 @@ export const extractProposalFromParts = (
 		const parsed = AiChatMutationProposalSchema.safeParse(part.output);
 		if (!parsed.success) {
 			console.warn('[extractProposalFromParts] schema validation failed');
-			return null;
+			continue;
 		}
 
 		if (!isAllowedProposal(parsed.data, allowlist)) {
 			console.warn('[extractProposalFromParts] allowlist rejected proposal');
-			return null;
+			continue;
 		}
 
 		return parsed.data;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -1,0 +1,41 @@
+import {
+	AiChatMutationProposalSchema,
+	type AiChatMutationProposal,
+} from '@/models/aiChatMutationProposal';
+import type { UIMessage } from 'ai';
+import { isAllowedProposal, type ProposalAllowlist } from './parseProposal';
+
+const PROPOSAL_TOOL_NAME = 'proposeShiftChange';
+
+export const extractProposalFromParts = (
+	parts: UIMessage['parts'],
+	allowlist: ProposalAllowlist,
+): AiChatMutationProposal | null => {
+	for (const part of parts) {
+		if (part.type !== 'dynamic-tool') {
+			continue;
+		}
+
+		if (
+			part.toolName !== PROPOSAL_TOOL_NAME ||
+			part.state !== 'output-available'
+		) {
+			continue;
+		}
+
+		const parsed = AiChatMutationProposalSchema.safeParse(part.output);
+		if (!parsed.success) {
+			console.warn('[extractProposalFromParts] schema validation failed');
+			return null;
+		}
+
+		if (!isAllowedProposal(parsed.data, allowlist)) {
+			console.warn('[extractProposalFromParts] allowlist rejected proposal');
+			return null;
+		}
+
+		return parsed.data;
+	}
+
+	return null;
+};

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -6,20 +6,39 @@ import type { UIMessage } from 'ai';
 import { isAllowedProposal, type ProposalAllowlist } from './parseProposal';
 
 const PROPOSAL_TOOL_NAME = 'proposeShiftChange';
+const PROPOSAL_TOOL_PART_TYPE = 'tool-proposeShiftChange';
+
+type ProposalOutputPart = Extract<
+	UIMessage['parts'][number],
+	{ state: 'output-available'; output: unknown }
+>;
+
+const isOutputAvailablePart = (
+	part: UIMessage['parts'][number],
+): part is ProposalOutputPart => {
+	return (
+		'state' in part && part.state === 'output-available' && 'output' in part
+	);
+};
+
+const isProposalToolPart = (part: ProposalOutputPart): boolean => {
+	if (part.type === PROPOSAL_TOOL_PART_TYPE) {
+		return true;
+	}
+
+	if (part.type !== 'dynamic-tool') {
+		return false;
+	}
+
+	return part.toolName === PROPOSAL_TOOL_NAME;
+};
 
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
 ): AiChatMutationProposal | null => {
 	for (const part of parts) {
-		if (part.type !== 'dynamic-tool') {
-			continue;
-		}
-
-		if (
-			part.toolName !== PROPOSAL_TOOL_NAME ||
-			part.state !== 'output-available'
-		) {
+		if (!isOutputAvailablePart(part) || !isProposalToolPart(part)) {
 			continue;
 		}
 

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/parseProposal.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/parseProposal.ts
@@ -44,7 +44,7 @@ const extractJsonCodeBlock = (
 	return { jsonText, failReason: null };
 };
 
-const isAllowedProposal = (
+export const isAllowedProposal = (
 	proposal: AiChatMutationProposal,
 	allowlist: ProposalAllowlist,
 ): boolean => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useAdjustmentChat.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useAdjustmentChat.ts
@@ -1,6 +1,6 @@
 import type { ServiceTypeId } from '@/models/valueObjects/serviceTypeId';
 import { useChat } from '@ai-sdk/react';
-import { TextStreamChatTransport, type UIMessage } from 'ai';
+import { DefaultChatTransport, type UIMessage } from 'ai';
 import { useCallback, useMemo } from 'react';
 
 export type ChatMessage = {
@@ -27,6 +27,7 @@ type UseAdjustmentChatOptions = {
 
 type UseAdjustmentChatReturn = {
 	messages: ChatMessage[];
+	rawMessages: UIMessage[];
 	isStreaming: boolean;
 	error: string | null;
 	sendMessage: (content: string) => Promise<void>;
@@ -58,8 +59,11 @@ export const useAdjustmentChat = ({
 	// transport を shiftContext に基づいて作成
 	const transport = useMemo(
 		() =>
-			new TextStreamChatTransport({
+			new DefaultChatTransport({
 				api: '/api/chat/shift-adjustment',
+				headers: {
+					'x-ai-response-format': 'uimessage',
+				},
 				body: {
 					context: {
 						shifts: [shiftContext],
@@ -108,6 +112,7 @@ export const useAdjustmentChat = ({
 
 	return {
 		messages,
+		rawMessages: sdkMessages,
 		isStreaming,
 		error: sdkError?.message ?? null,
 		sendMessage,


### PR DESCRIPTION
- [x] レビューコメントの内容を確認
- [x] `extractProposalFromParts.ts`: schema NG / allowlist NG 時に `return null` → `continue` で後続 part を探索
- [x] `extractProposalFromParts.test.ts`: NG→OK の複数 proposal part ケースのテスト追加（schema NG→OK / allowlist NG→OK の2ケース）
- [x] テスト実行で確認（12テスト全パス）
- [x] コードレビュー（指摘なし）
- [x] CodeQL セキュリティスキャン（アラートなし）