### PR TITLE
fix: スペースなし入力でDBのスペースあり名前を検索できない問題を修正 (#170)

### DIFF
--- a/src/backend/repositories/staffRepository.test.ts
+++ b/src/backend/repositories/staffRepository.test.ts
@@ -784,7 +784,145 @@ describe('StaffRepository', () => {
 			expect(mockStaffLimit).toHaveBeenCalledTimes(1);
 		});
 
-		// Known limitation: スペースなし入力でDB側にスペースありの名前がある場合はヒットしない
-		// 例: query="ヘルパー10", DB name="ヘルパー 10" → ヒットしない（仕様上許容）
+		it('スペースなし入力「ヘルパー05」→ DB「ヘルパー 05」にヒット（数字境界スペース挿入フォールバック）', async () => {
+			const helperRow = {
+				...baseStaffRow,
+				id: TEST_IDS.STAFF_2,
+				name: 'ヘルパー 05',
+				kana: null,
+				role: 'helper' as const,
+			};
+
+			// 1回目の検索（"ヘルパー05"）は0件、2回目（"ヘルパー 05"）は1件
+			const mockStaffLimit = vi
+				.fn()
+				.mockResolvedValueOnce({ data: [], error: null })
+				.mockResolvedValueOnce({ data: [helperRow], error: null });
+			const mockStaffOrder = vi.fn().mockReturnValue({ limit: mockStaffLimit });
+			const mockStaffOr = vi.fn().mockReturnValue({ order: mockStaffOrder });
+			const mockStaffEq = vi.fn().mockReturnValue({ or: mockStaffOr });
+			const mockStaffSelect = vi.fn().mockReturnValue({ eq: mockStaffEq });
+
+			const mockAbilityIn = vi
+				.fn()
+				.mockResolvedValue({ data: [], error: null });
+			const mockAbilitySelect = vi.fn().mockReturnValue({ in: mockAbilityIn });
+
+			(supabase.from as any).mockImplementation((table: string) => {
+				if (table === 'staffs') return { select: mockStaffSelect };
+				if (table === 'staff_service_type_abilities')
+					return { select: mockAbilitySelect };
+				throw new Error(`Unexpected table: ${table}`);
+			});
+
+			const result = await repository.searchByNameOrKana(
+				officeId,
+				'ヘルパー05',
+				10,
+			);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('ヘルパー 05');
+			// 1回目: コンパクト（スペースなし）クエリ, 2回目: 数字境界スペース挿入クエリ
+			expect(mockStaffOr).toHaveBeenNthCalledWith(
+				1,
+				'name.ilike.%ヘルパー05%,kana.ilike.%ヘルパー05%',
+			);
+			expect(mockStaffOr).toHaveBeenNthCalledWith(
+				2,
+				'name.ilike.%ヘルパー 05%,kana.ilike.%ヘルパー 05%',
+			);
+		});
+
+		it('スペースなし入力「ヘルパー10」→ DB「ヘルパー 10」にヒット（数字境界スペース挿入フォールバック）', async () => {
+			const helperRow = {
+				...baseStaffRow,
+				id: TEST_IDS.STAFF_3,
+				name: 'ヘルパー 10',
+				kana: null,
+				role: 'helper' as const,
+			};
+
+			// 1回目の検索（"ヘルパー10"）は0件、2回目（"ヘルパー 10"）は1件
+			const mockStaffLimit = vi
+				.fn()
+				.mockResolvedValueOnce({ data: [], error: null })
+				.mockResolvedValueOnce({ data: [helperRow], error: null });
+			const mockStaffOrder = vi.fn().mockReturnValue({ limit: mockStaffLimit });
+			const mockStaffOr = vi.fn().mockReturnValue({ order: mockStaffOrder });
+			const mockStaffEq = vi.fn().mockReturnValue({ or: mockStaffOr });
+			const mockStaffSelect = vi.fn().mockReturnValue({ eq: mockStaffEq });
+
+			const mockAbilityIn = vi
+				.fn()
+				.mockResolvedValue({ data: [], error: null });
+			const mockAbilitySelect = vi.fn().mockReturnValue({ in: mockAbilityIn });
+
+			(supabase.from as any).mockImplementation((table: string) => {
+				if (table === 'staffs') return { select: mockStaffSelect };
+				if (table === 'staff_service_type_abilities')
+					return { select: mockAbilitySelect };
+				throw new Error(`Unexpected table: ${table}`);
+			});
+
+			const result = await repository.searchByNameOrKana(
+				officeId,
+				'ヘルパー10',
+				10,
+			);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('ヘルパー 10');
+			expect(mockStaffOr).toHaveBeenNthCalledWith(
+				1,
+				'name.ilike.%ヘルパー10%,kana.ilike.%ヘルパー10%',
+			);
+			expect(mockStaffOr).toHaveBeenNthCalledWith(
+				2,
+				'name.ilike.%ヘルパー 10%,kana.ilike.%ヘルパー 10%',
+			);
+		});
+
+		it('数字境界なし入力「山田太郎」はフォールバックなし（searchWith 1回のみ）', async () => {
+			const staffRows = [
+				{
+					...baseStaffRow,
+					id: TEST_IDS.STAFF_2,
+					name: '山田太郎',
+					kana: null,
+					role: 'helper' as const,
+				},
+			];
+
+			const mockStaffLimit = vi
+				.fn()
+				.mockResolvedValue({ data: staffRows, error: null });
+			const mockStaffOrder = vi.fn().mockReturnValue({ limit: mockStaffLimit });
+			const mockStaffOr = vi.fn().mockReturnValue({ order: mockStaffOrder });
+			const mockStaffEq = vi.fn().mockReturnValue({ or: mockStaffOr });
+			const mockStaffSelect = vi.fn().mockReturnValue({ eq: mockStaffEq });
+
+			const mockAbilityIn = vi
+				.fn()
+				.mockResolvedValue({ data: [], error: null });
+			const mockAbilitySelect = vi.fn().mockReturnValue({ in: mockAbilityIn });
+
+			(supabase.from as any).mockImplementation((table: string) => {
+				if (table === 'staffs') return { select: mockStaffSelect };
+				if (table === 'staff_service_type_abilities')
+					return { select: mockAbilitySelect };
+				throw new Error(`Unexpected table: ${table}`);
+			});
+
+			const result = await repository.searchByNameOrKana(
+				officeId,
+				'山田太郎',
+				10,
+			);
+
+			expect(result).toHaveLength(1);
+			// フォールバックなし: searchWith は1回のみ
+			expect(mockStaffOr).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/src/backend/repositories/staffRepository.ts
+++ b/src/backend/repositories/staffRepository.ts
@@ -286,8 +286,9 @@ export class StaffRepository {
 
 		// フォールバック2（Issue #170）: スペースなし入力 → 数字境界スペースありDB
 		// 例: "ヘルパー05" → "ヘルパー 05"
-		const withDigitSpaces = compact.replace(/([^\d\s])(\d)/g, '$1 $2');
-		if (results.length === 0 && withDigitSpaces !== compact) {
+		// known limitation: digit→非数字境界（例: "05ヘルパー"）は未対応
+		const withDigitSpaces = normalized.replace(/([^\d\s])(\d)/g, '$1 $2');
+		if (results.length === 0 && withDigitSpaces !== normalized) {
 			return this.searchWith(officeId, withDigitSpaces, limit);
 		}
 

--- a/src/backend/repositories/staffRepository.ts
+++ b/src/backend/repositories/staffRepository.ts
@@ -284,6 +284,13 @@ export class StaffRepository {
 			return this.searchWith(officeId, compact, limit);
 		}
 
+		// フォールバック2（Issue #170）: スペースなし入力 → 数字境界スペースありDB
+		// 例: "ヘルパー05" → "ヘルパー 05"
+		const withDigitSpaces = compact.replace(/([^\d\s])(\d)/g, '$1 $2');
+		if (results.length === 0 && withDigitSpaces !== compact) {
+			return this.searchWith(officeId, withDigitSpaces, limit);
+		}
+
 		return results;
 	}
 


### PR DESCRIPTION
## 概要

スタッフ名検索において、入力にスペースが含まれない場合でも DB にスペースあり名前が登録されている場合にマッチできるよう、フォールバック処理（フォールバック2）を追加しました。

Closes #170

---

## 背景

PR #166 では「入力スペースあり → DB スペースなし」方向の正規化（フォールバック1）を対応済み。
本 PR はその **逆方向ケース**（入力スペースなし・DB スペースあり）への対応です。

例: LLM が `searchStaffs("ヘルパー05")` を呼び出した場合、DB の `ヘルパー 05` にヒットしなかった問題を修正します。

---

## 変更内容

### `src/backend/repositories/staffRepository.ts`

- `searchByNameOrKana` にフォールバック2を追加
- 0件 かつ 入力にスペースが含まれない場合、正規表現 `([^\d\s])(\d)` で数字境界にスペースを挿入して再検索
- 変数名を `compact` → `normalized` に変更（より意図が明確）
- known limitation コメントを追記（複数パターン対応は別途検討）

### `src/backend/repositories/staffRepository.test.ts`

- 逆方向ケース（入力スペースなし・DB スペースあり）のテストを追加

---

## テスト

- 全 33 テスト グリーン ✅

---

## Known Limitation

- 境界パターンは「非数字↔数字」のみ対応（例: `ヘルパー05` → `ヘルパー 05`）
- かな↔英字、漢字↔英字など他の境界パターンは別 Issue で検討
- DB 側に正規化カラムを追加する抜本対応は別途検討