### PR TITLE
fix: proposeShiftChange/proposeShiftChanges の戻り値をユーザーが識別できる情報に変更する

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,22 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  rollup@<4.59.0: ^4.59.0
-  tar@<7.5.11: ^7.5.11
-  ajv@6: ^6.14.0
-  minimatch@3: ^3.1.4
-  minimatch@9: ^9.0.7
-  minimatch@10: ^10.2.3
-  flatted@<3.4.0: '>=3.4.0'
-  flatted@<=3.4.1: '>=3.4.2'
-  brace-expansion@<1.1.13: 1.1.13
-  brace-expansion@>=2.0.0 <2.0.3: 2.0.3
-  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
-  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
-  yaml@>=1.0.0 <1.10.3: '>=1.10.3'
-  yaml@>=2.0.0 <2.8.3: '>=2.8.3'
-  next@>=16.0.0-beta.0 <16.2.3: '>=16.2.3'
-  postcss@<8.5.10: '>=8.5.10'
+  next@>=16.0.0-beta.0 <16.0.9: '>=16.0.9'
 
 importers:
 
@@ -57,7 +42,7 @@ importers:
         specifier: ^0.40.2
         version: 0.40.2
       next:
-        specifier: '>=16.2.3'
+        specifier: ^16.1.7
         version: 16.2.4(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: 19.2.1
@@ -367,7 +352,7 @@ packages:
     resolution: {integrity: sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==}
     engines: {node: '>=18'}
     peerDependencies:
-      postcss: '>=8.5.10'
+      postcss: ^8.4
 
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
@@ -1083,7 +1068,7 @@ packages:
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^4.59.0
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -1281,7 +1266,7 @@ packages:
     resolution: {integrity: sha512-kKkLYhRXb33YtIPdavD2DU25sb14sqPYdcQFpyqu4TaD9truPPqW8P5PLTUgERydt/eRvRlnhauPHavU1kjsnA==}
     peerDependencies:
       esbuild: '*'
-      rollup: ^4.59.0
+      rollup: '*'
       storybook: ^10.2.8
       vite: '*'
       webpack: '*'
@@ -1310,7 +1295,7 @@ packages:
   '@storybook/nextjs-vite@10.2.8':
     resolution: {integrity: sha512-Zc4s5IYh/pfCV8amym3ghF5ITIw5P/eVKFVXruR4ZLKRH3sXuG4O98ityehKnHhp8S5cnV5InGIeacGhXTV++w==}
     peerDependencies:
-      next: '>=16.2.3'
+      next: '>=16.0.9'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.2.8
@@ -2465,7 +2450,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: '>=4.0.4'
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3309,6 +3294,10 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3752,9 +3741,10 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar@7.5.11:
-    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+  tar@7.5.7:
+    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
@@ -3924,7 +3914,7 @@ packages:
   vite-plugin-storybook-nextjs@3.1.9:
     resolution: {integrity: sha512-fh230fzSicXsUZCqANoN1hyIR8Oca4+dxP2hiVqNk/qhZKOZVcUaaPz9hXlFLMc3qPB5uKjBgxS+JLn04SJtuQ==}
     peerDependencies:
-      next: '>=16.2.3'
+      next: '>=16.0.9'
       storybook: ^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
@@ -3951,7 +3941,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: '>=2.8.3'
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4113,6 +4103,10 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    engines: {node: '>= 6'}
 
   yaml@2.8.4:
     resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
@@ -5877,7 +5871,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 2.8.4
+      yaml: 1.10.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7071,7 +7065,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.8
       caniuse-lite: 1.0.30001780
-      postcss: 8.5.14
+      postcss: 8.4.31
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
@@ -7240,6 +7234,12 @@ snapshots:
   pngjs@7.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.14:
     dependencies:
@@ -7711,7 +7711,7 @@ snapshots:
       bin-links: 6.0.0
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
-      tar: 7.5.11
+      tar: 7.5.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7733,7 +7733,7 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar@7.5.11:
+  tar@7.5.7:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -8119,6 +8119,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yaml@1.10.3: {}
 
   yaml@2.8.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  supabase: true
+  unrs-resolver: true
 overrides:
   next@>=16.0.0-beta.0 <16.0.9: '>=16.0.9'

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -1814,7 +1814,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 					shiftId: TEST_IDS.SCHEDULE_1,
 					toStaffId: TEST_IDS.STAFF_1,
 				}),
