### PR TITLE
feat: proposeShiftChange(s) ツール結果に _meta（人間可読メタ情報）を付与する

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 10 # 利用中のpnpmバージョンに合わせてください
+          version: 11
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -3378,6 +3378,66 @@ describe('POST /api/chat/shift-adjustment', () => {
 					consoleErrorSpy.mockRestore();
 				}
 			});
+
+			it('shiftContext あり + allowlistedStaffIds に toStaffId が含まれない → findById が呼ばれず toStaffName が付与されない（Thread 3）', async () => {
+				// allowlistedStaffIds に STAFF_2 のみ含む状態で STAFF_1 を指定
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '提案して' }],
+							context: {
+								shifts: [
+									{
+										id: TEST_IDS.SCHEDULE_1,
+										clientId: TEST_IDS.CLIENT_1,
+										serviceTypeId: 'life-support',
+										clientName: '利用者A',
+										date: '2026-03-16',
+										startTime: '09:00',
+										endTime: '10:00',
+									},
+								],
+								staffIds: [TEST_IDS.STAFF_2], // STAFF_1 は含まれない
+							},
+						}),
+					},
+				);
+
+				await POST(request);
+
+				const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+					tools?: {
+						proposeShiftChange?: {
+							execute?: (input: {
+								type: 'change_shift_staff';
+								shiftId: string;
+								toStaffId: string;
+							}) => Promise<unknown>;
+						};
+					};
+				};
+
+				const execute = streamTextCall.tools?.proposeShiftChange?.execute;
+				expect(execute).toBeDefined();
+
+				// allowlist 違反で例外が発生すること
+				await expect(
+					execute?.({
+						type: 'change_shift_staff',
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_1, // allowlist 外
+					}),
+				).rejects.toThrow('スタッフIDが不正です');
+
+				// findById が呼ばれていないこと（allowlist 外スタッフのスタッフ名は取得しない）
+				expect(mockStaffRepositoryFindById).not.toHaveBeenCalled();
+			});
 		});
 
 		// ===== C-2: proposeShiftChanges / _meta 付与 =====

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -2457,6 +2457,140 @@ describe('POST /api/chat/shift-adjustment', () => {
 			consoleErrorSpy.mockRestore();
 		});
 
