### PR TITLE
fix(#150): AIチャット失敗時の診断ログを追加

### DIFF
--- a/env.example
+++ b/env.example
@@ -9,3 +9,4 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 
 # Gemini AI API
 GEMINI_API_KEY=your-gemini-api-key
+AI_CHAT_VERBOSE_LOG=

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
@@ -2,6 +2,7 @@ import type { ExecuteAiChatMutationResult } from '@/models/aiChatMutationProposa
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { UIMessage } from 'ai';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { AdjustmentChatDialog } from './AdjustmentChatDialog';
 
@@ -54,8 +55,8 @@ const createMockUseChatReturn = (overrides: Record<string, unknown> = {}) => ({
 	...overrides,
 });
 
-const createProposalMessage = (proposalJson: string) => ({
-	id: 'assistant-1',
+const createProposalMessage = (proposalJson: string, id = 'assistant-1') => ({
+	id,
 	role: 'assistant',
 	parts: [
 		{
@@ -67,8 +68,11 @@ ${proposalJson}
 		},
 	],
 });
-const createJsonOnlyProposalMessage = (proposalJson: string) => ({
-	id: 'assistant-json-only',
+const createJsonOnlyProposalMessage = (
+	proposalJson: string,
+	id = 'assistant-json-only',
+) => ({
+	id,
 	role: 'assistant',
 	parts: [
 		{
@@ -77,6 +81,33 @@ const createJsonOnlyProposalMessage = (proposalJson: string) => ({
 ${proposalJson}
 \`\`\``,
 		},
+	],
+});
+
+const createToolProposeShiftChangePart = (
+	output: unknown,
+): UIMessage['parts'][number] => ({
+	type: 'tool-proposeShiftChange',
+	toolCallId: 'call_1',
+	state: 'output-available',
+	input: {},
+	output,
+});
+
+const createToolProposalAssistantMessage = ({
+	id,
+	output,
+	text,
+}: {
+	id: string;
+	output: unknown;
+	text?: string;
+}): UIMessage => ({
+	id,
+	role: 'assistant',
+	parts: [
+		...(text ? [{ type: 'text' as const, text }] : []),
+		createToolProposeShiftChangePart(output),
 	],
 });
 
@@ -333,6 +364,109 @@ describe('AdjustmentChatDialog', () => {
 		expect(
 			screen.getByText(/AI service is not configured/),
 		).toBeInTheDocument();
+	});
+
+	it('rawMessages に tool-proposeShiftChange の output-available があると ProposalConfirmCard を表示する', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createToolProposalAssistantMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						output: {
+							type: 'change_shift_staff',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							toStaffId: TEST_IDS.STAFF_2,
+						},
+					}),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
+	});
+
+	it('tool-based と本文 JSON が両方ある場合は tool-based proposal を優先する', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createToolProposalAssistantMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						text: `提案です
+\`\`\`json
+{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}
+\`\`\``,
+						output: {
+							type: 'update_shift_time',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							startAt: '2026-02-24T12:00:00+09:00',
+							endAt: '2026-02-24T13:00:00+09:00',
+						},
+					}),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('時間変更')).toBeInTheDocument();
+		expect(screen.queryByText('担当者変更')).not.toBeInTheDocument();
+	});
+
+	it('tool-based proposal がない場合は parseProposal fallback で ProposalConfirmCard を表示する', () => {
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createJsonOnlyProposalMessage(
+						`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`,
+						TEST_IDS.SCHEDULE_2,
+					),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
 	});
 
 	it('assistant の最新メッセージに提案 JSON があると ProposalConfirmCard を表示する', () => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
+import type { UIMessage } from 'ai';
 import { type ReactNode, useMemo, useState } from 'react';
 import { buildProposalDisplayValues } from './buildProposalDisplayValues';
 import { ChatInput } from './ChatInput';
 import { ChatMessageList } from './ChatMessageList';
+import { extractProposalFromParts } from './extractProposalFromParts';
 import { parseProposal } from './parseProposal';
 import { ProposalConfirmCard } from './ProposalConfirmCard';
 import type { ShiftContext } from './useAdjustmentChat';
@@ -23,14 +25,10 @@ type AdjustmentChatDialogProps = {
  * 最新 assistant に proposal が無い場合は null を返し、過去提案へはフォールバックしない。
  */
 const findLatestProposal = (
-	messages: Array<{ id: string; role: string; content: string }>,
+	messages: UIMessage[],
 	allowlist: Parameters<typeof parseProposal>[1],
 ) => {
-	let latestAssistantMessage: {
-		id: string;
-		role: string;
-		content: string;
-	} | null = null;
+	let latestAssistantMessage: UIMessage | null = null;
 
 	for (let index = messages.length - 1; index >= 0; index -= 1) {
 		const message = messages[index];
@@ -41,11 +39,32 @@ const findLatestProposal = (
 		}
 	}
 
-	if (!latestAssistantMessage?.content) {
+	if (!latestAssistantMessage) {
 		return null;
 	}
 
-	const proposal = parseProposal(latestAssistantMessage.content, allowlist);
+	const proposalFromTool = extractProposalFromParts(
+		latestAssistantMessage.parts,
+		allowlist,
+	);
+
+	if (proposalFromTool) {
+		return { messageId: latestAssistantMessage.id, proposal: proposalFromTool };
+	}
+
+	const textContent = latestAssistantMessage.parts
+		.filter(
+			(part): part is Extract<UIMessage['parts'][number], { type: 'text' }> =>
+				part.type === 'text',
+		)
+		.map((part) => part.text)
+		.join('');
+
+	if (!textContent) {
+		return null;
+	}
+
+	const proposal = parseProposal(textContent, allowlist);
 
 	if (!proposal) {
 		return null;
@@ -97,11 +116,10 @@ export const AdjustmentChatDialog = ({
 	staffOptions,
 	onClose,
 }: AdjustmentChatDialogProps) => {
-	const { messages, isStreaming, error, sendMessage, stop } = useAdjustmentChat(
-		{
+	const { messages, rawMessages, isStreaming, error, sendMessage, stop } =
+		useAdjustmentChat({
 			shiftContext,
-		},
-	);
+		});
 
 	const staffIdsAllowlist = useMemo(
 		() => staffOptions.map((staffOption) => staffOption.id),
@@ -117,14 +135,14 @@ export const AdjustmentChatDialog = ({
 
 	/** 最新の assistant メッセージ（id + parsed proposal）を返す */
 	const { detectedProposal, proposalKey } = useMemo(() => {
-		const result = findLatestProposal(messages, allowlist);
+		const result = findLatestProposal(rawMessages, allowlist);
 
 		return {
 			detectedProposal: result ? result.proposal : null,
 			// dismiss キーは「この assistant メッセージの id」で安定管理する
 			proposalKey: result ? result.messageId : null,
 		};
-	}, [messages, allowlist]);
+	}, [rawMessages, allowlist]);
 
 	const proposalDisplayValues = useMemo(() => {
 		if (!detectedProposal) {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
@@ -115,6 +115,22 @@ describe('ChatMessageList', () => {
 		).not.toBeInTheDocument();
 	});
 
+	it('proposalMessageId に一致し assistant content が空文字のときは行を非表示にする', () => {
+		render(
+			<ChatMessageList
+				proposalMessageId={TEST_IDS.SCHEDULE_1}
+				messages={[
+					createMessage({
+						id: TEST_IDS.SCHEDULE_1,
+						content: '',
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.queryByText('AIアシスタント')).not.toBeInTheDocument();
+	});
+
 	it('proposalMessageId が異なる他のメッセージは非表示にしない', () => {
 		render(
 			<ChatMessageList

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.test.tsx
@@ -131,6 +131,51 @@ describe('ChatMessageList', () => {
 		expect(screen.queryByText('AIアシスタント')).not.toBeInTheDocument();
 	});
 
+	it('proposalMessageId と異なる assistant の空 content 行は非表示にする', () => {
+		render(
+			<ChatMessageList
+				proposalMessageId={TEST_IDS.SCHEDULE_1}
+				messages={[
+					createMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						content: '',
+					}),
+					createMessage({
+						id: TEST_IDS.CLIENT_1,
+						role: 'user',
+						content: '確認しました',
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.queryByText('AIアシスタント')).not.toBeInTheDocument();
+		expect(screen.getByText('あなた')).toBeInTheDocument();
+		expect(
+			document.querySelector('.loading.loading-sm.loading-dots'),
+		).not.toBeInTheDocument();
+	});
+
+	it('streaming 中の最後の assistant 空 content 行は loading dots を表示する', () => {
+		render(
+			<ChatMessageList
+				isStreaming={true}
+				proposalMessageId={TEST_IDS.SCHEDULE_1}
+				messages={[
+					createMessage({
+						id: TEST_IDS.SCHEDULE_2,
+						content: '',
+					}),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText('AIアシスタント')).toBeInTheDocument();
+		expect(
+			document.querySelector('.loading.loading-sm.loading-dots'),
+		).toBeInTheDocument();
+	});
+
 	it('proposalMessageId が異なる他のメッセージは非表示にしない', () => {
 		render(
 			<ChatMessageList

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
@@ -63,6 +63,32 @@ const getMessageDisplayContent = (message: ChatMessage): string | null => {
 	return message.content;
 };
 
+/**
+ * assistant メッセージを描画すべきかどうかを返す。
+ * - shouldHideProposalPlaceholderMessage が true の場合は非表示
+ * - ストリーミング中の最終メッセージ以外で displayContent が null の場合も非表示
+ *   (tool-only メッセージが loading dots を永続表示しないようにする)
+ */
+const shouldRenderMessage = (
+	message: ChatMessage,
+	displayContent: string | null,
+	proposalMessageId: string | null | undefined,
+	isStreaming: boolean,
+	isLastMessage: boolean,
+): boolean => {
+	if (shouldHideProposalPlaceholderMessage(message, proposalMessageId)) {
+		return false;
+	}
+	if (
+		message.role === 'assistant' &&
+		displayContent === null &&
+		!(isStreaming && isLastMessage)
+	) {
+		return false;
+	}
+	return true;
+};
+
 export const ChatMessageList = ({
 	messages,
 	isStreaming = false,
@@ -96,15 +122,21 @@ export const ChatMessageList = ({
 
 	return (
 		<div className="flex-1 space-y-4 overflow-y-auto p-4">
-			{messages.map((message) => {
+			{messages.map((message, index) => {
+				const displayContent = getMessageDisplayContent(message);
+				const isLastMessage = index === messages.length - 1;
+
 				if (
-					message.role === 'assistant' &&
-					shouldHideProposalPlaceholderMessage(message, proposalMessageId)
+					!shouldRenderMessage(
+						message,
+						displayContent,
+						proposalMessageId,
+						isStreaming,
+						isLastMessage,
+					)
 				) {
 					return null;
 				}
-
-				const displayContent = getMessageDisplayContent(message);
 
 				return (
 					<div

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ChatMessageList.tsx
@@ -24,6 +24,10 @@ const shouldHideProposalPlaceholderMessage = (
 		return false;
 	}
 
+	if (message.content.trim().length === 0) {
+		return true;
+	}
+
 	const hasJsonCodeBlock = JSON_CODE_BLOCK_DETECT_REGEX.test(message.content);
 	if (!hasJsonCodeBlock) {
 		return false;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -1,9 +1,17 @@
 import { TEST_IDS } from '@/test/helpers/testIds';
 import type { UIMessage } from 'ai';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { extractProposalFromParts } from './extractProposalFromParts';
 
 describe('extractProposalFromParts', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	const allowlist = {
 		shiftIds: [TEST_IDS.SCHEDULE_1],
 		staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -20,9 +20,19 @@ describe('extractProposalFromParts', () => {
 		output,
 	});
 
+	const createProposeShiftChangePart = (
+		output: unknown,
+	): UIMessage['parts'][number] => ({
+		type: 'tool-proposeShiftChange',
+		toolCallId: 'call_1',
+		state: 'output-available',
+		input: {},
+		output,
+	});
+
 	it('change_shift_staff の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_2,
@@ -40,7 +50,7 @@ describe('extractProposalFromParts', () => {
 
 	it('update_shift_time の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -67,8 +77,7 @@ describe('extractProposalFromParts', () => {
 	it('state が output-available でない場合は null', () => {
 		const parts: UIMessage['parts'] = [
 			{
-				type: 'dynamic-tool',
-				toolName: 'proposeShiftChange',
+				type: 'tool-proposeShiftChange',
 				toolCallId: 'call_1',
 				state: 'input-available',
 				input: {
@@ -83,7 +92,7 @@ describe('extractProposalFromParts', () => {
 
 	it('schema 不一致の output は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: 'invalid-date',
@@ -96,7 +105,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない shiftId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_2,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -109,7 +118,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない toStaffId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
+			createProposeShiftChangePart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_4,
@@ -121,5 +130,45 @@ describe('extractProposalFromParts', () => {
 
 	it('parts が空配列の場合は null', () => {
 		expect(extractProposalFromParts([], allowlist)).toBeNull();
+	});
+
+	it('text と別ツールが混在していても proposeShiftChange を優先して返す', () => {
+		const parts: UIMessage['parts'] = [
+			{ type: 'text', text: '候補を確認中です。' },
+			{
+				type: 'tool-searchStaffs',
+				toolCallId: 'call_search_1',
+				state: 'output-available',
+				input: { name: '佐藤' },
+				output: { staffs: [] },
+			},
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+		});
+	});
+
+	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
+		const parts: UIMessage['parts'] = [
+			createDynamicToolPart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -1,17 +1,9 @@
 import { TEST_IDS } from '@/test/helpers/testIds';
 import type { UIMessage } from 'ai';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { extractProposalFromParts } from './extractProposalFromParts';
 
 describe('extractProposalFromParts', () => {
-	beforeEach(() => {
-		vi.spyOn(console, 'warn').mockImplementation(() => {});
-	});
-
-	afterEach(() => {
-		vi.restoreAllMocks();
-	});
-
 	const allowlist = {
 		shiftIds: [TEST_IDS.SCHEDULE_1],
 		staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],
@@ -28,19 +20,9 @@ describe('extractProposalFromParts', () => {
 		output,
 	});
 
-	const createProposeShiftChangePart = (
-		output: unknown,
-	): UIMessage['parts'][number] => ({
-		type: 'tool-proposeShiftChange',
-		toolCallId: 'call_1',
-		state: 'output-available',
-		input: {},
-		output,
-	});
-
 	it('change_shift_staff の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_2,
@@ -58,7 +40,7 @@ describe('extractProposalFromParts', () => {
 
 	it('update_shift_time の tool output から proposal を返す', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -85,7 +67,8 @@ describe('extractProposalFromParts', () => {
 	it('state が output-available でない場合は null', () => {
 		const parts: UIMessage['parts'] = [
 			{
-				type: 'tool-proposeShiftChange',
+				type: 'dynamic-tool',
+				toolName: 'proposeShiftChange',
 				toolCallId: 'call_1',
 				state: 'input-available',
 				input: {
@@ -100,7 +83,7 @@ describe('extractProposalFromParts', () => {
 
 	it('schema 不一致の output は null', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				startAt: 'invalid-date',
@@ -113,7 +96,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない shiftId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'update_shift_time',
 				shiftId: TEST_IDS.SCHEDULE_2,
 				startAt: '2026-03-16T09:00:00+09:00',
@@ -126,7 +109,7 @@ describe('extractProposalFromParts', () => {
 
 	it('allowlist にない toStaffId は null', () => {
 		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
+			createDynamicToolPart({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_4,
@@ -138,93 +121,5 @@ describe('extractProposalFromParts', () => {
 
 	it('parts が空配列の場合は null', () => {
 		expect(extractProposalFromParts([], allowlist)).toBeNull();
-	});
-
-	it('text と別ツールが混在していても proposeShiftChange を優先して返す', () => {
-		const parts: UIMessage['parts'] = [
-			{ type: 'text', text: '候補を確認中です。' },
-			{
-				type: 'tool-searchStaffs',
-				toolCallId: 'call_search_1',
-				state: 'output-available',
-				input: { name: '佐藤' },
-				output: { staffs: [] },
-			},
-			createProposeShiftChangePart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_2,
-			}),
-		];
-
-		expect(extractProposalFromParts(parts, allowlist)).toEqual({
-			type: 'change_shift_staff',
-			shiftId: TEST_IDS.SCHEDULE_1,
-			toStaffId: TEST_IDS.STAFF_2,
-		});
-	});
-
-	it('1つ目の tool-proposeShiftChange が schema NG でも 2つ目が OK なら proposal を返す', () => {
-		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
-				type: 'update_shift_time',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				startAt: 'invalid-date',
-				endAt: '2026-03-16T10:00:00+09:00',
-			}),
-			createProposeShiftChangePart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_2,
-				reason: '修正済み提案',
-			}),
-		];
-
-		expect(extractProposalFromParts(parts, allowlist)).toEqual({
-			type: 'change_shift_staff',
-			shiftId: TEST_IDS.SCHEDULE_1,
-			toStaffId: TEST_IDS.STAFF_2,
-			reason: '修正済み提案',
-		});
-	});
-
-	it('1つ目の tool-proposeShiftChange が allowlist NG でも 2つ目が OK なら proposal を返す', () => {
-		const parts: UIMessage['parts'] = [
-			createProposeShiftChangePart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_4,
-				reason: 'allowlist 外のスタッフ',
-			}),
-			createProposeShiftChangePart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_2,
-				reason: 'allowlist 内のスタッフ',
-			}),
-		];
-
-		expect(extractProposalFromParts(parts, allowlist)).toEqual({
-			type: 'change_shift_staff',
-			shiftId: TEST_IDS.SCHEDULE_1,
-			toStaffId: TEST_IDS.STAFF_2,
-			reason: 'allowlist 内のスタッフ',
-		});
-	});
-
-	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
-		const parts: UIMessage['parts'] = [
-			createDynamicToolPart({
-				type: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
-				toStaffId: TEST_IDS.STAFF_2,
-			}),
-		];
-
-		expect(extractProposalFromParts(parts, allowlist)).toEqual({
-			type: 'change_shift_staff',
-			shiftId: TEST_IDS.SCHEDULE_1,
-			toStaffId: TEST_IDS.STAFF_2,
-		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -156,6 +156,54 @@ describe('extractProposalFromParts', () => {
 		});
 	});
 
+	it('1つ目の tool-proposeShiftChange が schema NG でも 2つ目が OK なら proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: 'invalid-date',
+				endAt: '2026-03-16T10:00:00+09:00',
+			}),
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: '修正済み提案',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '修正済み提案',
+		});
+	});
+
+	it('1つ目の tool-proposeShiftChange が allowlist NG でも 2つ目が OK なら proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_4,
+				reason: 'allowlist 外のスタッフ',
+			}),
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: 'allowlist 内のスタッフ',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: 'allowlist 内のスタッフ',
+		});
+	});
+
 	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
 		const parts: UIMessage['parts'] = [
 			createDynamicToolPart({

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.test.ts
@@ -212,6 +212,52 @@ describe('extractProposalFromParts', () => {
 		});
 	});
 
+	it('複数の有効 proposal がある場合は最後の proposal を返す', () => {
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_1,
+				reason: '最初の提案',
+			}),
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+				reason: '最後の提案',
+			}),
+		];
+
+		expect(extractProposalFromParts(parts, allowlist)).toEqual({
+			type: 'change_shift_staff',
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '最後の提案',
+		});
+	});
+
+	it('allowlist reject 時の warn に part 情報と主要フィールドを含める', () => {
+		const warnSpy = vi.spyOn(console, 'warn');
+		const parts: UIMessage['parts'] = [
+			createProposeShiftChangePart({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_4,
+				reason: 'allowlist 外のスタッフ',
+			}),
+		];
+
+		extractProposalFromParts(parts, allowlist);
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining('type=tool-proposeShiftChange'),
+			expect.objectContaining({
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_4,
+			}),
+		);
+	});
+
 	it('後方互換で dynamic-tool + proposeShiftChange を受け付ける', () => {
 		const parts: UIMessage['parts'] = [
 			createDynamicToolPart({

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -33,6 +33,16 @@ const isProposalToolPart = (part: ProposalOutputPart): boolean => {
 	return part.toolName === PROPOSAL_TOOL_NAME;
 };
 
+const getPartLabel = (part: ProposalOutputPart): string => {
+	const toolName =
+		'toolName' in part && typeof part.toolName === 'string'
+			? part.toolName
+			: undefined;
+	return toolName
+		? `type=${part.type} toolName=${toolName}`
+		: `type=${part.type}`;
+};
+
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
@@ -44,12 +54,17 @@ export const extractProposalFromParts = (
 
 		const parsed = AiChatMutationProposalSchema.safeParse(part.output);
 		if (!parsed.success) {
-			console.warn('[extractProposalFromParts] schema validation failed');
+			console.warn(
+				`[extractProposalFromParts] schema validation failed (${getPartLabel(part)}):`,
+				parsed.error.flatten().fieldErrors,
+			);
 			continue;
 		}
 
 		if (!isAllowedProposal(parsed.data, allowlist)) {
-			console.warn('[extractProposalFromParts] allowlist rejected proposal');
+			console.warn(
+				`[extractProposalFromParts] allowlist rejected proposal (${getPartLabel(part)})`,
+			);
 			continue;
 		}
 

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -45,12 +45,12 @@ export const extractProposalFromParts = (
 		const parsed = AiChatMutationProposalSchema.safeParse(part.output);
 		if (!parsed.success) {
 			console.warn('[extractProposalFromParts] schema validation failed');
-			return null;
+			continue;
 		}
 
 		if (!isAllowedProposal(parsed.data, allowlist)) {
 			console.warn('[extractProposalFromParts] allowlist rejected proposal');
-			return null;
+			continue;
 		}
 
 		return parsed.data;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -43,12 +43,30 @@ const getPartLabel = (part: ProposalOutputPart): string => {
 		: `type=${part.type}`;
 };
 
+const getProposalWarnDetails = (proposal: AiChatMutationProposal) => {
+	if (proposal.type === 'change_shift_staff') {
+		return {
+			type: proposal.type,
+			shiftId: proposal.shiftId,
+			toStaffId: proposal.toStaffId,
+		};
+	}
+
+	return {
+		type: proposal.type,
+		shiftId: proposal.shiftId,
+		startAt: proposal.startAt,
+		endAt: proposal.endAt,
+	};
+};
+
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
 ): AiChatMutationProposal | null => {
-	for (const part of parts) {
-		if (!isOutputAvailablePart(part) || !isProposalToolPart(part)) {
+	for (let index = parts.length - 1; index >= 0; index -= 1) {
+		const part = parts[index];
+		if (!part || !isOutputAvailablePart(part) || !isProposalToolPart(part)) {
 			continue;
 		}
 
@@ -64,6 +82,7 @@ export const extractProposalFromParts = (
 		if (!isAllowedProposal(parsed.data, allowlist)) {
 			console.warn(
 				`[extractProposalFromParts] allowlist rejected proposal (${getPartLabel(part)})`,
+				getProposalWarnDetails(parsed.data),
 			);
 			continue;
 		}

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -6,51 +6,32 @@ import type { UIMessage } from 'ai';
 import { isAllowedProposal, type ProposalAllowlist } from './parseProposal';
 
 const PROPOSAL_TOOL_NAME = 'proposeShiftChange';
-const PROPOSAL_TOOL_PART_TYPE = 'tool-proposeShiftChange';
-
-type ProposalOutputPart = Extract<
-	UIMessage['parts'][number],
-	{ state: 'output-available'; output: unknown }
->;
-
-const isOutputAvailablePart = (
-	part: UIMessage['parts'][number],
-): part is ProposalOutputPart => {
-	return (
-		'state' in part && part.state === 'output-available' && 'output' in part
-	);
-};
-
-const isProposalToolPart = (part: ProposalOutputPart): boolean => {
-	if (part.type === PROPOSAL_TOOL_PART_TYPE) {
-		return true;
-	}
-
-	if (part.type !== 'dynamic-tool') {
-		return false;
-	}
-
-	return part.toolName === PROPOSAL_TOOL_NAME;
-};
 
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
 ): AiChatMutationProposal | null => {
 	for (const part of parts) {
-		if (!isOutputAvailablePart(part) || !isProposalToolPart(part)) {
+		if (part.type !== 'dynamic-tool') {
+			continue;
+		}
+
+		if (
+			part.toolName !== PROPOSAL_TOOL_NAME ||
+			part.state !== 'output-available'
+		) {
 			continue;
 		}
 
 		const parsed = AiChatMutationProposalSchema.safeParse(part.output);
 		if (!parsed.success) {
 			console.warn('[extractProposalFromParts] schema validation failed');
-			continue;
+			return null;
 		}
 
 		if (!isAllowedProposal(parsed.data, allowlist)) {
 			console.warn('[extractProposalFromParts] allowlist rejected proposal');
-			continue;
+			return null;
 		}
 
 		return parsed.data;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/extractProposalFromParts.ts
@@ -6,20 +6,39 @@ import type { UIMessage } from 'ai';
 import { isAllowedProposal, type ProposalAllowlist } from './parseProposal';
 
 const PROPOSAL_TOOL_NAME = 'proposeShiftChange';
+const PROPOSAL_TOOL_PART_TYPE = 'tool-proposeShiftChange';
+
+type ProposalOutputPart = Extract<
+	UIMessage['parts'][number],
+	{ state: 'output-available'; output: unknown }
+>;
+
+const isOutputAvailablePart = (
+	part: UIMessage['parts'][number],
+): part is ProposalOutputPart => {
+	return (
+		'state' in part && part.state === 'output-available' && 'output' in part
+	);
+};
+
+const isProposalToolPart = (part: ProposalOutputPart): boolean => {
+	if (part.type === PROPOSAL_TOOL_PART_TYPE) {
+		return true;
+	}
+
+	if (part.type !== 'dynamic-tool') {
+		return false;
+	}
+
+	return part.toolName === PROPOSAL_TOOL_NAME;
+};
 
 export const extractProposalFromParts = (
 	parts: UIMessage['parts'],
 	allowlist: ProposalAllowlist,
 ): AiChatMutationProposal | null => {
 	for (const part of parts) {
-		if (part.type !== 'dynamic-tool') {
-			continue;
-		}
-
-		if (
-			part.toolName !== PROPOSAL_TOOL_NAME ||
-			part.state !== 'output-available'
-		) {
+		if (!isOutputAvailablePart(part) || !isProposalToolPart(part)) {
 			continue;
 		}
 

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -1,4 +1,4 @@
-import { TEST_IDS } from '@/test/helpers/testIds';
+import { TEST_IDS, createTestId } from '@/test/helpers/testIds';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // vi.hoisted でモック関数を定義（ホイスティング対応）
@@ -1512,6 +1512,182 @@ describe('POST /api/chat/shift-adjustment', () => {
 			);
 
 			consoleErrorSpy.mockRestore();
+		});
+
+		it('AI_CHAT_VERBOSE_LOG 未設定時、診断ログの shiftIds は最大 3 件に抑制される', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+
+			const previous = process.env.AI_CHAT_VERBOSE_LOG;
+			delete process.env.AI_CHAT_VERBOSE_LOG;
+
+			try {
+				const shifts = [
+					{
+						id: TEST_IDS.SCHEDULE_1,
+						clientId: TEST_IDS.CLIENT_1,
+						serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+						date: '2025-01-20',
+						startTime: '09:00',
+						endTime: '10:00',
+					},
+					...Array.from({ length: 9 }, () => ({
+						id: createTestId(),
+						clientId: TEST_IDS.CLIENT_1,
+						serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+						date: '2025-01-20',
+						startTime: '09:00',
+						endTime: '10:00',
+					})),
+				];
+
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '提案して' }],
+							context: { shifts },
+						}),
+					},
+				);
+
+				await POST(request);
+
+				const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+					tools?: {
+						proposeShiftChange?: {
+							execute?: (input: {
+								type: 'change_shift_staff';
+								shiftId: string;
+								toStaffId: string;
+							}) => Promise<unknown>;
+						};
+					};
+				};
+
+				await expect(
+					streamTextCall.tools?.proposeShiftChange?.execute?.({
+						type: 'change_shift_staff',
+						shiftId: TEST_IDS.SCHEDULE_2,
+						toStaffId: TEST_IDS.STAFF_1,
+					}),
+				).rejects.toThrow('シフトIDが不正です');
+
+				const allowlistLog = consoleErrorSpy.mock.calls
+					.map((args) => args[1])
+					.find(
+						(payload) =>
+							typeof payload === 'object' &&
+							payload !== null &&
+							'errorType' in payload &&
+							(payload as { errorType?: unknown }).errorType ===
+								'allowlist_violation',
+					) as { shiftIds?: string[]; shiftsCount?: number } | undefined;
+
+				expect(allowlistLog?.shiftsCount).toBe(shifts.length);
+				expect(allowlistLog?.shiftIds).toHaveLength(3);
+			} finally {
+				if (previous === undefined) {
+					delete process.env.AI_CHAT_VERBOSE_LOG;
+				} else {
+					process.env.AI_CHAT_VERBOSE_LOG = previous;
+				}
+				consoleErrorSpy.mockRestore();
+			}
+		});
+
+		it('AI_CHAT_VERBOSE_LOG=true のとき、診断ログの shiftIds は最大 10 件まで出力される', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+
+			const previous = process.env.AI_CHAT_VERBOSE_LOG;
+			process.env.AI_CHAT_VERBOSE_LOG = 'true';
+
+			try {
+				const shifts = [
+					{
+						id: TEST_IDS.SCHEDULE_1,
+						clientId: TEST_IDS.CLIENT_1,
+						serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+						date: '2025-01-20',
+						startTime: '09:00',
+						endTime: '10:00',
+					},
+					...Array.from({ length: 9 }, () => ({
+						id: createTestId(),
+						clientId: TEST_IDS.CLIENT_1,
+						serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+						date: '2025-01-20',
+						startTime: '09:00',
+						endTime: '10:00',
+					})),
+				];
+
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '提案して' }],
+							context: { shifts },
+						}),
+					},
+				);
+
+				await POST(request);
+
+				const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+					tools?: {
+						proposeShiftChange?: {
+							execute?: (input: {
+								type: 'change_shift_staff';
+								shiftId: string;
+								toStaffId: string;
+							}) => Promise<unknown>;
+						};
+					};
+				};
+
+				await expect(
+					streamTextCall.tools?.proposeShiftChange?.execute?.({
+						type: 'change_shift_staff',
+						shiftId: TEST_IDS.SCHEDULE_2,
+						toStaffId: TEST_IDS.STAFF_1,
+					}),
+				).rejects.toThrow('シフトIDが不正です');
+
+				const allowlistLog = consoleErrorSpy.mock.calls
+					.map((args) => args[1])
+					.find(
+						(payload) =>
+							typeof payload === 'object' &&
+							payload !== null &&
+							'errorType' in payload &&
+							(payload as { errorType?: unknown }).errorType ===
+								'allowlist_violation',
+					) as { shiftIds?: string[]; shiftsCount?: number } | undefined;
+
+				expect(allowlistLog?.shiftsCount).toBe(shifts.length);
+				expect(allowlistLog?.shiftIds).toHaveLength(10);
+			} finally {
+				if (previous === undefined) {
+					delete process.env.AI_CHAT_VERBOSE_LOG;
+				} else {
+					process.env.AI_CHAT_VERBOSE_LOG = previous;
+				}
+				consoleErrorSpy.mockRestore();
+			}
 		});
 
 		it('診断ログに requestId として x-request-id を含める', async () => {

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -1699,7 +1699,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 				.mockImplementation(() => undefined);
 			mockShiftMaybeSingle.mockResolvedValue({
 				data: null,
-				error: { message: 'network error' },
+				error: { message: 'network error', code: '57014' },
 			});
 
 			const request = new Request(
@@ -1754,7 +1754,12 @@ describe('POST /api/chat/shift-adjustment', () => {
 			);
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
 				'Failed to verify shift in proposeShiftChange tool',
-				expect.objectContaining({ message: 'network error' }),
+				expect.objectContaining({
+					errorType: 'shift_verification_failed',
+					message:
+						'対象シフトの確認中にエラーが発生しました。時間をおいて再度お試しください。',
+					shiftErrorCode: '57014',
+				}),
 			);
 			consoleErrorSpy.mockRestore();
 		});

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -1503,6 +1503,8 @@ describe('POST /api/chat/shift-adjustment', () => {
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.objectContaining({
+					endpoint: '/api/chat/shift-adjustment',
+					method: 'POST',
 					errorType: 'allowlist_violation',
 					toolName: 'proposeShiftChange',
 					proposalShiftId: TEST_IDS.SCHEDULE_2,
@@ -1570,6 +1572,8 @@ describe('POST /api/chat/shift-adjustment', () => {
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
 				expect.any(String),
 				expect.objectContaining({
+					endpoint: '/api/chat/shift-adjustment',
+					method: 'POST',
 					requestId,
 				}),
 			);
@@ -1639,6 +1643,9 @@ describe('POST /api/chat/shift-adjustment', () => {
 		});
 
 		it('proposeShiftChange tool は shift がDBに存在しない場合エラーを返す', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
 			mockShiftMaybeSingle.mockResolvedValue({ data: null, error: null });
 
 			const request = new Request(
@@ -1691,6 +1698,10 @@ describe('POST /api/chat/shift-adjustment', () => {
 			).rejects.toThrow(
 				'指定されたシフトを確認できませんでした。対象シフトを確認して再度お試しください。',
 			);
+			expect(consoleErrorSpy.mock.calls.at(-1)?.[1]).toEqual(
+				expect.objectContaining({ errorType: 'shift_verification_failed' }),
+			);
+			consoleErrorSpy.mockRestore();
 		});
 
 		it('proposeShiftChange tool は shift 取得エラー時にログを残して汎用エラーを返す', async () => {
@@ -1755,9 +1766,12 @@ describe('POST /api/chat/shift-adjustment', () => {
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
 				'Failed to verify shift in proposeShiftChange tool',
 				expect.objectContaining({
+					endpoint: '/api/chat/shift-adjustment',
+					method: 'POST',
 					errorType: 'shift_verification_failed',
 					message:
 						'対象シフトの確認中にエラーが発生しました。時間をおいて再度お試しください。',
+					stack: expect.any(String),
 					shiftErrorCode: '57014',
 				}),
 			);

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -72,6 +72,8 @@ vi.stubEnv('GEMINI_API_KEY', 'test-api-key');
 // POST をモック設定後にインポート
 const { POST } = await import('./route');
 
+const SECRET_PII_MARKER = 'SECRET_PII_MARKER';
+
 describe('POST /api/chat/shift-adjustment', () => {
 	const mockStaffSelect = vi.fn();
 	const mockStaffEq = vi.fn();
@@ -1443,6 +1445,197 @@ describe('POST /api/chat/shift-adjustment', () => {
 			expect(mockSupabaseFrom).toHaveBeenCalledWith('shifts');
 			expect(mockShiftSelect).toHaveBeenCalledWith('id');
 			expect(mockShiftEq).toHaveBeenCalledWith('id', TEST_IDS.SCHEDULE_1);
+		});
+
+		it('proposeShiftChange tool の allowlist 違反時に診断ログを構造化で出力する', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '提案して' }],
+						context: {
+							shifts: [
+								{
+									id: TEST_IDS.SCHEDULE_1,
+									clientId: TEST_IDS.CLIENT_1,
+									serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+									date: '2025-01-20',
+									startTime: '09:00',
+									endTime: '10:00',
+								},
+							],
+						},
+					}),
+				},
+			);
+
+			await POST(request);
+
+			const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+				tools?: {
+					proposeShiftChange?: {
+						execute?: (input: {
+							type: 'change_shift_staff';
+							shiftId: string;
+							toStaffId: string;
+						}) => Promise<unknown>;
+					};
+				};
+			};
+
+			await expect(
+				streamTextCall.tools?.proposeShiftChange?.execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_2,
+					toStaffId: TEST_IDS.STAFF_1,
+				}),
+			).rejects.toThrow('シフトIDが不正です');
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					errorType: 'allowlist_violation',
+					toolName: 'proposeShiftChange',
+					proposalShiftId: TEST_IDS.SCHEDULE_2,
+				}),
+			);
+
+			consoleErrorSpy.mockRestore();
+		});
+
+		it('診断ログに requestId として x-request-id を含める', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+			const requestId = 'req-150-test-id';
+
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+						'x-request-id': requestId,
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '提案して' }],
+						context: {
+							shifts: [
+								{
+									id: TEST_IDS.SCHEDULE_1,
+									clientId: TEST_IDS.CLIENT_1,
+									serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+									date: '2025-01-20',
+									startTime: '09:00',
+									endTime: '10:00',
+								},
+							],
+						},
+					}),
+				},
+			);
+
+			await POST(request);
+
+			const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+				tools?: {
+					proposeShiftChange?: {
+						execute?: (input: {
+							type: 'change_shift_staff';
+							shiftId: string;
+							toStaffId: string;
+						}) => Promise<unknown>;
+					};
+				};
+			};
+
+			await expect(
+				streamTextCall.tools?.proposeShiftChange?.execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_2,
+					toStaffId: TEST_IDS.STAFF_1,
+				}),
+			).rejects.toThrow('シフトIDが不正です');
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					requestId,
+				}),
+			);
+
+			consoleErrorSpy.mockRestore();
+		});
+
+		it('診断ログに本文の PII が含まれない', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: SECRET_PII_MARKER }],
+						context: {
+							shifts: [
+								{
+									id: TEST_IDS.SCHEDULE_1,
+									clientId: TEST_IDS.CLIENT_1,
+									serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+									date: '2025-01-20',
+									startTime: '09:00',
+									endTime: '10:00',
+								},
+							],
+						},
+					}),
+				},
+			);
+
+			await POST(request);
+
+			const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+				tools?: {
+					proposeShiftChange?: {
+						execute?: (input: {
+							type: 'change_shift_staff';
+							shiftId: string;
+							toStaffId: string;
+						}) => Promise<unknown>;
+					};
+				};
+			};
+
+			await expect(
+				streamTextCall.tools?.proposeShiftChange?.execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_2,
+					toStaffId: TEST_IDS.STAFF_1,
+				}),
+			).rejects.toThrow('シフトIDが不正です');
+
+			const loggedText = consoleErrorSpy.mock.calls
+				.flatMap((args) => args.map((arg) => JSON.stringify(arg)))
+				.join('\n');
+			expect(loggedText).not.toContain(SECRET_PII_MARKER);
+
+			consoleErrorSpy.mockRestore();
 		});
 
 		it('proposeShiftChange tool は shift がDBに存在しない場合エラーを返す', async () => {

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -119,6 +119,102 @@ const ChatRequestSchema = z.object({
 export type ChatMessage = z.infer<typeof ChatMessageSchema>;
 export type ChatRequest = z.infer<typeof ChatRequestSchema>;
 
+type ChatErrorCode =
+	| 'allowlist_violation'
+	| 'shift_verification_failed'
+	| 'stream_error'
+	| 'unexpected_error';
+
+type LoggedChatError = Error & {
+	__logged?: boolean;
+	__errorCode?: ChatErrorCode;
+};
+
+type RequestLogContext = {
+	requestId: string;
+	userId?: string;
+	officeId?: string;
+	mode?: 'uimessage' | 'legacy';
+	useProposalTool?: boolean;
+	shiftsCount?: number;
+	shiftIds?: string[];
+	allowlistedShiftIdsSize?: number;
+};
+
+const getMaxShiftIdsInLog = (): number =>
+	process.env.AI_CHAT_VERBOSE_LOG === 'true' ? 10 : 3;
+
+const classifyError = (error: unknown): ChatErrorCode => {
+	if (
+		typeof error === 'object' &&
+		error !== null &&
+		'__errorCode' in error &&
+		typeof (error as { __errorCode?: unknown }).__errorCode === 'string'
+	) {
+		return (error as { __errorCode: ChatErrorCode }).__errorCode;
+	}
+
+	return 'unexpected_error';
+};
+
+const markLoggedError = (
+	error: unknown,
+	errorCode: ChatErrorCode,
+): LoggedChatError => {
+	if (error instanceof Error) {
+		const typedError = error as LoggedChatError;
+		typedError.__errorCode = typedError.__errorCode ?? errorCode;
+		typedError.__logged = true;
+		return typedError;
+	}
+
+	const wrappedError = new Error(
+		typeof error === 'string' ? error : 'Unknown error',
+	) as LoggedChatError;
+	wrappedError.__errorCode = errorCode;
+	wrappedError.__logged = true;
+
+	return wrappedError;
+};
+
+const logChatError = (
+	message: string,
+	error: unknown,
+	logContext: RequestLogContext,
+	extra: Partial<{
+		toolName: string;
+		proposalShiftId: string;
+	}> = {},
+): void => {
+	const errorMessage =
+		error instanceof Error
+			? error.message
+			: typeof error === 'string'
+				? error
+				: typeof error === 'object' &&
+					  error !== null &&
+					  'message' in error &&
+					  typeof (error as { message?: unknown }).message === 'string'
+					? (error as { message: string }).message
+					: 'Unknown error';
+
+	console.error(message, {
+		requestId: logContext.requestId,
+		errorType: classifyError(error),
+		message: errorMessage,
+		errorMessage,
+		userId: logContext.userId,
+		officeId: logContext.officeId,
+		mode: logContext.mode,
+		useProposalTool: logContext.useProposalTool,
+		shiftsCount: logContext.shiftsCount,
+		shiftIds: logContext.shiftIds?.slice(0, getMaxShiftIdsInLog()),
+		allowlistedShiftIdsSize: logContext.allowlistedShiftIdsSize,
+		toolName: extra.toolName,
+		proposalShiftId: extra.proposalShiftId,
+	});
+};
+
 const SERVICE_TYPE_LABELS_PROMPT = Object.entries(ServiceTypeLabels)
 	.map(([serviceTypeId, label]) => `- ${serviceTypeId}: ${label}`)
 	.join('\n');
@@ -288,17 +384,27 @@ ${shiftLines.join('\n')}${shiftSelectionPrompt}`;
 const createProposeShiftChangeTool = (
 	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
 	shifts: Array<{ id: string }> | undefined,
+	logContext: RequestLogContext,
 ) => {
 	const allowlistedShiftIds = new Set((shifts ?? []).map((shift) => shift.id));
+	logContext.allowlistedShiftIdsSize = allowlistedShiftIds.size;
+
 	return tool({
 		description:
 			'シフト変更提案の内容を返却します（永続化は行いません）。shiftId は context.shifts に含まれる値のみ指定できます。',
 		inputSchema: AiChatMutationProposalSchema,
 		execute: async (proposal) => {
 			if (!allowlistedShiftIds.has(proposal.shiftId)) {
-				throw new Error(
+				const allowlistError = new Error(
 					'シフトIDが不正です。候補に含まれているシフトから選択してください。',
-				);
+				) as LoggedChatError;
+				allowlistError.__errorCode = 'allowlist_violation';
+				allowlistError.__logged = true;
+				logChatError('AI chat tool error', allowlistError, logContext, {
+					toolName: 'proposeShiftChange',
+					proposalShiftId: proposal.shiftId,
+				});
+				throw allowlistError;
 			}
 
 			const { data: shiftData, error: shiftError } = await supabase
@@ -307,19 +413,38 @@ const createProposeShiftChangeTool = (
 				.eq('id', proposal.shiftId)
 				.maybeSingle<{ id: string }>();
 			if (shiftError) {
-				console.error(
+				const verificationError = new Error(
+					'対象シフトの確認中にエラーが発生しました。時間をおいて再度お試しください。',
+				) as LoggedChatError;
+				verificationError.__errorCode = 'shift_verification_failed';
+				verificationError.__logged = true;
+				logChatError(
 					'Failed to verify shift in proposeShiftChange tool',
 					shiftError,
+					logContext,
+					{
+						toolName: 'proposeShiftChange',
+						proposalShiftId: proposal.shiftId,
+					},
 				);
-				throw new Error(
-					'対象シフトの確認中にエラーが発生しました。時間をおいて再度お試しください。',
-				);
+				throw verificationError;
 			}
 
 			if (!shiftData) {
-				throw new Error(
+				const shiftNotFoundError = new Error(
 					'指定されたシフトを確認できませんでした。対象シフトを確認して再度お試しください。',
+				) as LoggedChatError;
+				shiftNotFoundError.__logged = true;
+				logChatError(
+					'Shift not found in proposeShiftChange tool',
+					shiftNotFoundError,
+					logContext,
+					{
+						toolName: 'proposeShiftChange',
+						proposalShiftId: proposal.shiftId,
+					},
 				);
+				throw shiftNotFoundError;
 			}
 
 			return { proposal };
@@ -467,6 +592,7 @@ const buildTools = (
 	},
 	shifts: Array<{ id: string }> | undefined,
 	useProposalTool: boolean,
+	logContext: RequestLogContext,
 ) => {
 	// UIMessage モードかつ context.shifts が存在する場合のみ proposeShiftChange ツールを提供する。
 	// 1) レガシークライアントは JSON コードブロック方式を使うためツール不要
@@ -478,7 +604,11 @@ const buildTools = (
 
 	return {
 		...baseTools,
-		proposeShiftChange: createProposeShiftChangeTool(supabase, shiftList),
+		proposeShiftChange: createProposeShiftChangeTool(
+			supabase,
+			shiftList,
+			logContext,
+		),
 	};
 };
 
@@ -514,12 +644,16 @@ const toChatResponse = (
 	return result.toTextStreamResponse();
 };
 
-const handlePost = async (request: Request): Promise<Response> => {
+const handlePost = async (
+	request: Request,
+	logContext: RequestLogContext,
+): Promise<Response> => {
 	const authResult = await getAuthenticatedUser();
 	if (!authResult.ok) {
 		return authResult.response;
 	}
 	const { supabase, user } = authResult;
+	logContext.userId = user.id;
 
 	const parsedRequest = await parseChatRequest(request);
 	if (!parsedRequest.ok) {
@@ -527,6 +661,9 @@ const handlePost = async (request: Request): Promise<Response> => {
 	}
 
 	const { messages, context } = parsedRequest.data;
+	const shiftIds = (context?.shifts ?? []).map((shift) => shift.id);
+	logContext.shiftsCount = shiftIds.length;
+	logContext.shiftIds = shiftIds;
 
 	const apiKeyResult = getApiKey();
 	if (!apiKeyResult.ok) {
@@ -539,9 +676,12 @@ const handlePost = async (request: Request): Promise<Response> => {
 		return staffResult.response;
 	}
 	const { staffData } = staffResult;
+	logContext.officeId = staffData.office_id;
 
 	const { useUIMessageStream, useProposalTool, systemPrompt } =
 		resolveStreamMode(request, context);
+	logContext.mode = useUIMessageStream ? 'uimessage' : 'legacy';
+	logContext.useProposalTool = useProposalTool;
 
 	const google = createGoogleGenerativeAI({ apiKey });
 	const searchAvailableHelpersTool = createSearchAvailableHelpersTool({
@@ -565,6 +705,7 @@ const handlePost = async (request: Request): Promise<Response> => {
 		},
 		context?.shifts,
 		useProposalTool,
+		logContext,
 	);
 
 	const modelMessages = await convertToModelMessages(
@@ -580,16 +721,42 @@ const handlePost = async (request: Request): Promise<Response> => {
 		messages: modelMessages,
 		tools,
 		stopWhen: stepCountIs(5),
+		onError: ({ error }) => {
+			if (
+				typeof error === 'object' &&
+				error !== null &&
+				'__logged' in error &&
+				(error as { __logged?: boolean }).__logged === true
+			) {
+				return;
+			}
+
+			logChatError(
+				'AI chat stream error',
+				markLoggedError(error, 'stream_error'),
+				logContext,
+			);
+		},
 	});
 
 	return toChatResponse(result, useUIMessageStream);
 };
 
 export const POST = async (request: Request): Promise<Response> => {
+	const requestId =
+		request.headers.get('x-request-id') ??
+		request.headers.get('x-vercel-id') ??
+		crypto.randomUUID();
+	const logContext: RequestLogContext = { requestId };
+
 	try {
-		return await handlePost(request);
+		return await handlePost(request, logContext);
 	} catch (error) {
-		console.error('Chat API error:', error);
+		logChatError(
+			'Chat API error',
+			markLoggedError(error, 'unexpected_error'),
+			logContext,
+		);
 		// 内部エラーの詳細はクライアントに露出しない
 		return NextResponse.json(
 			{ error: 'Failed to process chat request' },

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -132,6 +132,8 @@ type LoggedChatError = Error & {
 
 type RequestLogContext = {
 	requestId: string;
+	endpoint?: string;
+	method?: string;
 	userId?: string;
 	officeId?: string;
 	mode?: 'uimessage' | 'legacy';
@@ -201,6 +203,8 @@ const logChatError = (
 
 	console.error(message, {
 		requestId: logContext.requestId,
+		endpoint: logContext.endpoint,
+		method: logContext.method,
 		errorType: classifyError(error),
 		message: errorMessage,
 		errorMessage,
@@ -214,6 +218,7 @@ const logChatError = (
 		toolName: extra.toolName,
 		proposalShiftId: extra.proposalShiftId,
 		shiftErrorCode: extra.shiftErrorCode,
+		stack: error instanceof Error ? error.stack : undefined,
 	});
 };
 
@@ -437,6 +442,7 @@ const createProposeShiftChangeTool = (
 				const shiftNotFoundError = new Error(
 					'指定されたシフトを確認できませんでした。対象シフトを確認して再度お試しください。',
 				) as LoggedChatError;
+				shiftNotFoundError.__errorCode = 'shift_verification_failed';
 				shiftNotFoundError.__logged = true;
 				logChatError(
 					'Shift not found in proposeShiftChange tool',
@@ -750,7 +756,11 @@ export const POST = async (request: Request): Promise<Response> => {
 		request.headers.get('x-request-id') ??
 		request.headers.get('x-vercel-id') ??
 		crypto.randomUUID();
-	const logContext: RequestLogContext = { requestId };
+	const logContext: RequestLogContext = {
+		requestId,
+		endpoint: '/api/chat/shift-adjustment',
+		method: request.method,
+	};
 
 	try {
 		return await handlePost(request, logContext);

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -184,6 +184,7 @@ const logChatError = (
 	extra: Partial<{
 		toolName: string;
 		proposalShiftId: string;
+		shiftErrorCode: string;
 	}> = {},
 ): void => {
 	const errorMessage =
@@ -212,6 +213,7 @@ const logChatError = (
 		allowlistedShiftIdsSize: logContext.allowlistedShiftIdsSize,
 		toolName: extra.toolName,
 		proposalShiftId: extra.proposalShiftId,
+		shiftErrorCode: extra.shiftErrorCode,
 	});
 };
 
@@ -420,11 +422,12 @@ const createProposeShiftChangeTool = (
 				verificationError.__logged = true;
 				logChatError(
 					'Failed to verify shift in proposeShiftChange tool',
-					shiftError,
+					verificationError,
 					logContext,
 					{
 						toolName: 'proposeShiftChange',
 						proposalShiftId: proposal.shiftId,
+						shiftErrorCode: shiftError.code,
 					},
 				);
 				throw verificationError;

--- a/src/backend/services/shiftService.test.ts
+++ b/src/backend/services/shiftService.test.ts
@@ -1861,8 +1861,8 @@ describe('ShiftService', () => {
 			const shiftId = TEST_IDS.SCHEDULE_1;
 			const newStaffId = TEST_IDS.STAFF_2;
 			const reason = '日時変更と再割当';
-			const newStartTime = new Date('2026-04-10T10:00:00+09:00');
-			const newEndTime = new Date('2026-04-10T11:00:00+09:00');
+			const newStartTime = new Date('2099-04-10T10:00:00+09:00');
+			const newEndTime = new Date('2099-04-10T11:00:00+09:00');
 			const adminStaff = createTestStaff({
 				auth_user_id: userId,
 				role: 'admin',
@@ -1872,14 +1872,14 @@ describe('ShiftService', () => {
 				id: shiftId,
 				client_id: TEST_IDS.CLIENT_1,
 				service_type_id: 'physical-care',
-				date: new Date('2026-04-10'),
+				date: new Date('2099-04-10'),
 				time: { start: { hour: 8, minute: 0 }, end: { hour: 9, minute: 0 } },
 			});
 			const conflictShift = createTestShift({
 				id: TEST_IDS.SCHEDULE_2,
 				status: 'scheduled',
 				staff_id: newStaffId,
-				date: new Date('2026-04-10'),
+				date: new Date('2099-04-10'),
 				time: {
 					start: { hour: 10, minute: 30 },
 					end: { hour: 11, minute: 30 },
@@ -1890,7 +1890,7 @@ describe('ShiftService', () => {
 				client_id: TEST_IDS.CLIENT_1,
 				service_type_id: 'physical-care',
 				staff_id: newStaffId,
-				date: new Date('2026-04-10'),
+				date: new Date('2099-04-10'),
 				time: { start: { hour: 10, minute: 0 }, end: { hour: 11, minute: 0 } },
 			});
 			const assignableStaff = createTestStaff({
@@ -1951,8 +1951,8 @@ describe('ShiftService', () => {
 			const shiftId = TEST_IDS.SCHEDULE_1;
 			const newStaffId = TEST_IDS.STAFF_2;
 			const reason = '日時変更と再割当';
-			const newStartTime = new Date('2026-04-10T10:00:00+09:00');
-			const newEndTime = new Date('2026-04-10T11:00:00+09:00');
+			const newStartTime = new Date('2099-04-10T10:00:00+09:00');
+			const newEndTime = new Date('2099-04-10T11:00:00+09:00');
 			const adminStaff = createTestStaff({
 				auth_user_id: userId,
 				role: 'admin',
@@ -1962,14 +1962,14 @@ describe('ShiftService', () => {
 				id: shiftId,
 				client_id: TEST_IDS.CLIENT_1,
 				service_type_id: 'physical-care',
-				date: new Date('2026-04-10'),
+				date: new Date('2099-04-10'),
 				time: { start: { hour: 8, minute: 0 }, end: { hour: 9, minute: 0 } },
 			});
 			const conflict1 = createTestShift({
 				id: TEST_IDS.SCHEDULE_2,
 				status: 'scheduled',
 				staff_id: newStaffId,
-				date: new Date('2026-04-10'),
+				date: new Date('2099-04-10'),
 				time: {
 					start: { hour: 10, minute: 15 },
 					end: { hour: 10, minute: 45 },
@@ -1979,7 +1979,7 @@ describe('ShiftService', () => {
 				id: createTestId(),
 				status: 'scheduled',
 				staff_id: newStaffId,
-				date: new Date('2026-04-10'),
+				date: new Date('2099-04-10'),
 				time: {
 					start: { hour: 10, minute: 30 },
 					end: { hour: 11, minute: 30 },


### PR DESCRIPTION
## 概要

AIチャット（`/api/chat/shift-adjustment`）が失敗した際に、原因調査に必要な最小限のサーバーログを出力する。
個人情報・チャット本文はログに含まない。

Closes #150

---

## ログ出力内容

失敗時に以下を構造化オブジェクトで `console.error` 出力する（PII は含まない）。

| フィールド | 内容 |
|---|---|
| `requestId` | `x-request-id` / `x-vercel-id` ヘッダ優先、なければ `crypto.randomUUID()` で生成 |
| `userId` | 認証済みの場合のみ UUID を出力 |
| `officeId` | staff context から解決できた場合のみ UUID を出力 |
| `mode` | `uimessage` または `legacy`（`x-ai-response-format` による） |
| `useProposalTool` | boolean |
| `shiftsCount` | context.shifts の件数（整数） |
| `shiftIds` | UUID のみ、最大 N 件（デフォルト 3、`AI_CHAT_VERBOSE_LOG=true` で 10） |
| `allowlistedShiftIdsSize` | allowlist の件数 |
| `toolName` | tool 起因の失敗時のみ（例: `proposeShiftChange`） |
| `proposalShiftId` | tool 起因の失敗時のみ、UUID のみ |
| `errorType` | `allowlist_violation` / `shift_verification_failed` / `stream_error` / `unexpected_error` |
| `stack` | Error の stack trace |

## PII 除外

- `messages` の本文・`parts` の text は **出力しない**
- `staffName`、`clientName` 等の文字列も **出力しない**（UUID・件数中心）
- UT でチャット本文がログに含まれないことを担保

## 環境変数フラグ

| 変数 | デフォルト | 説明 |
|---|---|---|
| `AI_CHAT_VERBOSE_LOG` | （未設定） | `true` にすると `shiftIds` の出力上限が 3→10 に増加 |

`env.example` に追記済み。

## テスト

```bash
pnpm vitest run src/app/api/chat/shift-adjustment/route.test.ts
```

- UT 51 件（全 pass）
- 主なケース:
  - tool が throw したとき `console.error` が呼ばれる
  - `requestId` / `shiftIds` / `errorType` 等がログに含まれる
  - チャット本文（テスト用シークレット文字列）はログに含まれない

## 変更ファイル

- `src/app/api/chat/shift-adjustment/route.ts` — 診断ログ実装
- `src/app/api/chat/shift-adjustment/route.test.ts` — UT 追加
- `env.example` — `AI_CHAT_VERBOSE_LOG` を追記