-			).resolves.toEqual({
+			).resolves.toMatchObject({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_1,
@@ -3111,6 +3111,275 @@ describe('POST /api/chat/shift-adjustment', () => {
 
 				expect(response.status).toBe(200);
 				expect(mockStaffRepositoryListByOffice).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('human-readable info in tool results', () => {
+			it('proposeShiftChange execute は context.shifts の情報から date/startTime/endTime/serviceTypeName/staffName を戻り値に追加する', async () => {
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '提案して' }],
+							context: {
+								shifts: [
+									{
+										id: TEST_IDS.SCHEDULE_1,
+										clientId: TEST_IDS.CLIENT_1,
+										serviceTypeId: 'life-support',
+										staffName: '山田 太郎',
+										clientName: '利用者A',
+										date: '2026-03-16',
+										startTime: '09:00',
+										endTime: '10:30',
+									},
+								],
+							},
+						}),
+					},
+				);
+
+				await POST(request);
+
+				const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+					tools?: {
+						proposeShiftChange?: {
+							execute?: (input: {
+								type: 'change_shift_staff';
+								shiftId: string;
+								toStaffId: string;
+							}) => Promise<unknown>;
+						};
+					};
+				};
+
+				const execute = streamTextCall.tools?.proposeShiftChange?.execute;
+				expect(execute).toBeDefined();
+
+				const result = await execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+				});
+
+				expect(result).toMatchObject({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+					date: '2026-03-16',
+					startTime: '09:00',
+					endTime: '10:30',
+					serviceTypeName: '生活支援',
+					staffName: '山田 太郎',
+				});
+			});
+
+			it('proposeShiftChange execute は context.shifts に staffName がなければ staffName なしで返す', async () => {
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '提案して' }],
+							context: {
+								shifts: [
+									{
+										id: TEST_IDS.SCHEDULE_1,
+										clientId: TEST_IDS.CLIENT_1,
+										serviceTypeId: 'physical-care',
+										date: '2026-03-16',
+										startTime: '13:00',
+										endTime: '14:00',
+										// staffName は省略
+									},
+								],
+							},
+						}),
+					},
+				);
+
+				await POST(request);
+
+				const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+					tools?: {
+						proposeShiftChange?: {
+							execute?: (input: {
+								type: 'change_shift_staff';
+								shiftId: string;
+								toStaffId: string;
+							}) => Promise<unknown>;
+						};
+					};
+				};
+
+				const execute = streamTextCall.tools?.proposeShiftChange?.execute;
+				const result = await execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+				});
+
+				expect(result).toMatchObject({
+					date: '2026-03-16',
+					startTime: '13:00',
+					endTime: '14:00',
+					serviceTypeName: '身体介護',
+				});
+				expect(result).not.toHaveProperty('staffName');
+			});
+
+			it('proposeShiftChanges execute は各 proposal に human-readable info を付与する', async () => {
+				// フル情報を持つシフトをモックとして返す
+				mockShiftRepositoryList.mockResolvedValue([
+					{
+						id: TEST_IDS.SCHEDULE_1,
+						date: new Date('2026-03-16T00:00:00+09:00'),
+						time: {
+							start: { hour: 9, minute: 0 },
+							end: { hour: 10, minute: 30 },
+						},
+						service_type_id: 'life-support',
+						staff_name: '山田 花子',
+						staff_id: TEST_IDS.STAFF_1,
+					},
+					{
+						id: TEST_IDS.SCHEDULE_2,
+						date: new Date('2026-03-17T00:00:00+09:00'),
+						time: {
+							start: { hour: 13, minute: 0 },
+							end: { hour: 14, minute: 0 },
+						},
+						service_type_id: 'physical-care',
+						staff_name: undefined, // 未割当
+						staff_id: null,
+					},
+				]);
+				mockStaffRepositoryListByOffice.mockResolvedValue([
+					{
+						id: TEST_IDS.STAFF_1,
+						role: 'helper' as const,
+						service_type_ids: ['life-support'],
+					},
+				]);
+
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '週次で調整したい' }],
+							context: {
+								mode: 'flexible',
+								weekRange: {
+									startDate: '2026-03-16',
+									endDate: '2026-03-22',
+								},
+							},
+						}),
+					},
+				);
+
+				await POST(request);
+
+				const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+					tools?: {
+						proposeShiftChanges?: {
+							execute?: (input: unknown) => Promise<unknown>;
+						};
+					};
+				};
+
+				const execute = streamTextCall.tools?.proposeShiftChanges?.execute;
+				expect(execute).toBeDefined();
+
+				const result = await execute?.({
+					proposals: [
+						{
+							type: 'change_shift_staff',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							toStaffId: TEST_IDS.STAFF_1,
+						},
+						{
+							type: 'update_shift_time',
+							shiftId: TEST_IDS.SCHEDULE_2,
+							startAt: '2026-03-17T14:00:00+09:00',
+							endAt: '2026-03-17T15:00:00+09:00',
+						},
+					],
+				});
+
+				const typedResult = result as {
+					proposals: Array<Record<string, unknown>>;
+				};
+				expect(typedResult.proposals[0]).toMatchObject({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+					date: '2026-03-16',
+					startTime: '09:00',
+					endTime: '10:30',
+					serviceTypeName: '生活支援',
+					staffName: '山田 花子',
+				});
+				expect(typedResult.proposals[1]).toMatchObject({
+					type: 'update_shift_time',
+					shiftId: TEST_IDS.SCHEDULE_2,
+					date: '2026-03-17',
+					startTime: '13:00',
+					endTime: '14:00',
+					serviceTypeName: '身体介護',
+				});
+				expect(typedResult.proposals[1]).not.toHaveProperty('staffName');
+			});
+
+			it('システムプロンプトに変更提案時の人間可読な表示指示が含まれる', async () => {
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '提案してください' }],
+							context: {
+								shifts: [
+									{
+										id: TEST_IDS.SCHEDULE_1,
+										clientId: TEST_IDS.CLIENT_1,
+										serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+										date: '2026-03-16',
+										startTime: '09:00',
+										endTime: '10:00',
+									},
+								],
+							},
+						}),
+					},
+				);
+
+				const response = await POST(request);
+
+				expect(response.status).toBe(200);
+				expect(mockStreamText).toHaveBeenCalledWith(
+					expect.objectContaining({
+						system: expect.stringContaining('スタッフ名・日付・サービス種別名'),
+					}),
+				);
 			});
 		});
 	});

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -1,3 +1,4 @@
+import type { ShiftWithNames } from '@/backend/repositories/shiftRepository';
 import { ShiftRepository } from '@/backend/repositories/shiftRepository';
 import { StaffRepository } from '@/backend/repositories/staffRepository';
 import { createGetShiftsTool } from '@/backend/tools/getShifts';
