### PR TITLE
fix: system prompt にシフトIDを明示し、shiftId 聞き返し・誤UUID混入を抑制する (#156)

### DIFF
--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -658,25 +658,21 @@ describe('POST /api/chat/shift-adjustment', () => {
 		const response = await POST(request);
 
 		expect(response.status).toBe(200);
-		expect(mockStreamText).toHaveBeenCalledWith(
-			expect.objectContaining({
-				system: expect.stringContaining(`shiftId: ${TEST_IDS.SCHEDULE_1}`),
-			}),
-		);
-		expect(mockStreamText).toHaveBeenCalledWith(
-			expect.objectContaining({
-				system: expect.stringContaining(
-					'shiftId は表示された値をそのまま使ってください',
-				),
-			}),
-		);
-		expect(mockStreamText).toHaveBeenCalledWith(
-			expect.objectContaining({
-				system: expect.stringContaining(
-					'context.shifts が 1 件のときは shiftId をユーザーに確認せず、そのまま使用してください',
-				),
-			}),
-		);
+
+		const calls = mockStreamText.mock.calls.map(([arg]) => arg);
+		const systems = calls
+			.map((call) => call.system)
+			.filter((system): system is string => typeof system === 'string');
+		const substrings = [
+			`shiftId: ${TEST_IDS.SCHEDULE_1}`,
+			'shiftId は表示された値をそのまま使ってください',
+			'context.shifts が 1 件のときは shiftId をユーザーに確認せず、そのまま使用してください',
+			'shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください',
+		];
+		const hasAll = (system: string) =>
+			substrings.every((substring) => system.includes(substring));
+
+		expect(systems.some((system) => hasAll(system))).toBe(true);
 	});
 
 	it('context.shifts が複数件のとき system にそれぞれの shiftId を含める', async () => {
@@ -715,30 +711,21 @@ describe('POST /api/chat/shift-adjustment', () => {
 		const response = await POST(request);
 
 		expect(response.status).toBe(200);
-		expect(mockStreamText).toHaveBeenCalledWith(
-			expect.objectContaining({
-				system: expect.stringContaining(`shiftId: ${TEST_IDS.SCHEDULE_1}`),
-			}),
-		);
-		expect(mockStreamText).toHaveBeenCalledWith(
-			expect.objectContaining({
-				system: expect.stringContaining(`shiftId: ${TEST_IDS.SCHEDULE_2}`),
-			}),
-		);
-		expect(mockStreamText).toHaveBeenCalledWith(
-			expect.objectContaining({
-				system: expect.stringContaining(
-					'shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください',
-				),
-			}),
-		);
-		expect(mockStreamText).toHaveBeenCalledWith(
-			expect.objectContaining({
-				system: expect.stringContaining(
-					'日時（date/start/end）や利用者名/スタッフ名など、ユーザーが識別できる情報で選んでもらってください',
-				),
-			}),
-		);
+
+		const calls = mockStreamText.mock.calls.map(([arg]) => arg);
+		const systems = calls
+			.map((call) => call.system)
+			.filter((system): system is string => typeof system === 'string');
+		const substrings = [
+			`shiftId: ${TEST_IDS.SCHEDULE_1}`,
+			`shiftId: ${TEST_IDS.SCHEDULE_2}`,
+			'shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください',
+			'日時（date/start/end）や利用者名/スタッフ名など、ユーザーが識別できる情報で選んでもらってください',
+		];
+		const hasAll = (system: string) =>
+			substrings.every((substring) => system.includes(substring));
+
+		expect(systems.some((system) => hasAll(system))).toBe(true);
 	});
 
 	it('context.shifts.date が YYYY-MM-DD 形式でない場合は 400 エラーを返す', async () => {

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -632,6 +632,115 @@ describe('POST /api/chat/shift-adjustment', () => {
 		);
 	});
 
+	it('context.shifts が1件のとき system にその shiftId と単一シフト時の指示文を含める', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: 'このシフトの調整をお願い' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+							staffName: 'スタッフA',
+							clientName: '利用者A',
+							date: '2025-01-20',
+							startTime: '09:00',
+							endTime: '10:00',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(`shiftId: ${TEST_IDS.SCHEDULE_1}`),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(
+					'shiftId は表示された値をそのまま使ってください',
+				),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(
+					'context.shifts が 1 件のときは shiftId をユーザーに確認せず、そのまま使用してください',
+				),
+			}),
+		);
+	});
+
+	it('context.shifts が複数件のとき system にそれぞれの shiftId を含める', async () => {
+		const request = new Request('http://localhost/api/chat/shift-adjustment', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				messages: [{ role: 'user', content: '候補シフトを確認したい' }],
+				context: {
+					shifts: [
+						{
+							id: TEST_IDS.SCHEDULE_1,
+							clientId: TEST_IDS.CLIENT_1,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+							staffName: 'スタッフA',
+							clientName: '利用者A',
+							date: '2025-01-20',
+							startTime: '09:00',
+							endTime: '10:00',
+						},
+						{
+							id: TEST_IDS.SCHEDULE_2,
+							clientId: TEST_IDS.CLIENT_2,
+							serviceTypeId: TEST_IDS.SERVICE_TYPE_2,
+							staffName: 'スタッフB',
+							clientName: '利用者B',
+							date: '2025-01-21',
+							startTime: '11:00',
+							endTime: '12:00',
+						},
+					],
+				},
+			}),
+		});
+
+		const response = await POST(request);
+
+		expect(response.status).toBe(200);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(`shiftId: ${TEST_IDS.SCHEDULE_1}`),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(`shiftId: ${TEST_IDS.SCHEDULE_2}`),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(
+					'shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください',
+				),
+			}),
+		);
+		expect(mockStreamText).toHaveBeenCalledWith(
+			expect.objectContaining({
+				system: expect.stringContaining(
+					'日時（date/start/end）や利用者名/スタッフ名など、ユーザーが識別できる情報で選んでもらってください',
+				),
+			}),
+		);
+	});
+
 	it('context.shifts.date が YYYY-MM-DD 形式でない場合は 400 エラーを返す', async () => {
 		const request = new Request('http://localhost/api/chat/shift-adjustment', {
 			method: 'POST',

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -376,6 +376,7 @@ const buildContextPrompt = (context: ChatRequest['context']): string => {
 - context.shifts[0] の date / clientId / serviceTypeId をそのまま tool 入力に使用してください。
 - shiftId は表示された値をそのまま使ってください（推測・書き換え禁止）。
 - context.shifts が 1 件のときは shiftId をユーザーに確認せず、そのまま使用してください。
+- shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください。
 - startTime / endTime は文字列（例: "09:00"）を { hour, minute } オブジェクトに変換して tool 入力してください。
   例: "09:00" → { hour: 9, minute: 0 }、"10:30" → { hour: 10, minute: 30 }
 - ユーザーが代替ヘルパーの提案・空きヘルパーの探索を求めている場合は、追加質問なしで即座に searchAvailableHelpers を呼び出してください。`

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -363,7 +363,7 @@ const buildContextPrompt = (context: ChatRequest['context']): string => {
 	const shiftLines = context.shifts.map((s) => {
 		const serviceTypeLabel = ServiceTypeLabels[s.serviceTypeId];
 
-		return `- ${s.date} ${s.startTime}〜${s.endTime}: ${s.clientName ?? '(利用者不明)'} / ${s.staffName ?? '(未割当)'} (${serviceTypeLabel}（serviceTypeId: ${s.serviceTypeId}）, clientId: ${s.clientId})`;
+		return `- ${s.date} ${s.startTime}〜${s.endTime}: ${s.clientName ?? '(利用者不明)'} / ${s.staffName ?? '(未割当)'} (${serviceTypeLabel}（serviceTypeId: ${s.serviceTypeId}）, clientId: ${s.clientId}, shiftId: ${s.id})`;
 	});
 
 	const shiftSelectionPrompt =
@@ -374,13 +374,17 @@ const buildContextPrompt = (context: ChatRequest['context']): string => {
 - context.shifts[0] が今回の対象シフトです。
 - このシフトを対象として扱い、日時・サービス内容・利用者の追加確認は行わないでください。
 - context.shifts[0] の date / clientId / serviceTypeId をそのまま tool 入力に使用してください。
+- shiftId は表示された値をそのまま使ってください（推測・書き換え禁止）。
+- context.shifts が 1 件のときは shiftId をユーザーに確認せず、そのまま使用してください。
 - startTime / endTime は文字列（例: "09:00"）を { hour, minute } オブジェクトに変換して tool 入力してください。
   例: "09:00" → { hour: 9, minute: 0 }、"10:30" → { hour: 10, minute: 30 }
 - ユーザーが代替ヘルパーの提案・空きヘルパーの探索を求めている場合は、追加質問なしで即座に searchAvailableHelpers を呼び出してください。`
 			: `
 
 ## 対象シフトの確認（重要）
-- context.shifts に複数シフトがあるため、どのシフトを対象にするかをユーザーに確認してください。`;
+- context.shifts に複数シフトがあるため、どのシフトを対象にするかをユーザーに確認してください。
+- shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください。
+- 日時（date/start/end）や利用者名/スタッフ名など、ユーザーが識別できる情報で選んでもらってください。`;
 
 	return `
 


### PR DESCRIPTION
## 概要

Issue #156 の対応です。

`/api/chat/shift-adjustment` の `buildContextPrompt` が出力するシフト情報に `shiftId` が含まれていなかったため、LLM が `proposal.shiftId` に誤ったUUID（officeId/clientId等）を入れて `allowlist_violation` が発生していました。

## 変更内容

### `src/app/api/chat/shift-adjustment/route.ts`

- **`buildContextPrompt`**: 各シフト行に `shiftId` を明示するよう追加
- **system prompt（単一シフト時）**: `shiftId` を推測・書き換えせずそのまま使用する指示を追加。ユーザーへの聞き返しを抑制
- **system prompt（複数シフト時）**: `shiftId` をユーザーに要求・提示せず、日時・担当者等の可視情報でシフトを選ばせる指示を追加

### `src/app/api/chat/shift-adjustment/route.test.ts`

- シフト1件のとき `system` に `shiftId` が含まれることを検証するテスト追加
- シフト複数件のとき各 `shiftId` が `system` に含まれることを検証するテスト追加
- 単一シフト時の聞き返し抑制指示文が含まれることを検証するテスト追加
- 複数シフト時の可視情報選択指示文が含まれることを検証するテスト追加

## 受け入れ条件の確認

- [x] `context.shifts` が1件のとき、system prompt の「現在のシフト情報」に shiftId が明示される
- [x] 上記条件で、AI が shiftId を尋ねない方向に改善する（聞き返し抑制指示を追加）
- [x] テスト PASS 済み

## 関連

Closes #156