### PR TITLE
feat: Phase 1-a バッチ提案スキーマ・型定義の追加

### DIFF
--- a/src/models/aiChatMutationProposal.test.ts
+++ b/src/models/aiChatMutationProposal.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import {
 	ALLOWLIST_MAX_SHIFT_IDS,
 	ALLOWLIST_MAX_STAFF_IDS,
+	AiChatMutationBatchProposalSchema,
 	AiChatMutationProposalSchema,
+	BATCH_PROPOSAL_MAX_COUNT,
+	ExecuteAiChatMutationBatchInputSchema,
 	ExecuteAiChatMutationInputSchema,
 	ProposalAllowlistSchema,
 } from './aiChatMutationProposal';
@@ -130,6 +133,15 @@ describe('ProposalAllowlistSchema', () => {
 		expect(result.success).toBe(false);
 	});
 
+	it('staffIds が空配列の場合はエラー', () => {
+		const result = ProposalAllowlistSchema.safeParse({
+			shiftIds: [TEST_IDS.SCHEDULE_1],
+			staffIds: [],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
 	it('shiftIds が上限を超える場合はエラー', () => {
 		const result = ProposalAllowlistSchema.safeParse({
 			shiftIds: Array.from({ length: ALLOWLIST_MAX_SHIFT_IDS + 1 }, () =>
@@ -153,6 +165,38 @@ describe('ProposalAllowlistSchema', () => {
 });
 
 describe('ExecuteAiChatMutationInputSchema', () => {
+	it('change_shift_staff + allowlist.staffIds ありの正常系を受け入れる', () => {
+		const result = ExecuteAiChatMutationInputSchema.safeParse({
+			proposal: {
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_2,
+			},
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+				staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('update_shift_time + allowlist.staffIds なしの正常系を受け入れる', () => {
+		const result = ExecuteAiChatMutationInputSchema.safeParse({
+			proposal: {
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: '2026-03-16T09:00:00+09:00',
+				endAt: '2026-03-16T10:00:00+09:00',
+			},
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
 	it('change_shift_staff で allowlist.staffIds が undefined の場合はエラー', () => {
 		const result = ExecuteAiChatMutationInputSchema.safeParse({
 			proposal: {
@@ -177,7 +221,7 @@ describe('ExecuteAiChatMutationInputSchema', () => {
 		}
 	});
 
-	it('change_shift_staff で allowlist.staffIds が空配列の場合はエラー', () => {
+	it('change_shift_staff で allowlist.staffIds が空配列の場合は min(1) のみでエラー', () => {
 		const result = ExecuteAiChatMutationInputSchema.safeParse({
 			proposal: {
 				type: 'change_shift_staff',
@@ -192,6 +236,127 @@ describe('ExecuteAiChatMutationInputSchema', () => {
 
 		expect(result.success).toBe(false);
 		if (!result.success) {
+			expect(
+				result.error.issues.some(
+					(issue) => issue.message === 'allowlist.staffIds must not be empty',
+				),
+			).toBe(false);
+		}
+	});
+});
+
+describe('AiChatMutationBatchProposalSchema', () => {
+	it('proposals が 1..max 件の場合は受け入れる', () => {
+		const result = AiChatMutationBatchProposalSchema.safeParse({
+			proposals: Array.from({ length: BATCH_PROPOSAL_MAX_COUNT }, () => ({
+				type: 'update_shift_time' as const,
+				shiftId: createTestId(),
+				startAt: '2026-03-16T09:00:00+09:00',
+				endAt: '2026-03-16T10:00:00+09:00',
+			})),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('proposals が 0 件の場合はエラー', () => {
+		const result = AiChatMutationBatchProposalSchema.safeParse({
+			proposals: [],
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it('proposals が max を超える場合はエラー', () => {
+		const result = AiChatMutationBatchProposalSchema.safeParse({
+			proposals: Array.from({ length: BATCH_PROPOSAL_MAX_COUNT + 1 }, () => ({
+				type: 'change_shift_staff' as const,
+				shiftId: createTestId(),
+				toStaffId: createTestId(),
+			})),
+		});
+
+		expect(result.success).toBe(false);
+	});
+});
+
+describe('ExecuteAiChatMutationBatchInputSchema', () => {
+	it('change_shift_staff + valid allowlist.staffIds の正常系を受け入れる', () => {
+		const result = ExecuteAiChatMutationBatchInputSchema.safeParse({
+			proposals: [
+				{
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_2,
+				},
+			],
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+				staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('mixed proposals の正常系を受け入れる', () => {
+		const result = ExecuteAiChatMutationBatchInputSchema.safeParse({
+			proposals: [
+				{
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_2,
+				},
+				{
+					type: 'update_shift_time',
+					shiftId: TEST_IDS.SCHEDULE_2,
+					startAt: '2026-03-16T11:00:00+09:00',
+					endAt: '2026-03-16T12:00:00+09:00',
+				},
+			],
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1, TEST_IDS.SCHEDULE_2],
+				staffIds: [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2],
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('change_shift_staff を含まない場合は allowlist.staffIds が無くても受け入れる', () => {
+		const result = ExecuteAiChatMutationBatchInputSchema.safeParse({
+			proposals: [
+				{
+					type: 'update_shift_time',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					startAt: '2026-03-16T09:00:00+09:00',
+					endAt: '2026-03-16T10:00:00+09:00',
+				},
+			],
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('change_shift_staff を含む場合は allowlist.staffIds が必須', () => {
+		const result = ExecuteAiChatMutationBatchInputSchema.safeParse({
+			proposals: [
+				{
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_2,
+				},
+			],
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+			},
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
 			expect(result.error.issues).toEqual(
 				expect.arrayContaining([
 					expect.objectContaining({
@@ -199,6 +364,31 @@ describe('ExecuteAiChatMutationInputSchema', () => {
 					}),
 				]),
 			);
+		}
+	});
+
+	it('change_shift_staff を含む場合は allowlist.staffIds 空配列で min(1) のみエラー', () => {
+		const result = ExecuteAiChatMutationBatchInputSchema.safeParse({
+			proposals: [
+				{
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_2,
+				},
+			],
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+				staffIds: [],
+			},
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(
+				result.error.issues.some(
+					(issue) => issue.message === 'allowlist.staffIds must not be empty',
+				),
+			).toBe(false);
 		}
 	});
 });

--- a/src/models/aiChatMutationProposal.test.ts
+++ b/src/models/aiChatMutationProposal.test.ts
@@ -7,6 +7,7 @@ import {
 	AiChatMutationProposalSchema,
 	BATCH_PROPOSAL_MAX_COUNT,
 	ExecuteAiChatMutationBatchInputSchema,
+	ExecuteAiChatMutationBatchResultSchema,
 	ExecuteAiChatMutationInputSchema,
 	ProposalAllowlistSchema,
 } from './aiChatMutationProposal';
@@ -133,13 +134,13 @@ describe('ProposalAllowlistSchema', () => {
 		expect(result.success).toBe(false);
 	});
 
-	it('staffIds が空配列の場合はエラー', () => {
+	it('staffIds が空配列の場合は受け入れる', () => {
 		const result = ProposalAllowlistSchema.safeParse({
 			shiftIds: [TEST_IDS.SCHEDULE_1],
 			staffIds: [],
 		});
 
-		expect(result.success).toBe(false);
+		expect(result.success).toBe(true);
 	});
 
 	it('shiftIds が上限を超える場合はエラー', () => {
@@ -197,6 +198,23 @@ describe('ExecuteAiChatMutationInputSchema', () => {
 		expect(result.success).toBe(true);
 	});
 
+	it('update_shift_time + allowlist.staffIds 空配列の正常系を受け入れる', () => {
+		const result = ExecuteAiChatMutationInputSchema.safeParse({
+			proposal: {
+				type: 'update_shift_time',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				startAt: '2026-03-16T09:00:00+09:00',
+				endAt: '2026-03-16T10:00:00+09:00',
+			},
+			allowlist: {
+				shiftIds: [TEST_IDS.SCHEDULE_1],
+				staffIds: [],
+			},
+		});
+
+		expect(result.success).toBe(true);
+	});
+
 	it('change_shift_staff で allowlist.staffIds が undefined の場合はエラー', () => {
 		const result = ExecuteAiChatMutationInputSchema.safeParse({
 			proposal: {
@@ -221,7 +239,7 @@ describe('ExecuteAiChatMutationInputSchema', () => {
 		}
 	});
 
-	it('change_shift_staff で allowlist.staffIds が空配列の場合は min(1) のみでエラー', () => {
+	it('change_shift_staff で allowlist.staffIds が空配列の場合はエラー', () => {
 		const result = ExecuteAiChatMutationInputSchema.safeParse({
 			proposal: {
 				type: 'change_shift_staff',
@@ -236,11 +254,13 @@ describe('ExecuteAiChatMutationInputSchema', () => {
 
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			expect(
-				result.error.issues.some(
-					(issue) => issue.message === 'allowlist.staffIds must not be empty',
-				),
-			).toBe(false);
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						path: ['allowlist', 'staffIds'],
+					}),
+				]),
+			);
 		}
 	});
 });
@@ -367,7 +387,7 @@ describe('ExecuteAiChatMutationBatchInputSchema', () => {
 		}
 	});
 
-	it('change_shift_staff を含む場合は allowlist.staffIds 空配列で min(1) のみエラー', () => {
+	it('change_shift_staff を含む場合は allowlist.staffIds 空配列でもエラー', () => {
 		const result = ExecuteAiChatMutationBatchInputSchema.safeParse({
 			proposals: [
 				{
@@ -384,11 +404,37 @@ describe('ExecuteAiChatMutationBatchInputSchema', () => {
 
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			expect(
-				result.error.issues.some(
-					(issue) => issue.message === 'allowlist.staffIds must not be empty',
-				),
-			).toBe(false);
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						path: ['allowlist', 'staffIds'],
+					}),
+				]),
+			);
 		}
+	});
+});
+
+describe('ExecuteAiChatMutationBatchResultSchema', () => {
+	it('results が1件以上ある場合を受け入れる', () => {
+		const result = ExecuteAiChatMutationBatchResultSchema.safeParse({
+			results: [
+				{
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					officeId: TEST_IDS.OFFICE_1,
+				},
+			],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('results が空配列の場合を受け入れる', () => {
+		const result = ExecuteAiChatMutationBatchResultSchema.safeParse({
+			results: [],
+		});
+
+		expect(result.success).toBe(true);
 	});
 });

--- a/src/models/aiChatMutationProposal.ts
+++ b/src/models/aiChatMutationProposal.ts
@@ -46,7 +46,7 @@ export const AiChatMutationProposalSchema = z.discriminatedUnion('type', [
 
 export const ProposalAllowlistSchema = z.object({
 	shiftIds: z.array(z.uuid()).min(1).max(ALLOWLIST_MAX_SHIFT_IDS),
-	staffIds: z.array(z.uuid()).min(1).max(ALLOWLIST_MAX_STAFF_IDS).optional(),
+	staffIds: z.array(z.uuid()).max(ALLOWLIST_MAX_STAFF_IDS).optional(),
 });
 
 export const ExecuteAiChatMutationInputSchema = z
@@ -56,7 +56,10 @@ export const ExecuteAiChatMutationInputSchema = z
 	})
 	.superRefine((input, ctx) => {
 		if (input.proposal.type === 'change_shift_staff') {
-			if (input.allowlist.staffIds === undefined) {
+			if (
+				input.allowlist.staffIds === undefined ||
+				input.allowlist.staffIds.length === 0
+			) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
 					message: 'allowlist.staffIds is required',
@@ -97,7 +100,10 @@ export const ExecuteAiChatMutationBatchInputSchema = z
 			return;
 		}
 
-		if (input.allowlist.staffIds === undefined) {
+		if (
+			input.allowlist.staffIds === undefined ||
+			input.allowlist.staffIds.length === 0
+		) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				message: 'allowlist.staffIds is required',

--- a/src/models/aiChatMutationProposal.ts
+++ b/src/models/aiChatMutationProposal.ts
@@ -46,7 +46,7 @@ export const AiChatMutationProposalSchema = z.discriminatedUnion('type', [
 
 export const ProposalAllowlistSchema = z.object({
 	shiftIds: z.array(z.uuid()).min(1).max(ALLOWLIST_MAX_SHIFT_IDS),
-	staffIds: z.array(z.uuid()).max(ALLOWLIST_MAX_STAFF_IDS).optional(),
+	staffIds: z.array(z.uuid()).min(1).max(ALLOWLIST_MAX_STAFF_IDS).optional(),
 });
 
 export const ExecuteAiChatMutationInputSchema = z
@@ -64,14 +64,6 @@ export const ExecuteAiChatMutationInputSchema = z
 				});
 				return;
 			}
-
-			if (input.allowlist.staffIds.length === 0) {
-				ctx.addIssue({
-					code: z.ZodIssueCode.custom,
-					message: 'allowlist.staffIds must not be empty',
-					path: ['allowlist', 'staffIds'],
-				});
-			}
 		}
 	});
 
@@ -79,6 +71,44 @@ export const ExecuteAiChatMutationResultSchema = z.object({
 	type: AiChatMutationProposalTypeSchema,
 	shiftId: z.uuid(),
 	officeId: z.uuid(),
+});
+
+// 1回のAI実行で受け付ける提案件数の上限
+export const BATCH_PROPOSAL_MAX_COUNT = 20;
+
+export const AiChatMutationBatchProposalSchema = z.object({
+	proposals: z
+		.array(AiChatMutationProposalSchema)
+		.min(1)
+		.max(BATCH_PROPOSAL_MAX_COUNT),
+});
+
+export const ExecuteAiChatMutationBatchInputSchema = z
+	.object({
+		proposals: AiChatMutationBatchProposalSchema.shape.proposals,
+		allowlist: ProposalAllowlistSchema,
+	})
+	.superRefine((input, ctx) => {
+		const hasChangeShiftStaffProposal = input.proposals.some(
+			(proposal) => proposal.type === 'change_shift_staff',
+		);
+
+		if (!hasChangeShiftStaffProposal) {
+			return;
+		}
+
+		if (input.allowlist.staffIds === undefined) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: 'allowlist.staffIds is required',
+				path: ['allowlist', 'staffIds'],
+			});
+			return;
+		}
+	});
+
+export const ExecuteAiChatMutationBatchResultSchema = z.object({
+	results: z.array(ExecuteAiChatMutationResultSchema),
 });
 
 export type AiChatMutationProposal = z.infer<
@@ -93,4 +123,16 @@ export type ExecuteAiChatMutationInput = z.infer<
 
 export type ExecuteAiChatMutationResult = z.infer<
 	typeof ExecuteAiChatMutationResultSchema
+>;
+
+export type AiChatMutationBatchProposal = z.infer<
+	typeof AiChatMutationBatchProposalSchema
+>;
+
+export type ExecuteAiChatMutationBatchInput = z.infer<
+	typeof ExecuteAiChatMutationBatchInputSchema
+>;
+
+export type ExecuteAiChatMutationBatchResult = z.infer<
+	typeof ExecuteAiChatMutationBatchResultSchema
 >;


### PR DESCRIPTION
## 概要

Phase 1-a として、AI チャット変異提案のバッチ処理に対応するスキーマと型定義を追加します。

## 変更内容

### 新規スキーマ・型

| スキーマ名 | 型名 | 説明 |
|---|---|---|
| `AiChatMutationBatchProposalSchema` | `AiChatMutationBatchProposal` | 複数提案をまとめるバッチコンテナ（1〜20件） |
| `ExecuteAiChatMutationBatchInputSchema` | `ExecuteAiChatMutationBatchInput` | バッチ実行入力（proposals + allowlist） |
| `ExecuteAiChatMutationBatchResultSchema` | `ExecuteAiChatMutationBatchResult` | バッチ実行結果（results 配列） |

### 定数追加

- `BATCH_PROPOSAL_MAX_COUNT = 20` — 1回の AI 実行で受け付ける提案件数の上限

### 条件付きバリデーション

`ExecuteAiChatMutationBatchInputSchema` に `superRefine` を実装：

- proposals に `change_shift_staff` が **1件でも含まれる場合**、`allowlist.staffIds` は必須 (min 1)
- 含まれない場合は `staffIds` 省略可

## テスト

`src/models/aiChatMutationProposal.test.ts` にユニットテスト 26 件を追加。

```
✓ unit  src/models/aiChatMutationProposal.test.ts (26 tests) 25ms
Test Files  1 passed (1)
     Tests  26 passed (26)
```

主なテストケース：
- バッチ提案の正常系（単一 / 複数 / 上限 20件）
- 上限超過エラー（21件）
- 空配列エラー（0件）
- `change_shift_staff` 含む場合の `staffIds` 必須バリデーション
- `change_shift_staff` を含まない場合の `staffIds` 省略許容
- バッチ結果スキーマの正常系

## 変更ファイル

- `src/models/aiChatMutationProposal.ts`
- `src/models/aiChatMutationProposal.test.ts`

## チェックリスト

- [x] テスト追加・全件パス (26/26)
- [x] TypeScript 型チェック通過
- [x] 既存スキーマ・型への破壊的変更なし