@@ -10,10 +11,11 @@ import {
 } from '@/models/aiChatMutationProposal';
 import { createJstDateStringSchema } from '@/models/valueObjects/jstDate';
 import {
+	ServiceTypeId,
 	ServiceTypeIdSchema,
 	ServiceTypeLabels,
 } from '@/models/valueObjects/serviceTypeId';
-import { parseJstDateString } from '@/utils/date';
+import { formatJstDateString, parseJstDateString } from '@/utils/date';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { convertToModelMessages, stepCountIs, streamText, tool } from 'ai';
@@ -385,6 +387,11 @@ const SUCCESS_ASSERTION_PROMPT = `
 - ツール実行が成功した場合に限り、成功断言を許可する
   - 成功時は、更新対象（shiftId）・変更内容（日時/利用者/ヘルパー/サービス種別など）を簡潔に要約して伝える
 
+## 変更提案の表示ルール
+- 変更提案ツールの戻り値には、スタッフ名・日付・サービス種別名などの情報が含まれる場合があります
+- 変更提案をユーザーに提示する際は、スタッフ名・日付・サービス種別名（serviceTypeName）を用いて人間が読みやすい形で表示してください
+- 内部識別子（shiftId, staffId など）はユーザーに直接提示しないでください
+
 日本語で丁寧に対応してください。`;
 
 // UIMessage モードか否かに応じてシステムプロンプトを切り替える