+		it('proposeShiftChange tool は context.staffIds の allowlist を検証する（Thread 7）', async () => {
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '提案して' }],
+						context: {
+							shifts: [
+								{
+									id: TEST_IDS.SCHEDULE_1,
+									clientId: TEST_IDS.CLIENT_1,
+									serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+									date: '2025-01-20',
+									startTime: '09:00',
+									endTime: '10:00',
+								},
+							],
+							staffIds: [TEST_IDS.STAFF_1],
+						},
+					}),
+				},
+			);
+
+			await POST(request);
+
+			const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+				tools?: {
+					proposeShiftChange?: {
+						execute?: (input: {
+							type: 'change_shift_staff';
+							shiftId: string;
+							toStaffId: string;
+						}) => Promise<unknown>;
+					};
+				};
+			};
+
+			const execute = streamTextCall.tools?.proposeShiftChange?.execute;
+			expect(execute).toBeDefined();
+
+			// staffIds に含まれていない STAFF_2 は拒否される
+			await expect(
+				execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_2,
+				}),
+			).rejects.toThrow('スタッフIDが不正です');
+
+			// staffIds に含まれている STAFF_1 は通過する
+			await expect(
+				execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+				}),
+			).resolves.toMatchObject({
+				type: 'change_shift_staff',
+				shiftId: TEST_IDS.SCHEDULE_1,
+				toStaffId: TEST_IDS.STAFF_1,
+			});
+		});
+
+		it('proposeShiftChange tool のスタッフ allowlist 違反時に logChatError の extra に toStaffId を含める（Thread 8）', async () => {
+			const consoleErrorSpy = vi
+				.spyOn(console, 'error')
+				.mockImplementation(() => undefined);
+
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '提案して' }],
+						context: {
+							shifts: [
+								{
+									id: TEST_IDS.SCHEDULE_1,
+									clientId: TEST_IDS.CLIENT_1,
+									serviceTypeId: TEST_IDS.SERVICE_TYPE_1,
+									date: '2025-01-20',
+									startTime: '09:00',
+									endTime: '10:00',
+								},
+							],
+							staffIds: [TEST_IDS.STAFF_1],
+						},
+					}),
+				},
+			);
+
+			await POST(request);
+
+			const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+				tools?: {
+					proposeShiftChange?: {
+						execute?: (input: {
+							type: 'change_shift_staff';
+							shiftId: string;
+							toStaffId: string;
+						}) => Promise<unknown>;
+					};
+				};
+			};
+
+			await expect(
+				streamTextCall.tools?.proposeShiftChange?.execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_2,
+				}),
+			).rejects.toThrow('スタッフIDが不正です');
+
+			expect(consoleErrorSpy).toHaveBeenCalledWith(
+				expect.any(String),
+				expect.objectContaining({
+					errorType: 'allowlist_violation',
+					toolName: 'proposeShiftChange',
+					toStaffId: TEST_IDS.STAFF_2,
+				}),
+			);
+
+			consoleErrorSpy.mockRestore();
+		});
+
 		it('スタッフが見つからない場合は 404 エラーを返す', async () => {
 			mockStaffMaybeSingle.mockResolvedValue({
 				data: null,

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -18,7 +18,10 @@ const {
 	mockCreateSearchStaffsTool,
 	mockCreateGetShiftsTool,
 	mockShiftRepositoryList,
+	mockShiftRepositoryFindByIds,
 	mockStaffRepositoryListByOffice,
+	mockStaffRepositoryFindById,
+	mockStaffRepositoryFindByIds,
 	mockStepCountIs,
 } = vi.hoisted(() => ({
 	mockStreamText: vi.fn(),
@@ -36,7 +39,10 @@ const {
 	mockCreateSearchStaffsTool: vi.fn(),
 	mockCreateGetShiftsTool: vi.fn(),
 	mockShiftRepositoryList: vi.fn(),
+	mockShiftRepositoryFindByIds: vi.fn(),
 	mockStaffRepositoryListByOffice: vi.fn(),
+	mockStaffRepositoryFindById: vi.fn(),
+	mockStaffRepositoryFindByIds: vi.fn(),
 	mockStepCountIs: vi.fn((n: number) => ({ type: 'stepCountIs', count: n })),
 }));
 
@@ -80,6 +86,7 @@ vi.mock('@/backend/repositories/shiftRepository', () => ({
 	ShiftRepository: function MockShiftRepository() {
 		return {
 			list: mockShiftRepositoryList,
+			findByIds: mockShiftRepositoryFindByIds,
 		};
 	},
 }));
@@ -88,6 +95,8 @@ vi.mock('@/backend/repositories/staffRepository', () => ({
 	StaffRepository: function MockStaffRepository() {
 		return {
 			listByOffice: mockStaffRepositoryListByOffice,
+			findById: mockStaffRepositoryFindById,
+			findByIds: mockStaffRepositoryFindByIds,
 		};
 	},
 }));
@@ -158,7 +167,10 @@ describe('POST /api/chat/shift-adjustment', () => {
 			description: 'mock get shifts tool',
 		});
 		mockShiftRepositoryList.mockResolvedValue([]);
+		mockShiftRepositoryFindByIds.mockResolvedValue([]);
 		mockStaffRepositoryListByOffice.mockResolvedValue([]);
+		mockStaffRepositoryFindById.mockResolvedValue(null);
+		mockStaffRepositoryFindByIds.mockResolvedValue([]);
 
 		// デフォルトのstreamTextモック
 		mockToUIMessageStreamResponse.mockReturnValue(
@@ -1814,7 +1826,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 					shiftId: TEST_IDS.SCHEDULE_1,
 					toStaffId: TEST_IDS.STAFF_1,
 				}),
-			).resolves.toEqual({
+			).resolves.toMatchObject({
 				type: 'change_shift_staff',
 				shiftId: TEST_IDS.SCHEDULE_1,
 				toStaffId: TEST_IDS.STAFF_1,
@@ -3111,6 +3123,281 @@ describe('POST /api/chat/shift-adjustment', () => {
 
 				expect(response.status).toBe(200);
 				expect(mockStaffRepositoryListByOffice).not.toHaveBeenCalled();
+			});
+		});
+
+		// ===== C-1: proposeShiftChange / _meta 付与 =====
+		describe('proposeShiftChange / _meta 付与', () => {
+			/** proposeShiftChange ツールの execute を取り出す共通ヘルパー */
+			const getExecute = async (shiftContextOverride?: {
+				clientName?: string;
+				serviceTypeId?: string;
+			}) => {
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '提案して' }],
+							context: {
+								shifts: [
+									{
+										id: TEST_IDS.SCHEDULE_1,
+										clientId: TEST_IDS.CLIENT_1,
+										serviceTypeId:
+											shiftContextOverride?.serviceTypeId ?? 'life-support',
+										clientName: shiftContextOverride?.clientName ?? '利用者A',
+										date: '2026-03-16',
+										startTime: '09:00',
+										endTime: '10:00',
+									},
+								],
+							},
+						}),
+					},
+				);
+
+				await POST(request);
+
+				const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+					tools?: {
+						proposeShiftChange?: {
+							execute?: (input: {
+								type: 'change_shift_staff';
+								shiftId: string;
+								toStaffId: string;
+							}) => Promise<unknown>;
+						};
+					};
+				};
+
+				return streamTextCall.tools?.proposeShiftChange?.execute;
+			};
+
+			it('shiftContext あり + findById 成功（change_shift_staff）→ _meta が toStaffName 付きで付与される', async () => {
+				mockStaffRepositoryFindById.mockResolvedValue({
+					id: TEST_IDS.STAFF_1,
+					office_id: TEST_IDS.OFFICE_1,
+					name: 'テストスタッフA',
+					role: 'helper',
+					created_at: new Date('2024-01-01T00:00:00.000Z'),
+					updated_at: new Date('2024-01-01T00:00:00.000Z'),
+				});
+
+				const execute = await getExecute({ clientName: '利用者A' });
+
+				const result = await execute?.({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+				});
+
+				expect(result).toEqual({
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_1,
+					_meta: {
+						shiftDate: '2026-03-16',
+						shiftStartTime: '09:00',
+						shiftEndTime: '10:00',
+						clientName: '利用者A',
+						serviceTypeName: '生活支援',
+						toStaffName: 'テストスタッフA',
+					},
+				});
+			});
+
+			it('shiftContext あり + findById がエラーをスロー → _meta なしで proposal が返る（フォールバック）', async () => {
+				mockStaffRepositoryFindById.mockRejectedValue(
+					new Error('DB connection error'),
+				);
+
+				const consoleErrorSpy = vi
+					.spyOn(console, 'error')
+					.mockImplementation(() => undefined);
+
+				try {
+					const execute = await getExecute();
+
+					const result = await execute?.({
+						type: 'change_shift_staff',
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_1,
+					});
+
+					// _meta なしで proposal がそのまま返ること
+					expect(result).toEqual({
+						type: 'change_shift_staff',
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_1,
+					});
+					// フォールバック時にエラーログが出力されること
+					expect(consoleErrorSpy).toHaveBeenCalledWith(
+						'Failed to build _meta for proposeShiftChange',
+						expect.anything(),
+					);
+				} finally {
+					consoleErrorSpy.mockRestore();
+				}
+			});
+		});
+
+		// ===== C-2: proposeShiftChanges / _meta 付与 =====
+		describe('proposeShiftChanges / _meta 付与', () => {
+			/** flexible モードで proposeShiftChanges execute を取り出す共通ヘルパー */
+			const getExecute = async () => {
+				mockShiftRepositoryList.mockResolvedValue([
+					{ id: TEST_IDS.SCHEDULE_1, staff_id: TEST_IDS.STAFF_1 },
+					{ id: TEST_IDS.SCHEDULE_2, staff_id: TEST_IDS.STAFF_2 },
+				]);
+				mockStaffRepositoryListByOffice.mockResolvedValue([
+					{
+						id: TEST_IDS.STAFF_1,
+						role: 'helper' as const,
+						service_type_ids: ['life-support'],
+					},
+					{
+						id: TEST_IDS.STAFF_2,
+						role: 'helper' as const,
+						service_type_ids: ['physical-care'],
+					},
+				]);
+
+				const request = new Request(
+					'http://localhost/api/chat/shift-adjustment',
+					{
+						method: 'POST',
+						headers: {
+							'Content-Type': 'application/json',
+							'x-ai-response-format': 'uimessage',
+						},
+						body: JSON.stringify({
+							messages: [{ role: 'user', content: '複数シフト調整して' }],
+							context: {
+								mode: 'flexible',
+								weekRange: {
+									startDate: '2026-03-16',
+									endDate: '2026-03-22',
+								},
+							},
+						}),
+					},
+				);
+
+				await POST(request);
+
+				const streamTextCall = mockStreamText.mock.calls.at(-1)?.[0] as {
+					tools?: {
+						proposeShiftChanges?: {
+							execute?: (input: unknown) => Promise<unknown>;
+						};
+					};
+				};
+
+				return streamTextCall.tools?.proposeShiftChanges?.execute;
+			};
+
+			it('findByIds 成功 → 各 proposal に _meta が付与される', async () => {
+				// ShiftRepository.findByIds: SCHEDULE_1 を返す
+				mockShiftRepositoryFindByIds.mockResolvedValue([
+					{
+						id: TEST_IDS.SCHEDULE_1,
+						client_id: TEST_IDS.CLIENT_1,
+						service_type_id: 'life-support',
+						staff_id: TEST_IDS.STAFF_1,
+						date: new Date('2026-03-16T00:00:00+09:00'),
+						time: {
+							start: { hour: 9, minute: 0 },
+							end: { hour: 10, minute: 0 },
+						},
+						status: 'scheduled',
+						is_unassigned: false,
+						created_at: new Date('2024-01-01T00:00:00.000Z'),
+						updated_at: new Date('2024-01-01T00:00:00.000Z'),
+						client_name: '利用者A',
+					},
+				]);
+				// StaffRepository.findByIds: STAFF_2 を返す
+				mockStaffRepositoryFindByIds.mockResolvedValue([
+					{
+						id: TEST_IDS.STAFF_2,
+						office_id: TEST_IDS.OFFICE_1,
+						name: 'テストスタッフB',
+						role: 'helper',
+						created_at: new Date('2024-01-01T00:00:00.000Z'),
+						updated_at: new Date('2024-01-01T00:00:00.000Z'),
+					},
+				]);
+
+				const execute = await getExecute();
+
+				const result = await execute?.({
+					proposals: [
+						{
+							type: 'change_shift_staff',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							toStaffId: TEST_IDS.STAFF_2,
+						},
+					],
+				});
+
+				expect(result).toEqual({
+					proposals: [
+						{
+							type: 'change_shift_staff',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							toStaffId: TEST_IDS.STAFF_2,
+							_meta: {
+								shiftDate: '2026-03-16',
+								shiftStartTime: '09:00',
+								shiftEndTime: '10:00',
+								clientName: '利用者A',
+								serviceTypeName: '生活支援',
+								toStaffName: 'テストスタッフB',
+							},
+						},
+					],
+				});
+			});
+
+			it('ShiftRepository.findByIds がエラーをスロー → proposals そのまま返る（フォールバック）', async () => {
+				mockShiftRepositoryFindByIds.mockRejectedValue(
+					new Error('DB connection error'),
+				);
+
+				const consoleErrorSpy = vi
+					.spyOn(console, 'error')
+					.mockImplementation(() => undefined);
+
+				try {
+					const execute = await getExecute();
+
+					const input = {
+						proposals: [
+							{
+								type: 'change_shift_staff' as const,
+								shiftId: TEST_IDS.SCHEDULE_1,
+								toStaffId: TEST_IDS.STAFF_2,
+							},
+						],
+					};
+
+					const result = await execute?.(input);
+
+					// _meta なしで proposals がそのまま返ること
+					expect(result).toEqual(input);
+					// フォールバック時にエラーログが出力されること
+					expect(consoleErrorSpy).toHaveBeenCalledWith(
+						'Failed to build _meta for proposeShiftChanges',
+						expect.anything(),
+					);
+				} finally {
+					consoleErrorSpy.mockRestore();
+				}
 			});
 		});
 	});

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -13,7 +13,7 @@ import {
 	ServiceTypeIdSchema,
 	ServiceTypeLabels,
 } from '@/models/valueObjects/serviceTypeId';
