### PR TITLE
fix: proposeShiftChange の入力形式とログを修正

### DIFF
--- a/src/app/actions/aiChatMutation.test.ts
+++ b/src/app/actions/aiChatMutation.test.ts
@@ -2,7 +2,15 @@ import { AiOperationLogService } from '@/backend/services/aiOperationLogService'
 import { ServiceError, ShiftService } from '@/backend/services/shiftService';
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { createSupabaseClient } from '@/utils/supabase/server';
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type Mock,
+} from 'vitest';
 import { executeAiChatMutationAction } from './aiChatMutation';
 
 vi.mock('@/utils/supabase/server');
@@ -60,7 +68,6 @@ const validInput = {
 		staffIds: [TEST_IDS.STAFF_2],
 	},
 };
-
 const mockAuthUser = (userId: string) => {
 	mockSupabase.auth.getUser.mockResolvedValue({
 		data: { user: { id: userId } },
@@ -79,6 +86,10 @@ beforeEach(() => {
 	(AiOperationLogService as unknown as Mock).mockImplementation(function () {
 		return mockAiOperationLogService;
 	});
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllEnvs();
 });
 
 describe('executeAiChatMutationAction', () => {
@@ -207,5 +218,76 @@ describe('executeAiChatMutationAction', () => {
 		expect(result.status).toBe(403);
 		expect(result.error).toBe('Forbidden');
 		expect(mockAiOperationLogService.logSilently).not.toHaveBeenCalled();
+	});
+	it('Validation failed は非テスト環境で console.warn を出力する', async () => {
+		mockAuthUser(TEST_IDS.USER_1);
+		vi.stubEnv('NODE_ENV', 'development');
+		vi.stubEnv('VITEST', 'false');
+		const warnSpy = vi
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+
+		await executeAiChatMutationAction({
+			...validInput,
+			proposal: {
+				...validInput.proposal,
+				shiftId: 'invalid-uuid',
+			},
+		});
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[executeAiChatMutationAction] Validation failed',
+			expect.objectContaining({ userId: TEST_IDS.USER_1 }),
+		);
+	});
+
+	it('ServiceError(403) は非テスト環境で console.warn を出力する', async () => {
+		mockAuthUser(TEST_IDS.USER_1);
+		mockShiftService.executeAiChatMutationProposal.mockRejectedValue(
+			new ServiceError(403, 'Forbidden'),
+		);
+		vi.stubEnv('NODE_ENV', 'development');
+		vi.stubEnv('VITEST', 'false');
+		const warnSpy = vi
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+
+		await executeAiChatMutationAction(validInput);
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[executeAiChatMutationAction] ServiceError',
+			expect.objectContaining({
+				userId: TEST_IDS.USER_1,
+				status: 403,
+				message: 'Forbidden',
+				proposalType: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+			}),
+		);
+	});
+
+	it('process.env.VITEST が true のとき console.warn を抑止する', async () => {
+		mockAuthUser(TEST_IDS.USER_1);
+		vi.stubEnv('NODE_ENV', 'development');
+		vi.stubEnv('VITEST', 'true');
+		const warnSpy = vi
+			.spyOn(console, 'warn')
+			.mockImplementation(() => undefined);
+
+		await executeAiChatMutationAction({
+			...validInput,
+			proposal: {
+				...validInput.proposal,
+				shiftId: 'invalid-uuid',
+			},
+		});
+
+		mockShiftService.findActorOfficeId.mockResolvedValue(TEST_IDS.OFFICE_1);
+		mockShiftService.executeAiChatMutationProposal.mockRejectedValue(
+			new ServiceError(400, 'Proposal target shift is not allowed'),
+		);
+		await executeAiChatMutationAction(validInput);
+
+		expect(warnSpy).not.toHaveBeenCalled();
 	});
 });

--- a/src/app/actions/aiChatMutation.test.ts
+++ b/src/app/actions/aiChatMutation.test.ts
@@ -237,7 +237,10 @@ describe('executeAiChatMutationAction', () => {
 
 		expect(warnSpy).toHaveBeenCalledWith(
 			'[executeAiChatMutationAction] Validation failed',
-			expect.objectContaining({ userId: TEST_IDS.USER_1 }),
+			expect.not.objectContaining({
+				userId: expect.any(String),
+				shiftId: expect.any(String),
+			}),
 		);
 	});
 
@@ -257,11 +260,16 @@ describe('executeAiChatMutationAction', () => {
 		expect(warnSpy).toHaveBeenCalledWith(
 			'[executeAiChatMutationAction] ServiceError',
 			expect.objectContaining({
-				userId: TEST_IDS.USER_1,
 				status: 403,
 				message: 'Forbidden',
 				proposalType: 'change_shift_staff',
-				shiftId: TEST_IDS.SCHEDULE_1,
+			}),
+		);
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[executeAiChatMutationAction] ServiceError',
+			expect.not.objectContaining({
+				userId: expect.any(String),
+				shiftId: expect.any(String),
 			}),
 		);
 	});