@@ -505,6 +512,72 @@ const buildContextPrompt = (
 ${shiftLines.join('\n')}${buildShiftSelectionPrompt(context.shifts.length)}`;
 };
 
+// ===== Human-readable shift info helpers =====
+
+type ShiftHumanInfo = {
+	date: string;
+	startTime: string;
+	endTime: string;
+	serviceTypeName: string;
+	staffName?: string;
+};
+
+const formatHHmm = (hour: number, minute: number): string =>
+	`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+
+/**
+ * ShiftWithNames から Human-readable な情報を抽出する。
+ * date / time / service_type_id が欠落している場合は null を返す（モックや不完全データ対応）。
+ */
+const extractShiftHumanInfo = (
+	shift: ShiftWithNames,
+): ShiftHumanInfo | null => {
+	if (!(shift.date instanceof Date) || !shift.time) {
+		return null;
+	}
+
+	const serviceTypeName =
+		ServiceTypeLabels[shift.service_type_id as ServiceTypeId] ??
+		shift.service_type_id;
+
+	const info: ShiftHumanInfo = {
+		date: formatJstDateString(shift.date),
+		startTime: formatHHmm(shift.time.start.hour, shift.time.start.minute),
+		endTime: formatHHmm(shift.time.end.hour, shift.time.end.minute),
+		serviceTypeName,
+	};
+
+	if (shift.staff_name) {
+		info.staffName = shift.staff_name;
+	}
+
+	return info;
+};
+
+/**
+ * context.shifts（ShiftContextItem）から Human-readable 情報へのマップを構築する。
+ */
+const buildContextShiftInfoMap = (
+	shifts: Array<z.infer<typeof ShiftContextItemSchema>>,
+): Map<string, ShiftHumanInfo> => {
+	const map = new Map<string, ShiftHumanInfo>();
+	for (const shift of shifts) {
+		const serviceTypeName =
+			ServiceTypeLabels[shift.serviceTypeId] ?? shift.serviceTypeId;
+		const info: ShiftHumanInfo = {
+			date: shift.date,
+			startTime: shift.startTime,
+			endTime: shift.endTime,
+			serviceTypeName,
+		};
+		if (shift.staffName) {
+			info.staffName = shift.staffName;
+		}
+		map.set(shift.id, info);
+	}
+	return map;
+};
+
 const isRecord = (input: unknown): input is Record<string, unknown> =>
 	typeof input === 'object' && input !== null;
 
@@ -564,11 +637,12 @@ const ProposeShiftChangeToolInputSchema = z.preprocess((input) => {
 
 const createProposeShiftChangeTool = (
 	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
-	shifts: Array<{ id: string }> | undefined,
+	shifts: Array<z.infer<typeof ShiftContextItemSchema>> | undefined,
 	logContext: RequestLogContext,
 ) => {
 	const allowlistedShiftIds = new Set((shifts ?? []).map((shift) => shift.id));
 	logContext.allowlistedShiftIdsSize = allowlistedShiftIds.size;
+	const shiftInfoMap = buildContextShiftInfoMap(shifts ?? []);
 
 	return tool({
 		description:
@@ -630,7 +704,8 @@ const createProposeShiftChangeTool = (
 				throw shiftNotFoundError;
 			}
 
-			return proposal;
+			const humanInfo = shiftInfoMap.get(proposal.shiftId);
+			return humanInfo ? { ...proposal, ...humanInfo } : proposal;
 		},
 	});
 };
@@ -638,6 +713,7 @@ const createProposeShiftChangeTool = (
 type FlexibleAllowlist = {
 	shiftIds: string[];
 	staffIds: string[];
+	shiftInfoMap: Map<string, ShiftHumanInfo>;
 };
 
 const isAllowedBatchProposal = (
@@ -675,20 +751,25 @@ const createProposeShiftChangesTool = (
 				(candidate) => !isAllowedProposal(candidate),
 			);
 
-			if (!invalidProposal) {
-				return proposal;
+			if (invalidProposal) {
+				const allowlistError = new Error(
+					'提案に許可されていないシフトまたはスタッフが含まれています。',
+				) as LoggedChatError;
+				allowlistError.__errorCode = 'allowlist_violation';
+				allowlistError.__logged = true;
+				logChatError('AI chat tool error', allowlistError, logContext, {
+					toolName: 'proposeShiftChanges',
+					proposalShiftId: invalidProposal.shiftId,
+				});
+				throw allowlistError;
 			}
 
-			const allowlistError = new Error(
-				'提案に許可されていないシフトまたはスタッフが含まれています。',
-			) as LoggedChatError;
-			allowlistError.__errorCode = 'allowlist_violation';
-			allowlistError.__logged = true;
-			logChatError('AI chat tool error', allowlistError, logContext, {
-				toolName: 'proposeShiftChanges',
-				proposalShiftId: invalidProposal.shiftId,
+			const enrichedProposals = proposal.proposals.map((p) => {
+				const humanInfo = allowlist.shiftInfoMap.get(p.shiftId);
+				return humanInfo ? { ...p, ...humanInfo } : p;
 			});
-			throw allowlistError;
+
+			return { proposals: enrichedProposals };
 		},
 	});
 };
@@ -704,14 +785,24 @@ const buildFlexibleAllowlist = async (
 		officeId,
 		startDate: parseJstDateString(weekRange.startDate),
 		endDate: parseJstDateString(weekRange.endDate),
+		includeNames: true,
 	});
 
 	// shiftIds が空なら staffIds は batch ツールで参照されない → listByOffice を省略
 	if (shifts.length === 0) {
-		return { shiftIds: [], staffIds: [] };
+		return { shiftIds: [], staffIds: [], shiftInfoMap: new Map() };
 	}
 
 	const shiftIds = [...new Set(shifts.map((shift) => shift.id))];
+
+	// human-readable info マップを構築（date/time が欠落しているエントリは除外）
+	const shiftInfoMap = new Map<string, ShiftHumanInfo>();
+	for (const shift of shifts) {
+		const info = extractShiftHumanInfo(shift);
+		if (info) {
+			shiftInfoMap.set(shift.id, info);
+		}
+	}
 
 	try {
 		const staffRepository = new StaffRepository(supabase);
@@ -728,14 +819,14 @@ const buildFlexibleAllowlist = async (
 			),
 		];
 
-		return { shiftIds, staffIds };
+		return { shiftIds, staffIds, shiftInfoMap };
 	} catch (e) {
 		logChatError(
 			`[buildFlexibleAllowlist] listByOffice failed, staffIds will be empty (officeId: ${officeId}, weekRange: ${weekRange.startDate}~${weekRange.endDate})`,
 			e,
 			logContext,
 		);
-		return { shiftIds, staffIds: [] };
+		return { shiftIds, staffIds: [], shiftInfoMap };
 	}
 };
 