-import { parseJstDateString } from '@/utils/date';
+import { formatJstDateString, parseJstDateString } from '@/utils/date';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { convertToModelMessages, stepCountIs, streamText, tool } from 'ai';
@@ -508,6 +508,22 @@ ${shiftLines.join('\n')}${buildShiftSelectionPrompt(context.shifts.length)}`;
 const isRecord = (input: unknown): input is Record<string, unknown> =>
 	typeof input === 'object' && input !== null;
 
+/**
+ * AI 参照専用のシフトメタ情報
+ * UI 確定処理・永続化には影響しない
+ */
+type ShiftMeta = {
+	shiftDate: string; // "2026-05-10"
+	shiftStartTime: string; // "09:00"
+	shiftEndTime: string; // "10:00"
+	clientName?: string;
+	serviceTypeName: string;
+	toStaffName?: string; // change_shift_staff のみ
+};
+
+const formatHHmm = (hour: number, minute: number): string =>
+	`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+
 const hasNestedToolInput = (
 	input: Record<string, unknown>,
 	key: string,
@@ -564,10 +580,11 @@ const ProposeShiftChangeToolInputSchema = z.preprocess((input) => {
 
 const createProposeShiftChangeTool = (
 	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
-	shifts: Array<{ id: string }> | undefined,
+	shifts: Array<z.infer<typeof ShiftContextItemSchema>> | undefined,
 	logContext: RequestLogContext,
 ) => {
 	const allowlistedShiftIds = new Set((shifts ?? []).map((shift) => shift.id));
+	const shiftContextMap = new Map((shifts ?? []).map((s) => [s.id, s]));
 	logContext.allowlistedShiftIdsSize = allowlistedShiftIds.size;
 
 	return tool({
@@ -630,7 +647,39 @@ const createProposeShiftChangeTool = (
 				throw shiftNotFoundError;
 			}
 
-			return proposal;
+			// _meta 構築（失敗時はフォールバックとして省略）
+			let meta: ShiftMeta | undefined;
+			try {
+				const shiftContext = shiftContextMap.get(proposal.shiftId);
+				if (shiftContext) {
+					const baseMeta: ShiftMeta = {
+						shiftDate: shiftContext.date,
+						shiftStartTime: shiftContext.startTime,
+						shiftEndTime: shiftContext.endTime,
+						clientName: shiftContext.clientName,
+						serviceTypeName: ServiceTypeLabels[shiftContext.serviceTypeId],
+					};
+
+					if (proposal.type === 'change_shift_staff') {
+						const staffRepo = new StaffRepository(supabase);
+						const toStaff = await staffRepo.findById(proposal.toStaffId);
+						if (toStaff) {
+							baseMeta.toStaffName = toStaff.name;
+						}
+					}
+
+					meta = baseMeta;
+				}
+			} catch (e) {
+				logChatError(
+					'Failed to build _meta for proposeShiftChange',
+					e,
+					logContext,
+					{ toolName: 'proposeShiftChange', proposalShiftId: proposal.shiftId },
+				);
+			}
+
+			return meta ? { ...proposal, _meta: meta } : proposal;
 		},
 	});
 };
@@ -661,6 +710,7 @@ const isAllowedBatchProposal = (
 
 const createProposeShiftChangesTool = (
 	allowlist: FlexibleAllowlist,
+	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
 	logContext: RequestLogContext,
 ) => {
 	const isAllowedProposal = isAllowedBatchProposal(allowlist);
@@ -675,20 +725,83 @@ const createProposeShiftChangesTool = (
 				(candidate) => !isAllowedProposal(candidate),
 			);
 
-			if (!invalidProposal) {
-				return proposal;
+			if (invalidProposal) {
+				const allowlistError = new Error(
+					'提案に許可されていないシフトまたはスタッフが含まれています。',
+				) as LoggedChatError;
+				allowlistError.__errorCode = 'allowlist_violation';
+				allowlistError.__logged = true;
+				logChatError('AI chat tool error', allowlistError, logContext, {
+					toolName: 'proposeShiftChanges',
+					proposalShiftId: invalidProposal.shiftId,
+				});
+				throw allowlistError;
 			}
 
-			const allowlistError = new Error(
-				'提案に許可されていないシフトまたはスタッフが含まれています。',
-			) as LoggedChatError;
-			allowlistError.__errorCode = 'allowlist_violation';
-			allowlistError.__logged = true;
-			logChatError('AI chat tool error', allowlistError, logContext, {
-				toolName: 'proposeShiftChanges',
-				proposalShiftId: invalidProposal.shiftId,
-			});
-			throw allowlistError;
+			// _meta を各 proposal に付与（失敗時はフォールバックとして省略）
+			try {
+				const shiftIds = [...new Set(proposal.proposals.map((p) => p.shiftId))];
+				const toStaffIds = [
+					...new Set(
+						proposal.proposals
+							.filter((p) => p.type === 'change_shift_staff')
+							.map(
+								(p) =>
+									(p as { type: 'change_shift_staff'; toStaffId: string })
+										.toStaffId,
+							),
+					),
+				];
+
+				const [shifts, staffs] = await Promise.all([
+					new ShiftRepository(supabase).findByIds(shiftIds),
+					new StaffRepository(supabase).findByIds(toStaffIds),
+				]);
+
+				const shiftMap = new Map(shifts.map((s) => [s.id, s]));
+				const staffMap = new Map(staffs.map((s) => [s.id, s]));
+
+				const proposalsWithMeta = proposal.proposals.map((p) => {
+					const shift = shiftMap.get(p.shiftId);
+					if (!shift) return p;
+
+					const meta: ShiftMeta = {
+						shiftDate: formatJstDateString(shift.date),
+						shiftStartTime: formatHHmm(
+							shift.time.start.hour,
+							shift.time.start.minute,
+						),
+						shiftEndTime: formatHHmm(
+							shift.time.end.hour,
+							shift.time.end.minute,
+						),
+						clientName: shift.client_name,
+						serviceTypeName: ServiceTypeLabels[shift.service_type_id],
+					};
+
+					if (p.type === 'change_shift_staff') {
+						const toStaff = staffMap.get(
+							(p as { type: 'change_shift_staff'; toStaffId: string })
+								.toStaffId,
+						);
+						if (toStaff) {
+							meta.toStaffName = toStaff.name;
+						}
+					}
+
+					return { ...p, _meta: meta };
+				});
+
+				return { proposals: proposalsWithMeta };
+			} catch (e) {
+				logChatError(
+					'Failed to build _meta for proposeShiftChanges',
+					e,
+					logContext,
+					{ toolName: 'proposeShiftChanges' },
+				);
+				return proposal;
+			}
 		},
 	});
 };
@@ -890,6 +1003,7 @@ const buildTools = (
 				? {
 						proposeShiftChanges: createProposeShiftChangesTool(
 							flexibleAllowlist,
+							supabase,
 							logContext,
 						),
 					}

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -13,7 +13,11 @@ import {
 	ServiceTypeIdSchema,
 	ServiceTypeLabels,
 } from '@/models/valueObjects/serviceTypeId';
-import { formatJstDateString, parseJstDateString } from '@/utils/date';
+import {
+	formatJstDateString,
+	parseJstDateString,
+	timeObjectToString,
+} from '@/utils/date';
 import { createSupabaseClient } from '@/utils/supabase/server';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { convertToModelMessages, stepCountIs, streamText, tool } from 'ai';
@@ -521,9 +525,6 @@ type ShiftMeta = {
 	toStaffName?: string; // change_shift_staff のみ
 };
 
-const formatHHmm = (hour: number, minute: number): string =>
-	`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
-
 const hasNestedToolInput = (
 	input: Record<string, unknown>,
 	key: string,
@@ -578,12 +579,34 @@ const ProposeShiftChangeToolInputSchema = z.preprocess((input) => {
 	return input;
 }, AiChatMutationProposalSchema);
 
+const throwAllowlistViolation = (
+	message: string,
+	logContext: RequestLogContext,
+	extra: Record<string, unknown>,
+): never => {
+	const err = new Error(message) as LoggedChatError;
+	err.__errorCode = 'allowlist_violation';
+	err.__logged = true;
+	logChatError('AI chat tool error', err, logContext, extra);
+	throw err;
+};
+
+const isStaffAllowlistViolation = (
+	proposal: z.infer<typeof AiChatMutationProposalSchema>,
+	allowlistedStaffIds: Set<string>,
+): boolean =>
+	allowlistedStaffIds.size > 0 &&
+	proposal.type === 'change_shift_staff' &&
+	!allowlistedStaffIds.has(proposal.toStaffId);
+
 const createProposeShiftChangeTool = (
 	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
 	shifts: Array<z.infer<typeof ShiftContextItemSchema>> | undefined,
 	logContext: RequestLogContext,
+	allowedStaffIds: string[] = [],
 ) => {
 	const allowlistedShiftIds = new Set((shifts ?? []).map((shift) => shift.id));
+	const allowlistedStaffIds = new Set(allowedStaffIds);
 	const shiftContextMap = new Map((shifts ?? []).map((s) => [s.id, s]));
 	logContext.allowlistedShiftIdsSize = allowlistedShiftIds.size;
 	const staffRepo = new StaffRepository(supabase);
@@ -594,16 +617,19 @@ const createProposeShiftChangeTool = (
 		inputSchema: ProposeShiftChangeToolInputSchema,
 		execute: async (proposal) => {
 			if (!allowlistedShiftIds.has(proposal.shiftId)) {
-				const allowlistError = new Error(
+				throwAllowlistViolation(
 					'シフトIDが不正です。候補に含まれているシフトから選択してください。',
-				) as LoggedChatError;
-				allowlistError.__errorCode = 'allowlist_violation';
-				allowlistError.__logged = true;
-				logChatError('AI chat tool error', allowlistError, logContext, {
-					toolName: 'proposeShiftChange',
-					proposalShiftId: proposal.shiftId,
-				});
-				throw allowlistError;
+					logContext,
+					{ toolName: 'proposeShiftChange', proposalShiftId: proposal.shiftId },
+				);
+			}
+
+			if (isStaffAllowlistViolation(proposal, allowlistedStaffIds)) {
+				throwAllowlistViolation(
+					'スタッフIDが不正です。候補に含まれているスタッフから選択してください。',
+					logContext,
+					{ toolName: 'proposeShiftChange', proposalShiftId: proposal.shiftId },
+				);
 			}
 
 			const { data: shiftData, error: shiftError } = await supabase
@@ -770,14 +796,8 @@ const createProposeShiftChangesTool = (
 
 					const meta: ShiftMeta = {
 						shiftDate: formatJstDateString(shift.date),
-						shiftStartTime: formatHHmm(
-							shift.time.start.hour,
-							shift.time.start.minute,
-						),
-						shiftEndTime: formatHHmm(
-							shift.time.end.hour,
-							shift.time.end.minute,
-						),
+						shiftStartTime: timeObjectToString(shift.time.start),
+						shiftEndTime: timeObjectToString(shift.time.end),
 						clientName: shift.client_name,
 						serviceTypeName: ServiceTypeLabels[shift.service_type_id],
 					};

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -586,6 +586,7 @@ const createProposeShiftChangeTool = (
 	const allowlistedShiftIds = new Set((shifts ?? []).map((shift) => shift.id));
 	const shiftContextMap = new Map((shifts ?? []).map((s) => [s.id, s]));
 	logContext.allowlistedShiftIdsSize = allowlistedShiftIds.size;
+	const staffRepo = new StaffRepository(supabase);
 
 	return tool({
 		description:
@@ -661,7 +662,6 @@ const createProposeShiftChangeTool = (
 					};
 
 					if (proposal.type === 'change_shift_staff') {
-						const staffRepo = new StaffRepository(supabase);
 						const toStaff = await staffRepo.findById(proposal.toStaffId);
 						if (toStaff) {
 							baseMeta.toStaffName = toStaff.name;
@@ -744,12 +744,15 @@ const createProposeShiftChangesTool = (
 				const toStaffIds = [
 					...new Set(
 						proposal.proposals
-							.filter((p) => p.type === 'change_shift_staff')
-							.map(
-								(p) =>
-									(p as { type: 'change_shift_staff'; toStaffId: string })
-										.toStaffId,
-							),
+							.filter(
+								(
+									p,
+								): p is Extract<
+									(typeof proposal.proposals)[number],
+									{ type: 'change_shift_staff' }
+								> => p.type === 'change_shift_staff',
+							)
+							.map((p) => p.toStaffId),
 					),
 				];
 
@@ -780,10 +783,7 @@ const createProposeShiftChangesTool = (
 					};
 
 					if (p.type === 'change_shift_staff') {
-						const toStaff = staffMap.get(
-							(p as { type: 'change_shift_staff'; toStaffId: string })
-								.toStaffId,
-						);
+						const toStaff = staffMap.get(p.toStaffId);
 						if (toStaff) {
 							meta.toStaffName = toStaff.name;
 						}

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -232,6 +232,7 @@ const logChatError = (
 		toolName: string;
 		proposalShiftId: string;
 		shiftErrorCode: string;
+		toStaffId: string;
 	}> = {},
 ): void => {
 	const errorMessage =
@@ -263,6 +264,7 @@ const logChatError = (
 		toolName: extra.toolName,
 		proposalShiftId: extra.proposalShiftId,
 		shiftErrorCode: extra.shiftErrorCode,
+		toStaffId: extra.toStaffId,
 		stack: error instanceof Error ? error.stack : undefined,
 	});
 };
@@ -599,6 +601,16 @@ const isStaffAllowlistViolation = (
 	proposal.type === 'change_shift_staff' &&
 	!allowlistedStaffIds.has(proposal.toStaffId);
 
+/** change_shift_staff 提案から toStaffId を取り出す（それ以外は undefined） */
+const extractToStaffId = (
+	proposal: z.infer<typeof AiChatMutationProposalSchema>,
+): string | undefined =>
+	proposal.type === 'change_shift_staff' ? proposal.toStaffId : undefined;
+
+/** context から staffIds を取り出す（未設定なら空配列） */
+const getContextStaffIds = (context: ChatRequest['context']): string[] =>
+	context?.staffIds ?? [];
+
 const createProposeShiftChangeTool = (
 	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
 	shifts: Array<z.infer<typeof ShiftContextItemSchema>> | undefined,
@@ -628,7 +640,11 @@ const createProposeShiftChangeTool = (
 				throwAllowlistViolation(
 					'スタッフIDが不正です。候補に含まれているスタッフから選択してください。',
 					logContext,
-					{ toolName: 'proposeShiftChange', proposalShiftId: proposal.shiftId },
+					{
+						toolName: 'proposeShiftChange',
+						proposalShiftId: proposal.shiftId,
+						toStaffId: extractToStaffId(proposal),
+					},
 				);
 			}
 
@@ -701,7 +717,11 @@ const createProposeShiftChangeTool = (
 					'Failed to build _meta for proposeShiftChange',
 					e,
 					logContext,
-					{ toolName: 'proposeShiftChange', proposalShiftId: proposal.shiftId },
+					{
+						toolName: 'proposeShiftChange',
+						proposalShiftId: proposal.shiftId,
+						toStaffId: extractToStaffId(proposal),
+					},
 				);
 			}
 
@@ -1042,6 +1062,7 @@ const buildTools = (
 			supabase,
 			shiftList,
 			logContext,
+			getContextStaffIds(context),
 		),
 	};
 };

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -584,7 +584,7 @@ const ProposeShiftChangeToolInputSchema = z.preprocess((input) => {
 const throwAllowlistViolation = (
 	message: string,
 	logContext: RequestLogContext,
-	extra: Record<string, unknown>,
+	extra: Parameters<typeof logChatError>[3],
 ): never => {
 	const err = new Error(message) as LoggedChatError;
 	err.__errorCode = 'allowlist_violation';
@@ -610,6 +610,39 @@ const extractToStaffId = (
 /** context から staffIds を取り出す（未設定なら空配列） */
 const getContextStaffIds = (context: ChatRequest['context']): string[] =>
 	context?.staffIds ?? [];
+
+/** proposeShiftChange ツール用の _meta を構築する（失敗時は undefined を返す） */
+const buildProposeShiftChangeMeta = async (
+	proposal: z.infer<typeof AiChatMutationProposalSchema>,
+	shiftContextMap: Map<string, z.infer<typeof ShiftContextItemSchema>>,
+	staffRepo: StaffRepository,
+	allowlistedStaffIds: Set<string>,
+): Promise<ShiftMeta | undefined> => {
+	const shiftContext = shiftContextMap.get(proposal.shiftId);
+	if (!shiftContext) return undefined;
+
+	const baseMeta: ShiftMeta = {
+		shiftDate: shiftContext.date,
+		shiftStartTime: shiftContext.startTime,
+		shiftEndTime: shiftContext.endTime,
+		clientName: shiftContext.clientName,
+		serviceTypeName: ServiceTypeLabels[shiftContext.serviceTypeId],
+	};
+
+	if (proposal.type === 'change_shift_staff') {
+		const isAllowedStaff =
+			allowlistedStaffIds.size === 0 ||
+			allowlistedStaffIds.has(proposal.toStaffId);
+		if (isAllowedStaff) {
+			const toStaff = await staffRepo.findById(proposal.toStaffId);
+			if (toStaff) {
+				baseMeta.toStaffName = toStaff.name;
+			}
+		}
+	}
+
+	return baseMeta;
+};
 
 const createProposeShiftChangeTool = (
 	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
@@ -693,25 +726,12 @@ const createProposeShiftChangeTool = (
 			// _meta 構築（失敗時はフォールバックとして省略）
 			let meta: ShiftMeta | undefined;
 			try {
-				const shiftContext = shiftContextMap.get(proposal.shiftId);
-				if (shiftContext) {
-					const baseMeta: ShiftMeta = {
-						shiftDate: shiftContext.date,
-						shiftStartTime: shiftContext.startTime,
-						shiftEndTime: shiftContext.endTime,
-						clientName: shiftContext.clientName,
-						serviceTypeName: ServiceTypeLabels[shiftContext.serviceTypeId],
-					};
-
-					if (proposal.type === 'change_shift_staff') {
-						const toStaff = await staffRepo.findById(proposal.toStaffId);
-						if (toStaff) {
-							baseMeta.toStaffName = toStaff.name;
-						}
-					}
-
-					meta = baseMeta;
-				}
+				meta = await buildProposeShiftChangeMeta(
+					proposal,
+					shiftContextMap,
+					staffRepo,
+					allowlistedStaffIds,
+				);
 			} catch (e) {
 				logChatError(
 					'Failed to build _meta for proposeShiftChange',

--- a/src/backend/repositories/shiftRepository.test.ts
+++ b/src/backend/repositories/shiftRepository.test.ts
@@ -1061,4 +1061,94 @@ describe('ShiftRepository', () => {
 			expect(mockSupabase._mockQuery.limit).toHaveBeenCalledWith(100);
 		});
 	});
+
+	describe('findByIds', () => {
+		const makeShiftRow = (id: string) => ({
+			id,
+			client_id: TEST_IDS.CLIENT_1,
+			service_type_id: 'life-support' as const,
+			staff_id: TEST_IDS.STAFF_1,
+			start_time: '2026-05-10T00:00:00+09:00',
+			end_time: '2026-05-10T01:00:00+09:00',
+			status: 'scheduled' as const,
+			is_unassigned: false,
+			canceled_reason: null,
+			canceled_category: null,
+			canceled_at: null,
+			notes: null,
+			created_at: '2026-01-01T00:00:00Z',
+			updated_at: '2026-01-01T00:00:00Z',
+		});
+
+		it('空配列を渡した場合は即 [] を返す（DB アクセスなし）', async () => {
+			const result = await repository.findByIds([]);
+
+			expect(result).toEqual([]);
+			expect(mockSupabase.from).not.toHaveBeenCalled();
+		});
+
+		it('指定した IDs で .in("id", ids) を使って検索する', async () => {
+			const ids = [TEST_IDS.SCHEDULE_1, TEST_IDS.SCHEDULE_2];
+			const rows = ids.map(makeShiftRow);
+
+			mockSupabase._mockQuery.order.mockResolvedValueOnce({
+				data: rows,
+				error: null,
+			});
+
+			await repository.findByIds(ids);
+
+			expect(mockSupabase._mockQuery.in).toHaveBeenCalledWith('id', ids);
+		});
+
+		it('clients と staffs を JOIN する SELECT を発行する', async () => {
+			const ids = [TEST_IDS.SCHEDULE_1];
+			const rows = ids.map(makeShiftRow);
+
+			mockSupabase._mockQuery.order.mockResolvedValueOnce({
+				data: rows,
+				error: null,
+			});
+
+			await repository.findByIds(ids);
+
+			expect(mockSupabase._mockQuery.select).toHaveBeenCalledWith(
+				'*, clients(name, office_id), staffs(name)',
+			);
+		});
+
+		it('返却されたデータを ShiftWithNames[] にマッピングする', async () => {
+			const ids = [TEST_IDS.SCHEDULE_1];
+			const rows = [
+				{
+					...makeShiftRow(TEST_IDS.SCHEDULE_1),
+					clients: { name: 'テスト利用者', office_id: TEST_IDS.OFFICE_1 },
+					staffs: { name: 'テストスタッフ' },
+				},
+			];
+
+			mockSupabase._mockQuery.order.mockResolvedValueOnce({
+				data: rows,
+				error: null,
+			});
+
+			const result = await repository.findByIds(ids);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].client_name).toBe('テスト利用者');
+			expect(result[0].staff_name).toBe('テストスタッフ');
+		});
+
+		it('DB エラー時は例外をスローする', async () => {
+			const ids = [TEST_IDS.SCHEDULE_1];
+			const dbError = new Error('DB error');
+
+			mockSupabase._mockQuery.order.mockResolvedValueOnce({
+				data: null,
+				error: dbError,
+			});
+
+			await expect(repository.findByIds(ids)).rejects.toThrow('DB error');
+		});
+	});
 });

--- a/src/backend/repositories/shiftRepository.test.ts
+++ b/src/backend/repositories/shiftRepository.test.ts
@@ -1113,7 +1113,7 @@ describe('ShiftRepository', () => {
 			await repository.findByIds(ids);
 
 			expect(mockSupabase._mockQuery.select).toHaveBeenCalledWith(
-				'*, clients(name, office_id), staffs(name)',
+				'*, clients(name), staffs(name)',
 			);
 		});
 
@@ -1122,7 +1122,7 @@ describe('ShiftRepository', () => {
 			const rows = [
 				{
 					...makeShiftRow(TEST_IDS.SCHEDULE_1),
-					clients: { name: 'テスト利用者', office_id: TEST_IDS.OFFICE_1 },
+					clients: { name: 'テスト利用者' },
 					staffs: { name: 'テストスタッフ' },
 				},
 			];
@@ -1137,6 +1137,50 @@ describe('ShiftRepository', () => {
 			expect(result).toHaveLength(1);
 			expect(result[0].client_name).toBe('テスト利用者');
 			expect(result[0].staff_name).toBe('テストスタッフ');
+		});
+
+		it('clients が null の場合、client_name は undefined になる', async () => {
+			const ids = [TEST_IDS.SCHEDULE_1];
+			const rows = [
+				{
+					...makeShiftRow(TEST_IDS.SCHEDULE_1),
+					clients: null,
+					staffs: { name: 'テストスタッフ' },
+				},
+			];
+
+			mockSupabase._mockQuery.order.mockResolvedValueOnce({
+				data: rows,
+				error: null,
+			});
+
+			const result = await repository.findByIds(ids);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].client_name).toBeUndefined();
+			expect(result[0].staff_name).toBe('テストスタッフ');
+		});
+
+		it('staffs が null の場合、staff_name は undefined になる', async () => {
+			const ids = [TEST_IDS.SCHEDULE_1];
+			const rows = [
+				{
+					...makeShiftRow(TEST_IDS.SCHEDULE_1),
+					clients: { name: 'テスト利用者' },
+					staffs: null,
+				},
+			];
+
+			mockSupabase._mockQuery.order.mockResolvedValueOnce({
+				data: rows,
+				error: null,
+			});
+
+			const result = await repository.findByIds(ids);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].client_name).toBe('テスト利用者');
+			expect(result[0].staff_name).toBeUndefined();
 		});
 
 		it('DB エラー時は例外をスローする', async () => {

--- a/src/backend/repositories/shiftRepository.ts
+++ b/src/backend/repositories/shiftRepository.ts
@@ -218,6 +218,36 @@ export class ShiftRepository {
 		return this.toDomain(data);
 	}
 
+	/**
+	 * 複数の ID でシフトを一括取得する
+	 * clients・staffs を JOIN して client_name / staff_name も返す
+	 * 空配列時は即 [] を返す
+	 */
+	async findByIds(ids: string[]): Promise<ShiftWithNames[]> {
+		if (ids.length === 0) return [];
+
+		const { data, error } = await this.supabase
+			.from('shifts')
+			.select('*, clients(name, office_id), staffs(name)')
+			.in('id', ids)
+			.order('start_time');
+
+		if (error) throw error;
+
+		return (data ?? []).map((row) => {
+			const listRow = row as ShiftListRow;
+			const shift = this.toDomain(listRow);
+			const clientName = this.extractNameFromRelation(listRow.clients);
+			const staffName = this.extractNameFromRelation(listRow.staffs);
+
+			return {
+				...shift,
+				...(clientName ? { client_name: clientName } : {}),
+				...(staffName ? { staff_name: staffName } : {}),
+			};
+		});
+	}
+
 	async create(shift: Shift): Promise<void> {
 		const dbData = this.toDB(shift);
 		const { error } = await this.supabase.from('shifts').insert(dbData);

--- a/src/backend/repositories/shiftRepository.ts
+++ b/src/backend/repositories/shiftRepository.ts
@@ -132,6 +132,18 @@ export class ShiftRepository {
 		return relation.name;
 	}
 
+	private mapRowToShiftWithNames(row: ShiftListRow): ShiftWithNames {
+		const shift = this.toDomain(row);
+		const clientName = this.extractNameFromRelation(row.clients);
+		const staffName = this.extractNameFromRelation(row.staffs);
+
+		return {
+			...shift,
+			...(clientName ? { client_name: clientName } : {}),
+			...(staffName ? { staff_name: staffName } : {}),
+		};
+	}
+
 	async list(filters: ShiftFilters = {}): Promise<ShiftWithNames[]> {
 		if (filters.date !== undefined && !isValidJstDateString(filters.date)) {
 			throw new Error(`ShiftRepository.list: 無効な date 値 "${filters.date}"`);
@@ -188,18 +200,9 @@ export class ShiftRepository {
 		const { data, error } = await query.order('start_time');
 		if (error) throw error;
 
-		return (data ?? []).map((row) => {
-			const listRow = row as ShiftListRow;
-			const shift = this.toDomain(listRow);
-			const clientName = this.extractNameFromRelation(listRow.clients);
-			const staffName = this.extractNameFromRelation(listRow.staffs);
-
-			return {
-				...shift,
-				...(clientName ? { client_name: clientName } : {}),
-				...(staffName ? { staff_name: staffName } : {}),
-			};
-		});
+		return (data ?? []).map((row) =>
+			this.mapRowToShiftWithNames(row as ShiftListRow),
+		);
 	}
 
 	async findById(id: string): Promise<Shift | null> {
@@ -229,18 +232,9 @@ export class ShiftRepository {
 
 		if (error) throw error;
 
-		return (data ?? []).map((row) => {
-			const listRow = row as ShiftListRow;
-			const shift = this.toDomain(listRow);
-			const clientName = this.extractNameFromRelation(listRow.clients);
-			const staffName = this.extractNameFromRelation(listRow.staffs);
-
-			return {
-				...shift,
-				...(clientName ? { client_name: clientName } : {}),
-				...(staffName ? { staff_name: staffName } : {}),
-			};
-		});
+		return (data ?? []).map((row) =>
+			this.mapRowToShiftWithNames(row as ShiftListRow),
+		);
 	}
 
 	async create(shift: Shift): Promise<void> {

--- a/src/backend/repositories/shiftRepository.ts
+++ b/src/backend/repositories/shiftRepository.ts
@@ -30,13 +30,8 @@ type ShiftRow = Database['public']['Tables']['shifts']['Row'];
 type ShiftInsert = Database['public']['Tables']['shifts']['Insert'];
 type ShiftListRow = ShiftRow & {
 	clients?:
-		| Pick<Database['public']['Tables']['clients']['Row'], 'name' | 'office_id'>
-		| Array<
-				Pick<
-					Database['public']['Tables']['clients']['Row'],
-					'name' | 'office_id'
-				>
-		  >
+		| Pick<Database['public']['Tables']['clients']['Row'], 'name'>
+		| Array<Pick<Database['public']['Tables']['clients']['Row'], 'name'>>
 		| null;
 	staffs?:
 		| Pick<Database['public']['Tables']['staffs']['Row'], 'name'>
@@ -228,7 +223,7 @@ export class ShiftRepository {
 
 		const { data, error } = await this.supabase
 			.from('shifts')
-			.select('*, clients(name, office_id), staffs(name)')
+			.select('*, clients(name), staffs(name)')
 			.in('id', ids)
 			.order('start_time');
 

--- a/src/backend/repositories/staffRepository.test.ts
+++ b/src/backend/repositories/staffRepository.test.ts
@@ -925,4 +925,93 @@ describe('StaffRepository', () => {
 			expect(mockStaffOr).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	describe('findByIds', () => {
+		const baseRow = {
+			id: TEST_IDS.STAFF_1,
+			office_id: TEST_IDS.OFFICE_1,
+			name: '管理者A',
+			kana: null as string | null,
+			role: 'admin' as const,
+			email: 'admin@example.com',
+			note: null as string | null,
+			auth_user_id: null as string | null,
+			created_at: '2025-12-22T00:00:00Z',
+			updated_at: '2025-12-22T00:00:00Z',
+		};
+
+		it('空配列を渡した場合は即 [] を返す（DB アクセスなし）', async () => {
+			const result = await repository.findByIds([]);
+
+			expect(result).toEqual([]);
+			expect(supabase.from).not.toHaveBeenCalled();
+		});
+
+		it('指定した IDs で .in("id", ids) を使って検索する', async () => {
+			const ids = [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2];
+			const rows = [
+				baseRow,
+				{ ...baseRow, id: TEST_IDS.STAFF_2, name: 'ヘルパーB' },
+			];
+
+			const mockSelect = vi.fn().mockReturnThis();
+			const mockIn = vi.fn().mockResolvedValueOnce({ data: rows, error: null });
+
+			(supabase.from as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+				select: mockSelect,
+				in: mockIn,
+			});
+			mockSelect.mockReturnValueOnce({ in: mockIn });
+
+			await repository.findByIds(ids);
+
+			expect(mockIn).toHaveBeenCalledWith('id', ids);
+		});
+
+		it('取得したデータを Staff[] にマッピングして返す', async () => {
+			const ids = [TEST_IDS.STAFF_1, TEST_IDS.STAFF_2];
+			const rows = [
+				baseRow,
+				{
+					...baseRow,
+					id: TEST_IDS.STAFF_2,
+					name: 'ヘルパーB',
+					role: 'helper' as const,
+				},
+			];
+
+			const mockSelect = vi.fn().mockReturnThis();
+			const mockIn = vi.fn().mockResolvedValueOnce({ data: rows, error: null });
+
+			(supabase.from as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+				select: mockSelect,
+				in: mockIn,
+			});
+			mockSelect.mockReturnValueOnce({ in: mockIn });
+
+			const result = await repository.findByIds(ids);
+
+			expect(result).toHaveLength(2);
+			expect(result[0].name).toBe('管理者A');
+			expect(result[1].name).toBe('ヘルパーB');
+		});
+
+		it('DB エラー時は例外をスローする', async () => {
+			const ids = [TEST_IDS.STAFF_1];
+			const dbError = new Error('DB error');
+
+			const mockSelect = vi.fn().mockReturnThis();
+			const mockIn = vi
+				.fn()
+				.mockResolvedValueOnce({ data: null, error: dbError });
+
+			(supabase.from as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+				select: mockSelect,
+				in: mockIn,
+			});
+			mockSelect.mockReturnValueOnce({ in: mockIn });
+
+			await expect(repository.findByIds(ids)).rejects.toThrow('DB error');
+		});
+	});
 });

--- a/src/backend/repositories/staffRepository.ts
+++ b/src/backend/repositories/staffRepository.ts
@@ -156,6 +156,22 @@ export class StaffRepository {
 		return this.toDomain(data);
 	}
 
+	/**
+	 * 複数の ID でスタッフを一括取得する
+	 * 空配列時は即 [] を返す
+	 */
+	async findByIds(ids: string[]): Promise<Staff[]> {
+		if (ids.length === 0) return [];
+
+		const { data, error } = await this.supabase
+			.from('staffs')
+			.select('*')
+			.in('id', ids);
+
+		if (error) throw error;
+		return (data ?? []).map((row) => this.toDomain(row));
+	}
+
 	async findWithServiceTypesById(
 		id: string,
 	): Promise<StaffWithServiceTypes | null> {


### PR DESCRIPTION
## 概要

proposeShiftChange / proposeShiftChanges ツールの `execute` 結果に `_meta` フィールド（人間可読メタ情報）を付与する。AIが返却値をもとに要約メッセージを生成する際、UUID ではなく日付・時間・クライアント名・サービス種別・スタッフ名を使えるようにする。

Closes #177

## 変更内容

### レビュー指摘対応 (F-1〜F-3・F-5)

| 指摘 | 内容 | 対応ファイル |
|------|------|-------------|
| F-1 | 型キャスト除去・適切な型付け | `route.ts` |
| F-2 | StaffRepository クロージャ化 | `route.ts` |
| F-3 | shiftRepository の SELECT 修正 | `shiftRepository.ts` |
| F-5 | findByIds テスト追加 | `*.test.ts` |

### 変更ファイル

- `src/backend/repositories/shiftRepository.ts` — `findByIds()` 追加・SELECT 修正（F-3）
- `src/backend/repositories/shiftRepository.test.ts` — findByIds テスト追加（F-5）
- `src/backend/repositories/staffRepository.ts` — `findByIds()` 追加
- `src/backend/repositories/staffRepository.test.ts` — findByIds テスト追加
- `src/app/api/chat/shift-adjustment/route.ts` — `_meta` 付与・型キャスト除去（F-1）・StaffRepository クロージャ化（F-2）

## _meta フィールドの構造

```json
{
  "type": "change_shift_staff",
  "shiftId": "uuid-xxx",
  "toStaffId": "uuid-yyy",
  "reason": "体調不良のため",
  "_meta": {
    "shiftDate": "2026-05-10",
    "shiftStartTime": "09:00",
    "shiftEndTime": "10:00",
    "clientName": "山田 花子",
    "serviceTypeName": "身体介護",
    "toStaffName": "田中 一郎"
  }
}
```

## テスト

- 全テスト通過・型エラーなし
- findByIds のユニットテストを shiftRepository / staffRepository 両方に追加

## 注意事項

- `_meta` は AI へのフィードバック専用フィールド。UI 表示・永続化には使用しない
- DB クエリ失敗時は `_meta` を省略し、UUID のみの返却値にフォールバックする