--- a/src/app/actions/aiChatMutation.ts
+++ b/src/app/actions/aiChatMutation.ts
@@ -37,7 +37,6 @@ export const executeAiChatMutationAction = async (
 	if (!parsedInput.success) {
 		if (process.env.NODE_ENV !== 'test' && process.env.VITEST !== 'true') {
 			console.warn('[executeAiChatMutationAction] Validation failed', {
-				userId: user.id,
 				issues: parsedInput.error.flatten(),
 			});
 		}
@@ -98,11 +97,9 @@ export const executeAiChatMutationAction = async (
 
 			if (process.env.NODE_ENV !== 'test' && process.env.VITEST !== 'true') {
 				console.warn('[executeAiChatMutationAction] ServiceError', {
-					userId: user.id,
 					status: error.status,
 					message: error.message,
 					proposalType: parsedInput.data.proposal.type,
-					shiftId: parsedInput.data.proposal.shiftId,
 				});
 			}
 

--- a/src/app/actions/aiChatMutation.ts
+++ b/src/app/actions/aiChatMutation.ts
@@ -96,11 +96,7 @@ export const executeAiChatMutationAction = async (
 				return errorResult(error.message, error.status);
 			}
 
-			if (
-				process.env.NODE_ENV !== 'test' &&
-				process.env.VITEST !== 'true' &&
-				error.status !== 403
-			) {
+			if (process.env.NODE_ENV !== 'test' && process.env.VITEST !== 'true') {
 				console.warn('[executeAiChatMutationAction] ServiceError', {
 					userId: user.id,
 					status: error.status,

--- a/src/app/actions/aiChatMutation.ts
+++ b/src/app/actions/aiChatMutation.ts
@@ -35,6 +35,12 @@ export const executeAiChatMutationAction = async (
 
 	const parsedInput = ExecuteAiChatMutationInputSchema.safeParse(input);
 	if (!parsedInput.success) {
+		if (process.env.NODE_ENV !== 'test' && process.env.VITEST !== 'true') {
+			console.warn('[executeAiChatMutationAction] Validation failed', {
+				userId: user.id,
+				issues: parsedInput.error.flatten(),
+			});
+		}
 		return errorResult('Validation failed', 400, parsedInput.error.flatten());
 	}
 
@@ -89,6 +95,21 @@ export const executeAiChatMutationAction = async (
 				logServerError(error);
 				return errorResult(error.message, error.status);
 			}
+
+			if (
+				process.env.NODE_ENV !== 'test' &&
+				process.env.VITEST !== 'true' &&
+				error.status !== 403
+			) {
+				console.warn('[executeAiChatMutationAction] ServiceError', {
+					userId: user.id,
+					status: error.status,
+					message: error.message,
+					proposalType: parsedInput.data.proposal.type,
+					shiftId: parsedInput.data.proposal.shiftId,
+				});
+			}
+
 			return errorResult(error.message, error.status, error.details);
 		}
 		logServerError(error);

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -1634,16 +1634,89 @@ describe('POST /api/chat/shift-adjustment', () => {
 					toStaffId: TEST_IDS.STAFF_1,
 				}),
 			).resolves.toEqual({
-				proposal: {
-					type: 'change_shift_staff',
-					shiftId: TEST_IDS.SCHEDULE_1,
-					toStaffId: TEST_IDS.STAFF_1,
-				},
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_1,
 			});
 
 			expect(mockSupabaseFrom).toHaveBeenCalledWith('shifts');
 			expect(mockShiftSelect).toHaveBeenCalledWith('id');
 			expect(mockShiftEq).toHaveBeenCalledWith('id', TEST_IDS.SCHEDULE_1);
+		});
+
+		it('proposeShiftChange tool の inputSchema はネスト形式も受け付ける', async () => {
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '提案して' }],
+						context: {
+							shifts: [
+								{
+									id: TEST_IDS.SCHEDULE_1,
+									clientId: TEST_IDS.CLIENT_1,
+									serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+									date: '2025-01-20',
+									startTime: '09:00',
+									endTime: '10:00',
+								},
+							],
+						},
+					}),
+				},
+			);
+
+			await POST(request);
+
+			const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+				tools?: {
+					proposeShiftChange?: {
+						inputSchema?: { parse: (input: unknown) => unknown };
+					};
+				};
+			};
+
+			const inputSchema = streamTextCall.tools?.proposeShiftChange
+				?.inputSchema as unknown as {
+				parse: (input: unknown) => unknown;
+			};
+
+			expect(inputSchema).toBeDefined();
+
+			expect(
+				inputSchema.parse({
+					change_shift_staff: {
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_1,
+						reason: '欠勤対応',
+					},
+				}),
+			).toEqual({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_1,
+				reason: '欠勤対応',
+			});
+
+			expect(
+				inputSchema.parse({
+					update_shift_time: {
+						shiftId: TEST_IDS.SCHEDULE_1,
+						startAt: '2026-03-16T09:00:00+09:00',
+						endAt: '2026-03-16T10:00:00+09:00',
+					},
+				}),
+			).toEqual({
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: '2026-03-16T09:00:00+09:00',
+				endAt: '2026-03-16T10:00:00+09:00',
+			});
 		});
 
 		it('proposeShiftChange tool の allowlist 違反時に診断ログを構造化で出力する', async () => {

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -1719,6 +1719,42 @@ describe('POST /api/chat/shift-adjustment', () => {
 				startAt: '2026-03-16T09:00:00+09:00',
 				endAt: '2026-03-16T10:00:00+09:00',
 			});
+
+			expect(() =>
+				inputSchema.parse({
+					change_shift_staff: null,
+					update_shift_time: {
+						shiftId: TEST_IDS.SCHEDULE_1,
+						startAt: '2026-03-16T09:00:00+09:00',
+						endAt: '2026-03-16T10:00:00+09:00',
+					},
+				}),
+			).toThrow();
+
+			expect(() =>
+				inputSchema.parse({
+					change_shift_staff: 'invalid',
+					update_shift_time: {
+						shiftId: TEST_IDS.SCHEDULE_1,
+						startAt: '2026-03-16T09:00:00+09:00',
+						endAt: '2026-03-16T10:00:00+09:00',
+					},
+				}),
+			).toThrow();
+
+			expect(() =>
+				inputSchema.parse({
+					change_shift_staff: {
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_1,
+					},
+					update_shift_time: {
+						shiftId: TEST_IDS.SCHEDULE_1,
+						startAt: '2026-03-16T09:00:00+09:00',
+						endAt: '2026-03-16T10:00:00+09:00',
+					},
+				}),
+			).toThrow();
 		});
 
 		it('proposeShiftChange tool の allowlist 違反時に診断ログを構造化で出力する', async () => {

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -1691,6 +1691,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 			expect(
 				inputSchema.parse({
 					change_shift_staff: {
+						type: 'update_shift_time',
 						shiftId: TEST_IDS.SCHEDULE_1,
 						toStaffId: TEST_IDS.STAFF_1,
 						reason: '欠勤対応',
@@ -1706,6 +1707,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 			expect(
 				inputSchema.parse({
 					update_shift_time: {
+						type: 'change_shift_staff',
 						shiftId: TEST_IDS.SCHEDULE_1,
 						startAt: '2026-03-16T09:00:00+09:00',
 						endAt: '2026-03-16T10:00:00+09:00',

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -406,23 +406,32 @@ const ProposeShiftChangeToolInputSchema = z.preprocess((input) => {
 	}
 
 	const obj = input as Record<string, unknown>;
+	const hasChangeShiftStaffKey = 'change_shift_staff' in obj;
+	const hasUpdateShiftTimeKey = 'update_shift_time' in obj;
 
-	if (
-		'change_shift_staff' in obj &&
+	if (hasChangeShiftStaffKey && hasUpdateShiftTimeKey) {
+		return {
+			type: '__ambiguous_nested_tool_input__',
+		};
+	}
+
+	const hasChangeShiftStaff =
+		hasChangeShiftStaffKey &&
 		typeof obj.change_shift_staff === 'object' &&
-		obj.change_shift_staff !== null
-	) {
+		obj.change_shift_staff !== null;
+	const hasUpdateShiftTime =
+		hasUpdateShiftTimeKey &&
+		typeof obj.update_shift_time === 'object' &&
+		obj.update_shift_time !== null;
+
+	if (hasChangeShiftStaff) {
 		return {
 			...(obj.change_shift_staff as Record<string, unknown>),
 			type: 'change_shift_staff',
 		};
 	}
 
-	if (
-		'update_shift_time' in obj &&
-		typeof obj.update_shift_time === 'object' &&
-		obj.update_shift_time !== null
-	) {
+	if (hasUpdateShiftTime) {
 		return {
 			...(obj.update_shift_time as Record<string, unknown>),
 			type: 'update_shift_time',

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -252,7 +252,7 @@ const LEGACY_PROPOSAL_TOOL_PROMPT = `
 const PROPOSAL_TOOL_PROMPT = `
 - proposeShiftChange: シフト変更提案の内容を返却します（永続化は行いません）
   - シフト変更の提案を返すときは assistant 本文に JSON を書かず、必ずこのツールを呼び出してください
-  - 入力は change_shift_staff または update_shift_time の形式に厳密に従ってください
+  - 入力は次の JSON 例（type を含む形式）に厳密に従ってください
 
 ## proposeShiftChange と成功断言の区別（重要）
 - proposeShiftChange の呼び出しは成功断言ではありません
@@ -400,6 +400,38 @@ const buildContextPrompt = (context: ChatRequest['context']): string => {
 ${shiftLines.join('\n')}${shiftSelectionPrompt}`;
 };
 
+const ProposeShiftChangeToolInputSchema = z.preprocess((input) => {
+	if (typeof input !== 'object' || input === null) {
+		return input;
+	}
+
+	const obj = input as Record<string, unknown>;
+
+	if (
+		'change_shift_staff' in obj &&
+		typeof obj.change_shift_staff === 'object' &&
+		obj.change_shift_staff !== null
+	) {
+		return {
+			type: 'change_shift_staff',
+			...(obj.change_shift_staff as Record<string, unknown>),
+		};
+	}
+
+	if (
+		'update_shift_time' in obj &&
+		typeof obj.update_shift_time === 'object' &&
+		obj.update_shift_time !== null
+	) {
+		return {
+			type: 'update_shift_time',
+			...(obj.update_shift_time as Record<string, unknown>),
+		};
+	}
+
+	return input;
+}, AiChatMutationProposalSchema);
+
 const createProposeShiftChangeTool = (
 	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
 	shifts: Array<{ id: string }> | undefined,
@@ -411,7 +443,7 @@ const createProposeShiftChangeTool = (
 	return tool({
 		description:
 			'シフト変更提案の内容を返却します（永続化は行いません）。shiftId は context.shifts に含まれる値のみ指定できます。',
-		inputSchema: AiChatMutationProposalSchema,
+		inputSchema: ProposeShiftChangeToolInputSchema,
 		execute: async (proposal) => {
 			if (!allowlistedShiftIds.has(proposal.shiftId)) {
 				const allowlistError = new Error(
@@ -468,7 +500,7 @@ const createProposeShiftChangeTool = (
 				throw shiftNotFoundError;
 			}
 
-			return { proposal };
+			return proposal;
 		},
 	});
 };

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -413,8 +413,8 @@ const ProposeShiftChangeToolInputSchema = z.preprocess((input) => {
 		obj.change_shift_staff !== null
 	) {
 		return {
-			type: 'change_shift_staff',
 			...(obj.change_shift_staff as Record<string, unknown>),
+			type: 'change_shift_staff',
 		};
 	}
 
@@ -424,8 +424,8 @@ const ProposeShiftChangeToolInputSchema = z.preprocess((input) => {
 		obj.update_shift_time !== null
 	) {
 		return {
-			type: 'update_shift_time',
 			...(obj.update_shift_time as Record<string, unknown>),
+			type: 'update_shift_time',
 		};
 	}
 


### PR DESCRIPTION
Closes #158\n\n## 変更内容\n- proposeShiftChange tool の output を proposal 本体に統一（UI 側の proposal 抽出と整合）\n- proposeShiftChange tool の inputSchema を後方互換（ネスト形式も許容し正規化）\n- executeAiChatMutationAction で 400(入力バリデーション) / 4xx(ServiceError) 時に PII を含まない warn ログを追加（Vitest 実行時は抑止）\n\n## テスト\n- pnpm vitest run src/app/api/chat/shift-adjustment/route.test.ts