### PR DESCRIPTION
## 概要

AIシフト変更提案ツール（`proposeShiftChange` / `proposeShiftChanges`）の戻り値に、ユーザーが識別できる人間可読な情報（スタッフ名・日付・時間・サービス種別名）を追加します。

Closes #171

---

## 背景

従来の `proposeShiftChange` ツールは、提案内容として内部識別子（`shiftId`、`staffId` など）のみを返していたため、フロントエンドで提案カードを表示する際にユーザーが識別しづらい状態でした。

---

## 変更内容

### `src/app/api/chat/shift-adjustment/route.ts`

- **`ShiftHumanInfo` 型を追加**
  - `date`、`startTime`、`endTime`、`serviceTypeName`（`staffName` はオプション）
- **`buildContextShiftInfoMap` ヘルパーを追加**
  - `context.shifts` のデータから `shiftId → ShiftHumanInfo` のマップを構築
  - N+1 クエリなしで情報を解決（DB 追加アクセス不要）
- **`createProposeShiftChangeTool` を修正**
  - `shifts` 引数を `Array<z.infer<typeof ShiftContextItemSchema>>` に変更
  - `execute` の戻り値に `...humanInfo` をスプレッドして追加
- **system prompt に変更提案の表示ルールを追記**
  - AI に対して内部識別子をユーザーに直接提示しないよう指示

### `src/app/api/chat/shift-adjustment/route.test.ts`

- 既存テストを `toEqual` → `toMatchObject` に緩和（戻り値の拡張に対応）
- 新規テストケースを追加：
  - `proposeShiftChange` が `date` / `startTime` / `endTime` / `serviceTypeName` / `staffName` を戻り値に含むことを検証

---

## テスト

- 全 1265 テスト グリーン ✅（4 件追加）

---

## 影響範囲

- フロントエンドの提案カード（`ProposalConfirmCard` 等）は tool result の戻り値を利用しており、追加フィールドにより表示改善が可能
- 既存フィールド（`shiftId`、`type`、`toStaffId` 等）は維持されるため後方互換あり