### PR TITLE
feat(#146) PR-B2: tool結果→提案カード配線

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
@@ -2,6 +2,7 @@ import type { ExecuteAiChatMutationResult } from '@/models/aiChatMutationProposa
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { UIMessage } from 'ai';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { AdjustmentChatDialog } from './AdjustmentChatDialog';
 
@@ -54,8 +55,8 @@ const createMockUseChatReturn = (overrides: Record<string, unknown> = {}) => ({
 	...overrides,
 });
 
-const createProposalMessage = (proposalJson: string) => ({
-	id: 'assistant-1',
+const createProposalMessage = (proposalJson: string, id = 'assistant-1') => ({
+	id,
 	role: 'assistant',
 	parts: [
 		{
@@ -67,8 +68,11 @@ ${proposalJson}
 		},
 	],
 });
-const createJsonOnlyProposalMessage = (proposalJson: string) => ({
-	id: 'assistant-json-only',
+const createJsonOnlyProposalMessage = (
+	proposalJson: string,
+	id = 'assistant-json-only',
+) => ({
+	id,
 	role: 'assistant',
 	parts: [
 		{
@@ -77,6 +81,33 @@ const createJsonOnlyProposalMessage = (proposalJson: string) => ({
 ${proposalJson}
 \`\`\``,
 		},
+	],
+});
+
+const createToolProposeShiftChangePart = (
+	output: unknown,
+): UIMessage['parts'][number] => ({
+	type: 'tool-proposeShiftChange',
+	toolCallId: 'call_1',
+	state: 'output-available',
+	input: {},
+	output,
+});
+
+const createToolProposalAssistantMessage = ({
+	id,
+	output,
+	text,
+}: {
+	id: string;
+	output: unknown;
+	text?: string;
+}): UIMessage => ({
+	id,
+	role: 'assistant',
+	parts: [
+		...(text ? [{ type: 'text' as const, text }] : []),
+		createToolProposeShiftChangePart(output),
 	],
 });
 
@@ -333,6 +364,109 @@ describe('AdjustmentChatDialog', () => {
 		expect(
 			screen.getByText(/AI service is not configured/),
 		).toBeInTheDocument();
+	});
+
+	it('rawMessages に tool-proposeShiftChange の output-available があると ProposalConfirmCard を表示する', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createToolProposalAssistantMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						output: {
+							type: 'change_shift_staff',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							toStaffId: TEST_IDS.STAFF_2,
+						},
+					}),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
+	});
+
+	it('tool-based と本文 JSON が両方ある場合は tool-based proposal を優先する', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createToolProposalAssistantMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						text: `提案です
+\`\`\`json
+{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}
+\`\`\``,
+						output: {
+							type: 'update_shift_time',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							startAt: '2026-02-24T12:00:00+09:00',
+							endAt: '2026-02-24T13:00:00+09:00',
+						},
+					}),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('時間変更')).toBeInTheDocument();
+		expect(screen.queryByText('担当者変更')).not.toBeInTheDocument();
+	});
+
+	it('tool-based proposal がない場合は parseProposal fallback で ProposalConfirmCard を表示する', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createJsonOnlyProposalMessage(
+						`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`,
+						TEST_IDS.SCHEDULE_2,
+					),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
 	});
 
 	it('assistant の最新メッセージに提案 JSON があると ProposalConfirmCard を表示する', () => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import type { UIMessage } from 'ai';
 import { type ReactNode, useMemo, useState } from 'react';
 import { buildProposalDisplayValues } from './buildProposalDisplayValues';
 import { ChatInput } from './ChatInput';
 import { ChatMessageList } from './ChatMessageList';
+import { extractProposalFromParts } from './extractProposalFromParts';
 import { parseProposal } from './parseProposal';
 import { ProposalConfirmCard } from './ProposalConfirmCard';
 import type { ShiftContext } from './useAdjustmentChat';
@@ -23,14 +25,10 @@ type AdjustmentChatDialogProps = {
  * 最新 assistant に proposal が無い場合は null を返し、過去提案へはフォールバックしない。
  */
 const findLatestProposal = (
-	messages: Array<{ id: string; role: string; content: string }>,
+	messages: UIMessage[],
 	allowlist: Parameters<typeof parseProposal>[1],
 ) => {
-	let latestAssistantMessage: {
-		id: string;
-		role: string;
-		content: string;
-	} | null = null;
+	let latestAssistantMessage: UIMessage | null = null;
 
 	for (let index = messages.length - 1; index >= 0; index -= 1) {
 		const message = messages[index];
@@ -41,11 +39,32 @@ const findLatestProposal = (
 		}
 	}
 
-	if (!latestAssistantMessage?.content) {
+	if (!latestAssistantMessage) {
 		return null;
 	}
 
-	const proposal = parseProposal(latestAssistantMessage.content, allowlist);
+	const proposalFromTool = extractProposalFromParts(
+		latestAssistantMessage.parts,
+		allowlist,
+	);
+
+	if (proposalFromTool) {
+		return { messageId: latestAssistantMessage.id, proposal: proposalFromTool };
+	}
+
+	const textContent = latestAssistantMessage.parts
+		.filter(
+			(part): part is Extract<UIMessage['parts'][number], { type: 'text' }> =>
+				part.type === 'text',
+		)
+		.map((part) => part.text)
+		.join('');
+
+	if (!textContent) {
+		return null;
+	}
+
+	const proposal = parseProposal(textContent, allowlist);
 
 	if (!proposal) {
 		return null;
@@ -97,11 +116,10 @@ export const AdjustmentChatDialog = ({
 	staffOptions,
 	onClose,
 }: AdjustmentChatDialogProps) => {
-	const { messages, isStreaming, error, sendMessage, stop } = useAdjustmentChat(
-		{
+	const { messages, rawMessages, isStreaming, error, sendMessage, stop } =
+		useAdjustmentChat({
 			shiftContext,
-		},
-	);
+		});
 
 	const staffIdsAllowlist = useMemo(
 		() => staffOptions.map((staffOption) => staffOption.id),
@@ -117,14 +135,14 @@ export const AdjustmentChatDialog = ({
 
 	/** 最新の assistant メッセージ（id + parsed proposal）を返す */
 	const { detectedProposal, proposalKey } = useMemo(() => {
-		const result = findLatestProposal(messages, allowlist);
+		const result = findLatestProposal(rawMessages, allowlist);
 
 		return {
 			detectedProposal: result ? result.proposal : null,
 			// dismiss キーは「この assistant メッセージの id」で安定管理する
 			proposalKey: result ? result.messageId : null,
 		};
-	}, [messages, allowlist]);
+	}, [rawMessages, allowlist]);
 
 	const proposalDisplayValues = useMemo(() => {
 		if (!detectedProposal) {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
@@ -115,6 +115,22 @@ describe('ChatMessageList', () => {
 		).not.toBeInTheDocument();
 	});
 
+	it('proposalMessageId に一致し assistant content が空文字のときは行を非表示にする', () => {
+		render(
+			<ChatMessageList
+				proposalMessageId={TEST_IDS.SCHEDULE_1}
+				messages={[
+					createMessage({
+						id: TEST_IDS.SCHEDULE_1,
+						content: '',
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.queryByText('AIアシスタント')).not.toBeInTheDocument();
+	});
+
 	it('proposalMessageId が異なる他のメッセージは非表示にしない', () => {
 		render(
 			<ChatMessageList

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
@@ -131,6 +131,51 @@ describe('ChatMessageList', () => {
 		expect(screen.queryByText('AIアシスタント')).not.toBeInTheDocument();
 	});
 
+	it('proposalMessageId と異なる assistant の空 content 行は非表示にする', () => {
+		render(
+			<ChatMessageList
+				proposalMessageId={TEST_IDS.SCHEDULE_1}
+				messages={[
+					createMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						content: '',
+					}),
+					createMessage({
+						id: TEST_IDS.CLIENT_1,
+						role: 'user',
+						content: '確認しました',
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.queryByText('AIアシスタント')).not.toBeInTheDocument();
+		expect(screen.getByText('あなた')).toBeInTheDocument();
+		expect(
+			document.querySelector('.loading.loading-sm.loading-dots'),
+		).not.toBeInTheDocument();
+	});
+
+	it('streaming 中の最後の assistant 空 content 行は loading dots を表示する', () => {
+		render(
+			<ChatMessageList
+				isStreaming={true}
+				proposalMessageId={TEST_IDS.SCHEDULE_1}
+				messages={[
+					createMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						content: '',
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText('AIアシスタント')).toBeInTheDocument();
+		expect(
+			document.querySelector('.loading.loading-sm.loading-dots'),
+		).toBeInTheDocument();
+	});
+
 	it('proposalMessageId が異なる他のメッセージは非表示にしない', () => {
 		render(
 			<ChatMessageList

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
@@ -63,6 +63,32 @@ const getMessageDisplayContent = (message: ChatMessage): string | null => {
 	return message.content;
 };
 
+/**
+ * assistant メッセージを描画すべきかどうかを返す。
+ * - shouldHideProposalPlaceholderMessage が true の場合は非表示
+ * - ストリーミング中の最終メッセージ以外で displayContent が null の場合も非表示
+ *   (tool-only メッセージが loading dots を永続表示しないようにする)
+ */
+const shouldRenderMessage = (
+	message: ChatMessage,
+	displayContent: string | null,
+	proposalMessageId: string | null | undefined,
+	isStreaming: boolean,
+	isLastMessage: boolean,
+): boolean => {
+	if (shouldHideProposalPlaceholderMessage(message, proposalMessageId)) {
+		return false;
+	}
+	if (
+		message.role === 'assistant' &&
+		displayContent === null &&
+		!(isStreaming && isLastMessage)
+	) {
+		return false;
+	}
+	return true;
+};
+
 export const ChatMessageList = ({
 	messages,
 	isStreaming = false,
@@ -96,15 +122,21 @@ export const ChatMessageList = ({
 
 	return (
 		<div className="flex-1 space-y-4 overflow-y-auto p-4">
-			{messages.map((message) => {
+			{messages.map((message, index) => {
+				const displayContent = getMessageDisplayContent(message);
+				const isLastMessage = index === messages.length - 1;
+
 				if (
-					message.role === 'assistant' &&
-					shouldHideProposalPlaceholderMessage(message, proposalMessageId)
+					!shouldRenderMessage(
+						message,
+						displayContent,
+						proposalMessageId,
+						isStreaming,
+						isLastMessage,
+					)
 				) {
 					return null;
 				}
-
-				const displayContent = getMessageDisplayContent(message);
 
 				return (
 					<div

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
@@ -24,6 +24,10 @@ const shouldHideProposalPlaceholderMessage = (
 		return false;
 	}
 
+	if (message.content.trim().length === 0) {
+		return true;
+	}
+
 	const hasJsonCodeBlock = JSON_CODE_BLOCK_DETECT_REGEX.test(message.content);
 	if (!hasJsonCodeBlock) {
 		return false;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -1,9 +1,17 @@
 import { TEST_IDS } from '@/test/helpers/testIds';
 import type { UIMessage } from 'ai';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { extractProposalFromParts } from './extractProposalFromParts';
 
 describe('extractProposalFromParts', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	const allowlist = {
 		shiftIds: [TEST_IDS.SCHEDULE_1],
 		staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -20,9 +20,19 @@ describe('extractProposalFromParts', () => {
 		output,
 	});
 
+	const createProposeShiftChangePart = (
+		output: unknown,
+	): UIMessage['parts'][number] => ({
+		type: 'tool-proposeShiftChange',
+		toolCallId: 'call_1',
+		state: 'output-available',
+		input: {},
+		output,
+	});
+
 	it('change_shift_staff の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_2,
@@ -40,7 +50,7 @@ describe('extractProposalFromParts', () => {
 
 	it('update_shift_time の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -67,8 +77,7 @@ describe('extractProposalFromParts', () => {
 	it('state が output-available でない場合は null', () => {
 		const parts: UIMessage['parts'] = [
 			{
-				type: 'dynamic-tool',
-				toolName: 'proposeShiftChange',
+				type: 'tool-proposeShiftChange',
 				toolCallId: 'call_1',
 				state: 'input-available',
 				input: {
@@ -83,7 +92,7 @@ describe('extractProposalFromParts', () => {
 
 	it('schema 不一致の output は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: 'invalid-date',
@@ -96,7 +105,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない shiftId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_2,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -109,7 +118,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない toStaffId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_4,
@@ -121,5 +130,45 @@ describe('extractProposalFromParts', () => {
 
 	it('parts が空配列の場合は null', () => {
 		expect(extractProposalFromParts([], allowlist)).toBeNull();
+	});
+
+	it('text と別ツールが混在していても proposeShiftChange を優先して返す', () => {
+		const parts: UIMessage['parts'] = [
+			{ type: 'text', text: '候補を確認中です。' },
+			{
+				type: 'tool-searchStaffs',
+				toolCallId: 'call_search_1',
+				state: 'output-available',
+				input: { name: '佐藤' },
+				output: { staffs: [] },
+			},
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+		});
+	});
+
+	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
+		const parts: UIMessage['parts'] = [
+			createDynamicToolPart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -1,17 +1,9 @@
 import { TEST_IDS } from '@/test/helpers/testIds';
 import type { UIMessage } from 'ai';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { extractProposalFromParts } from './extractProposalFromParts';
 
 describe('extractProposalFromParts', () => {
-	beforeEach(() => {
-		vi.spyOn(console, 'warn').mockImplementation(() => {});
-	});
-
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
 	const allowlist = {
 		shiftIds: [TEST_IDS.SCHEDULE_1],
 		staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],
@@ -28,19 +20,9 @@ describe('extractProposalFromParts', () => {
 		output,
 	});
 
-	const createProposeShiftChangePart = (
-		output: unknown,
-	): UIMessage['parts'][number] => ({
-		type: 'tool-proposeShiftChange',
-		toolCallId: 'call_1',
-		state: 'output-available',
-		input: {},
-		output,
-	});
-
 	it('change_shift_staff の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_2,
@@ -58,7 +40,7 @@ describe('extractProposalFromParts', () => {
 
 	it('update_shift_time の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -85,7 +67,8 @@ describe('extractProposalFromParts', () => {
 	it('state が output-available でない場合は null', () => {
 		const parts: UIMessage['parts'] = [
 			{
-				type: 'tool-proposeShiftChange',
+				type: 'dynamic-tool',
+				toolName: 'proposeShiftChange',
 				toolCallId: 'call_1',
 				state: 'input-available',
 				input: {
@@ -100,7 +83,7 @@ describe('extractProposalFromParts', () => {
 
 	it('schema 不一致の output は null', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: 'invalid-date',
@@ -113,7 +96,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない shiftId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_2,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -126,7 +109,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない toStaffId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_4,
@@ -138,93 +121,5 @@ describe('extractProposalFromParts', () => {
 
 	it('parts が空配列の場合は null', () => {
 		expect(extractProposalFromParts([], allowlist)).toBeNull();
-	});
-
-	it('text と別ツールが混在していても proposeShiftChange を優先して返す', () => {
-		const parts: UIMessage['parts'] = [
-			{ type: 'text', text: '候補を確認中です。' },
-			{
-				type: 'tool-searchStaffs',
-				toolCallId: 'call_search_1',
-				state: 'output-available',
-				input: { name: '佐藤' },
-				output: { staffs: [] },
-			},
-			createProposeShiftChangePart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_2,
-			}),
-		];
-
-		expect(extractProposalFromParts(parts, allowlist)).toEqual({
-			type: 'change_shift_staff',
-			shiftId: TEST_IDS.SCHEDULE_1,
-			toStaffId: TEST_IDS.STAFF_2,
-		});
-	});
-
-	it('1つ目の tool-proposeShiftChange が schema NG でも 2つ目が OK なら proposal を返す', () => {
-		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
-				type: 'update_shift_time',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				startAt: 'invalid-date',
-				endAt: '2026-03-16T10:00:00+09:00',
-			}),
-			createProposeShiftChangePart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_2,
-				reason: '修正済み提案',
-			}),
-		];
-
-		expect(extractProposalFromParts(parts, allowlist)).toEqual({
-			type: 'change_shift_staff',
-			shiftId: TEST_IDS.SCHEDULE_1,
-			toStaffId: TEST_IDS.STAFF_2,
-			reason: '修正済み提案',
-		});
-	});
-
-	it('1つ目の tool-proposeShiftChange が allowlist NG でも 2つ目が OK なら proposal を返す', () => {
-		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_4,
-				reason: 'allowlist 外のスタッフ',
-			}),
-			createProposeShiftChangePart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_2,
-				reason: 'allowlist 内のスタッフ',
-			}),
-		];
-
-		expect(extractProposalFromParts(parts, allowlist)).toEqual({
-			type: 'change_shift_staff',
-			shiftId: TEST_IDS.SCHEDULE_1,
-			toStaffId: TEST_IDS.STAFF_2,
-			reason: 'allowlist 内のスタッフ',
-		});
-	});
-
-	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
-		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_2,
-			}),
-		];
-
-		expect(extractProposalFromParts(parts, allowlist)).toEqual({
-			type: 'change_shift_staff',
-			shiftId: TEST_IDS.SCHEDULE_1,
-			toStaffId: TEST_IDS.STAFF_2,
-		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -156,6 +156,54 @@ describe('extractProposalFromParts', () => {
 		});
 	});
 
+	it('1つ目の tool-proposeShiftChange が schema NG でも 2つ目が OK なら proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: 'invalid-date',
+				endAt: '2026-03-16T10:00:00+09:00',
+			}),
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: '修正済み提案',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '修正済み提案',
+		});
+	});
+
+	it('1つ目の tool-proposeShiftChange が allowlist NG でも 2つ目が OK なら proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_4,
+				reason: 'allowlist 外のスタッフ',
+			}),
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: 'allowlist 内のスタッフ',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: 'allowlist 内のスタッフ',
+		});
+	});
+
 	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
 		const parts: UIMessage['parts'] = [
 			createDynamicToolPart({

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -212,6 +212,52 @@ describe('extractProposalFromParts', () => {
 		});
 	});
 
+	it('複数の有効 proposal がある場合は最後の proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_1,
+				reason: '最初の提案',
+			}),
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: '最後の提案',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '最後の提案',
+		});
+	});
+
+	it('allowlist reject 時の warn に part 情報と主要フィールドを含める', () => {
+		const warnSpy = vi.spyOn(console, 'warn');
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_4,
+				reason: 'allowlist 外のスタッフ',
+			}),
+		];
+
+		extractProposalFromParts(parts, allowlist);
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('type=tool-proposeShiftChange'),
+			expect.objectContaining({
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_4,
+			}),
+		);
+	});
+
 	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
 		const parts: UIMessage['parts'] = [
 			createDynamicToolPart({

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -33,6 +33,16 @@ const isProposalToolPart = (part: ProposalOutputPart): boolean => {
 	return part.toolName === PROPOSAL_TOOL_NAME;
 };
 
+const getPartLabel = (part: ProposalOutputPart): string => {
+	const toolName =
+		'toolName' in part && typeof part.toolName === 'string'
+			? part.toolName
+			: undefined;
+	return toolName
+		? `type=${part.type} toolName=${toolName}`
+		: `type=${part.type}`;
+};
+
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
@@ -44,12 +54,17 @@ export const extractProposalFromParts = (
 
 		const parsed = AiChatMutationProposalSchema.safeParse(part.output);
 		if (!parsed.success) {
-			console.warn('[extractProposalFromParts] schema validation failed');
+			console.warn(
+				`[extractProposalFromParts] schema validation failed (${getPartLabel(part)}):`,
+				parsed.error.flatten().fieldErrors,
+			);
 			continue;
 		}
 
 		if (!isAllowedProposal(parsed.data, allowlist)) {
-			console.warn('[extractProposalFromParts] allowlist rejected proposal');
+			console.warn(
+				`[extractProposalFromParts] allowlist rejected proposal (${getPartLabel(part)})`,
+			);
 			continue;
 		}
 

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -45,12 +45,12 @@ export const extractProposalFromParts = (
 		const parsed = AiChatMutationProposalSchema.safeParse(part.output);
 		if (!parsed.success) {
 			console.warn('[extractProposalFromParts] schema validation failed');
-			return null;
+			continue;
 		}
 
 		if (!isAllowedProposal(parsed.data, allowlist)) {
 			console.warn('[extractProposalFromParts] allowlist rejected proposal');
-			return null;
+			continue;
 		}
 
 		return parsed.data;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -43,12 +43,30 @@ const getPartLabel = (part: ProposalOutputPart): string => {
 		: `type=${part.type}`;
 };
 
+const getProposalWarnDetails = (proposal: AiChatMutationProposal) => {
+	if (proposal.type === 'change_shift_staff') {
+		return {
+			type: proposal.type,
+			shiftId: proposal.shiftId,
+			toStaffId: proposal.toStaffId,
+		};
+	}
+
+	return {
+		type: proposal.type,
+		shiftId: proposal.shiftId,
+		startAt: proposal.startAt,
+		endAt: proposal.endAt,
+	};
+};
+
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
 ): AiChatMutationProposal | null => {
-	for (const part of parts) {
-		if (!isOutputAvailablePart(part) || !isProposalToolPart(part)) {
+	for (let index = parts.length - 1; index >= 0; index -= 1) {
+		const part = parts[index];
+		if (!part || !isOutputAvailablePart(part) || !isProposalToolPart(part)) {
 			continue;
 		}
 
@@ -64,6 +82,7 @@ export const extractProposalFromParts = (
 		if (!isAllowedProposal(parsed.data, allowlist)) {
 			console.warn(
 				`[extractProposalFromParts] allowlist rejected proposal (${getPartLabel(part)})`,
+				getProposalWarnDetails(parsed.data),
 			);
 			continue;
 		}

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -6,51 +6,32 @@ import type { UIMessage } from 'ai';
 import { isAllowedProposal, type ProposalAllowlist } from './parseProposal';
 
 const PROPOSAL_TOOL_NAME = 'proposeShiftChange';
-const PROPOSAL_TOOL_PART_TYPE = 'tool-proposeShiftChange';
-
-type ProposalOutputPart = Extract<
-	UIMessage['parts'][number],
-	{ state: 'output-available'; output: unknown }
->;
-
-const isOutputAvailablePart = (
-	part: UIMessage['parts'][number],
-): part is ProposalOutputPart => {
-	return (
-		'state' in part && part.state === 'output-available' && 'output' in part
-	);
-};
-
-const isProposalToolPart = (part: ProposalOutputPart): boolean => {
-	if (part.type === PROPOSAL_TOOL_PART_TYPE) {
-		return true;
-	}
-
-	if (part.type !== 'dynamic-tool') {
-		return false;
-	}
-
-	return part.toolName === PROPOSAL_TOOL_NAME;
-};
 
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
 ): AiChatMutationProposal | null => {
 	for (const part of parts) {
-		if (!isOutputAvailablePart(part) || !isProposalToolPart(part)) {
+		if (part.type !== 'dynamic-tool') {
+			continue;
+		}
+
+		if (
+			part.toolName !== PROPOSAL_TOOL_NAME ||
+			part.state !== 'output-available'
+		) {
 			continue;
 		}
 
 		const parsed = AiChatMutationProposalSchema.safeParse(part.output);
 		if (!parsed.success) {
 			console.warn('[extractProposalFromParts] schema validation failed');
-			continue;
+			return null;
 		}
 
 		if (!isAllowedProposal(parsed.data, allowlist)) {
 			console.warn('[extractProposalFromParts] allowlist rejected proposal');
-			continue;
+			return null;
 		}
 
 		return parsed.data;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -6,20 +6,39 @@ import type { UIMessage } from 'ai';
 import { isAllowedProposal, type ProposalAllowlist } from './parseProposal';
 
 const PROPOSAL_TOOL_NAME = 'proposeShiftChange';
+const PROPOSAL_TOOL_PART_TYPE = 'tool-proposeShiftChange';
+
+type ProposalOutputPart = Extract<
+	UIMessage['parts'][number],
+	{ state: 'output-available'; output: unknown }
+>;
+
+const isOutputAvailablePart = (
+	part: UIMessage['parts'][number],
+): part is ProposalOutputPart => {
+	return (
+		'state' in part && part.state === 'output-available' && 'output' in part
+	);
+};
+
+const isProposalToolPart = (part: ProposalOutputPart): boolean => {
+	if (part.type === PROPOSAL_TOOL_PART_TYPE) {
+		return true;
+	}
+
+	if (part.type !== 'dynamic-tool') {
+		return false;
+	}
+
+	return part.toolName === PROPOSAL_TOOL_NAME;
+};
 
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
 ): AiChatMutationProposal | null => {
 	for (const part of parts) {
-		if (part.type !== 'dynamic-tool') {
-			continue;
-		}
-
-		if (
-			part.toolName !== PROPOSAL_TOOL_NAME ||
-			part.state !== 'output-available'
-		) {
+		if (!isOutputAvailablePart(part) || !isProposalToolPart(part)) {
 			continue;
 		}
 


### PR DESCRIPTION
## 概要

Phase2 PR-B2: tool-result（UIMessage.parts）から proposal を抽出して `ProposalConfirmCard` に表示するフロント側の配線を実装します。

Closes #146

## 変更内容

### 新規ファイル
- `extractProposalFromParts.ts` — rawMessages の UIMessage.parts から tool-result/tool-call を探索し proposal を抽出するユーティリティ
- `extractProposalFromParts.test.ts` — 上記の単体テスト（tool優先/fallback/複数提案/スキーマNG等）

### 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `AdjustmentChatDialog.tsx` | rawMessages を参照し `extractProposalFromParts` を優先呼び出し、フォールバックに `parseProposal` を使用。`proposalMessageId` に assistant message.id を採用 |
| `AdjustmentChatDialog.test.tsx` | tool parts 由来の proposal 表示テスト・fallback テスト・tool-only メッセージ非表示テストを追加 |
| `ChatMessageList.tsx` | tool-only で content が空の assistant 行を非表示 |
| `ChatMessageList.test.tsx` | 上記の表示制御テストを追加 |
| `useAdjustmentChat.ts` | rawMessages を公開するよう変更 |
| `parseProposal.ts` | 軽微な型修正 |

## 実装ポイント

- **tool優先 / parseProposal fallback**: `extractProposalFromParts` で tool-result からの抽出を試み、取得できない場合は従来の `parseProposal`（本文中 ```json``` ブロック解析）にフォールバック
- **proposalMessageId の安定化**: assistant message.id を proposalKey として使用し、ストリーミング更新でも dismiss/confirm 状態がチラつかないよう制御
- **tool-only メッセージ非表示**: content が空で parts のみの assistant 行を ChatMessageList で非表示化し、チャット本文に JSON が露出しない状態を完遂

## テスト結果

```
Test Files  174 passed | 1 skipped (175)
     Tests  1350 passed | 1 skipped (1351)
```

## 関連
- 親 Issue: #143（Phase2 全体）
- 前提 PR: #144（サーバ側 tool calling）、#145（PR-B1: transport切替 + 抽出ユーティリティ下地）