### PR TITLE
fix: 確定確認ダイアログのID表示を人間可読な情報に変更

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.stories.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.stories.tsx
@@ -40,3 +40,40 @@ export const Loading: Story = {
 		isLoading: true,
 	},
 };
+
+export const WithMeta: Story = {
+	args: {
+		proposal: {
+			proposals: [
+				{
+					type: 'change_shift_staff',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					toStaffId: TEST_IDS.STAFF_2,
+					reason: '欠勤対応',
+					_meta: {
+						shiftDate: '2026-03-16',
+						shiftStartTime: '09:00',
+						shiftEndTime: '10:00',
+						clientName: '田中花子',
+						serviceTypeName: '生活支援',
+						toStaffName: '鈴木太郎',
+					},
+				},
+				{
+					type: 'update_shift_time',
+					shiftId: TEST_IDS.SCHEDULE_2,
+					startAt: '2026-03-16T09:00:00+09:00',
+					endAt: '2026-03-16T10:00:00+09:00',
+					reason: '利用者都合',
+					_meta: {
+						shiftDate: '2026-03-16',
+						shiftStartTime: '09:00',
+						shiftEndTime: '10:00',
+						clientName: '田中花子',
+						serviceTypeName: '生活支援',
+					},
+				},
+			],
+		},
+	},
+};

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.test.tsx
@@ -22,6 +22,39 @@ const proposal = {
 	],
 };
 
+const proposalWithMeta = {
+	proposals: [
+		{
+			type: 'change_shift_staff' as const,
+			shiftId: TEST_IDS.SCHEDULE_1,
+			toStaffId: TEST_IDS.STAFF_2,
+			reason: '欠勤対応',
+			_meta: {
+				shiftDate: '2026-03-16',
+				shiftStartTime: '09:00',
+				shiftEndTime: '10:00',
+				clientName: '田中花子',
+				serviceTypeName: '生活支援',
+				toStaffName: '鈴木太郎',
+			},
+		},
+		{
+			type: 'update_shift_time' as const,
+			shiftId: TEST_IDS.SCHEDULE_2,
+			startAt: '2026-03-16T09:00:00+09:00',
+			endAt: '2026-03-16T10:00:00+09:00',
+			reason: '利用者都合',
+			_meta: {
+				shiftDate: '2026-03-16',
+				shiftStartTime: '09:00',
+				shiftEndTime: '10:00',
+				clientName: '田中花子',
+				serviceTypeName: '生活支援',
+			},
+		},
+	],
+};
+
 describe('BatchProposalConfirmCard', () => {
 	it('初期表示では全提案が承認状態で表示される', () => {
 		render(
@@ -91,5 +124,131 @@ describe('BatchProposalConfirmCard', () => {
 		await user.click(screen.getByRole('button', { name: 'キャンセル' }));
 
 		expect(onCancel).toHaveBeenCalledTimes(1);
+	});
+
+	describe('_meta なし（フォールバック表示）', () => {
+		it('change_shift_staff は UUID ベースのフォールバック表示になる', () => {
+			render(
+				<BatchProposalConfirmCard
+					proposal={proposal}
+					onConfirm={vi.fn()}
+					onCancel={vi.fn()}
+				/>,
+			);
+
+			expect(
+				screen.getByText(
+					`shiftId: ${TEST_IDS.SCHEDULE_1} / toStaffId: ${TEST_IDS.STAFF_2}`,
+				),
+			).toBeInTheDocument();
+		});
+
+		it('update_shift_time は startAt / endAt のフォールバック表示になる', () => {
+			render(
+				<BatchProposalConfirmCard
+					proposal={proposal}
+					onConfirm={vi.fn()}
+					onCancel={vi.fn()}
+				/>,
+			);
+
+			expect(
+				screen.getByText(
+					'2026-03-16T09:00:00+09:00 → 2026-03-16T10:00:00+09:00',
+				),
+			).toBeInTheDocument();
+		});
+	});
+
+	describe('_meta あり（人間可読表示）', () => {
+		it('change_shift_staff は日付・利用者名・時間・担当者名を表示する', () => {
+			render(
+				<BatchProposalConfirmCard
+					proposal={proposalWithMeta}
+					onConfirm={vi.fn()}
+					onCancel={vi.fn()}
+				/>,
+			);
+
+			expect(
+				screen.getByText('2026-03-16 田中花子様 09:00〜10:00 → 鈴木太郎'),
+			).toBeInTheDocument();
+		});
+
+		it('update_shift_time は日付・時間帯を表示する', () => {
+			render(
+				<BatchProposalConfirmCard
+					proposal={proposalWithMeta}
+					onConfirm={vi.fn()}
+					onCancel={vi.fn()}
+				/>,
+			);
+
+			expect(screen.getByText('2026-03-16 09:00〜10:00')).toBeInTheDocument();
+		});
+
+		it('clientName が未設定の場合は「利用者不明」を表示する', () => {
+			const proposalNoClient = {
+				proposals: [
+					{
+						type: 'change_shift_staff' as const,
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_2,
+						reason: '欠勤対応',
+						_meta: {
+							shiftDate: '2026-03-16',
+							shiftStartTime: '09:00',
+							shiftEndTime: '10:00',
+							toStaffName: '鈴木太郎',
+						},
+					},
+				],
+			};
+
+			render(
+				<BatchProposalConfirmCard
+					proposal={proposalNoClient}
+					onConfirm={vi.fn()}
+					onCancel={vi.fn()}
+				/>,
+			);
+
+			expect(
+				screen.getByText('2026-03-16 利用者不明様 09:00〜10:00 → 鈴木太郎'),
+			).toBeInTheDocument();
+		});
+
+		it('toStaffName が未設定の場合は toStaffId を表示する', () => {
+			const proposalNoStaffName = {
+				proposals: [
+					{
+						type: 'change_shift_staff' as const,
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_2,
+						reason: '欠勤対応',
+						_meta: {
+							shiftDate: '2026-03-16',
+							shiftStartTime: '09:00',
+							shiftEndTime: '10:00',
+							clientName: '田中花子',
+						},
+					},
+				],
+			};
+
+			render(
+				<BatchProposalConfirmCard
+					proposal={proposalNoStaffName}
+					onConfirm={vi.fn()}
+					onCancel={vi.fn()}
+				/>,
+			);
+
+			expect(
+				screen.getByText(
+					`2026-03-16 田中花子様 09:00〜10:00 → ${TEST_IDS.STAFF_2}`,
+				),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.test.tsx
@@ -175,7 +175,7 @@ describe('BatchProposalConfirmCard', () => {
 			).toBeInTheDocument();
 		});
 
-		it('update_shift_time は日付・時間帯を表示する', () => {
+		it('update_shift_time は日付・利用者名・時間帯を表示する', () => {
 			render(
 				<BatchProposalConfirmCard
 					proposal={proposalWithMeta}
@@ -184,7 +184,40 @@ describe('BatchProposalConfirmCard', () => {
 				/>,
 			);
 
-			expect(screen.getByText('2026-03-16 09:00〜10:00')).toBeInTheDocument();
+			expect(
+				screen.getByText('2026-03-16 田中花子様 09:00〜10:00'),
+			).toBeInTheDocument();
+		});
+
+		it('update_shift_time で clientName が未設定の場合は「利用者不明」を表示する', () => {
+			const proposalNoClientForUpdate = {
+				proposals: [
+					{
+						type: 'update_shift_time' as const,
+						shiftId: TEST_IDS.SCHEDULE_2,
+						startAt: '2026-03-16T09:00:00+09:00',
+						endAt: '2026-03-16T10:00:00+09:00',
+						reason: '利用者都合',
+						_meta: {
+							shiftDate: '2026-03-16',
+							shiftStartTime: '09:00',
+							shiftEndTime: '10:00',
+						},
+					},
+				],
+			};
+
+			render(
+				<BatchProposalConfirmCard
+					proposal={proposalNoClientForUpdate}
+					onConfirm={vi.fn()}
+					onCancel={vi.fn()}
+				/>,
+			);
+
+			expect(
+				screen.getByText('2026-03-16 利用者不明様 09:00〜10:00'),
+			).toBeInTheDocument();
 		});
 
 		it('clientName が未設定の場合は「利用者不明」を表示する', () => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.test.tsx
@@ -283,5 +283,41 @@ describe('BatchProposalConfirmCard', () => {
 				),
 			).toBeInTheDocument();
 		});
+
+		it('update_shift_time は _meta.shiftStartTime/shiftEndTime でなく proposal.startAt/endAt の時刻を表示する', () => {
+			// _meta の shiftStartTime/shiftEndTime (DB 元の値) と
+			// proposal.startAt/endAt (変更後の値) が異なる場合、
+			// proposal.startAt/endAt の時刻が表示されること
+			const proposalWithDifferentTimes = {
+				proposals: [
+					{
+						type: 'update_shift_time' as const,
+						shiftId: TEST_IDS.SCHEDULE_2,
+						startAt: '2026-03-16T11:00:00+09:00',
+						endAt: '2026-03-16T12:00:00+09:00',
+						reason: '利用者都合',
+						_meta: {
+							shiftDate: '2026-03-16',
+							shiftStartTime: '09:00', // DB 元の値（古い）
+							shiftEndTime: '10:00', // DB 元の値（古い）
+							clientName: '田中花子',
+						},
+					},
+				],
+			};
+
+			render(
+				<BatchProposalConfirmCard
+					proposal={proposalWithDifferentTimes}
+					onConfirm={vi.fn()}
+					onCancel={vi.fn()}
+				/>,
+			);
+
+			// proposal.startAt/endAt の時刻 (11:00〜12:00) が表示される
+			expect(
+				screen.getByText('2026-03-16 田中花子様 11:00〜12:00'),
+			).toBeInTheDocument();
+		});
 	});
 });

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.tsx
@@ -38,8 +38,10 @@ const createProposalDescription = (
 	}
 
 	if (proposal._meta) {
-		const { shiftDate, shiftStartTime, shiftEndTime } = proposal._meta;
-		return `${shiftDate} ${shiftStartTime}〜${shiftEndTime}`;
+		const { shiftDate, shiftStartTime, shiftEndTime, clientName } =
+			proposal._meta;
+		const displayName = clientName ?? '利用者不明';
+		return `${shiftDate} ${displayName}様 ${shiftStartTime}〜${shiftEndTime}`;
 	}
 
 	return `${proposal.startAt} → ${proposal.endAt}`;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.tsx
@@ -18,6 +18,12 @@ const OPERATION_LABELS: Record<AiChatMutationProposal['type'], string> = {
 	update_shift_time: '時間変更',
 };
 
+/**
+ * ISO 8601 オフセット付き文字列（例: "2026-03-16T09:00:00+09:00"）から
+ * HH:mm を抽出する。T の直後の時刻部分はオフセット時刻そのもの。
+ */
+const isoToHHmm = (isoString: string): string => isoString.slice(11, 16);
+
 const createProposalDescription = (
 	proposal: AiChatMutationProposal,
 ): string => {
@@ -38,10 +44,11 @@ const createProposalDescription = (
 	}
 
 	if (proposal._meta) {
-		const { shiftDate, shiftStartTime, shiftEndTime, clientName } =
-			proposal._meta;
+		const { shiftDate, clientName } = proposal._meta;
 		const displayName = clientName ?? '利用者不明';
-		return `${shiftDate} ${displayName}様 ${shiftStartTime}〜${shiftEndTime}`;
+		const startTime = isoToHHmm(proposal.startAt);
+		const endTime = isoToHHmm(proposal.endAt);
+		return `${shiftDate} ${displayName}様 ${startTime}〜${endTime}`;
 	}
 
 	return `${proposal.startAt} → ${proposal.endAt}`;

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.tsx
@@ -22,7 +22,24 @@ const createProposalDescription = (
 	proposal: AiChatMutationProposal,
 ): string => {
 	if (proposal.type === 'change_shift_staff') {
+		if (proposal._meta) {
+			const {
+				shiftDate,
+				shiftStartTime,
+				shiftEndTime,
+				clientName,
+				toStaffName,
+			} = proposal._meta;
+			const displayName = clientName ?? '利用者不明';
+			const staffDisplay = toStaffName ?? proposal.toStaffId;
+			return `${shiftDate} ${displayName}様 ${shiftStartTime}〜${shiftEndTime} → ${staffDisplay}`;
+		}
 		return `shiftId: ${proposal.shiftId} / toStaffId: ${proposal.toStaffId}`;
+	}
+
+	if (proposal._meta) {
+		const { shiftDate, shiftStartTime, shiftEndTime } = proposal._meta;
+		return `${shiftDate} ${shiftStartTime}〜${shiftEndTime}`;
 	}
 
 	return `${proposal.startAt} → ${proposal.endAt}`;

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -3593,6 +3593,42 @@ describe('POST /api/chat/shift-adjustment', () => {
 					consoleErrorSpy.mockRestore();
 				}
 			});
+
+			it('findByIds で shiftId が見つからない場合 → AI 提供の _meta を除去して返す', async () => {
+				// findByIds が空を返す（shiftId が DB に存在しない）
+				mockShiftRepositoryFindByIds.mockResolvedValue([]);
+				mockStaffRepositoryFindByIds.mockResolvedValue([]);
+
+				const execute = await getExecute();
+
+				const result = await execute?.({
+					proposals: [
+						{
+							type: 'change_shift_staff',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							toStaffId: TEST_IDS.STAFF_2,
+							_meta: {
+								shiftDate: '2026-03-16',
+								shiftStartTime: '09:00',
+								shiftEndTime: '10:00',
+								clientName: 'AI提供の利用者名',
+								toStaffName: 'AI提供のスタッフ名',
+							},
+						},
+					],
+				});
+
+				// _meta が除去されていること
+				expect(result).toEqual({
+					proposals: [
+						{
+							type: 'change_shift_staff',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							toStaffId: TEST_IDS.STAFF_2,
+						},
+					],
+				});
+			});
 		});
 	});
 });

--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -3379,6 +3379,77 @@ describe('POST /api/chat/shift-adjustment', () => {
 				}
 			});
 
+			it('shiftContext あり（update_shift_time）→ _meta の shiftStartTime/shiftEndTime/shiftDate が proposal.startAt/endAt から生成される', async () => {
+				// getExecute のシフトコンテキストは startTime:'09:00', endTime:'10:00', date:'2026-03-16'
+				// proposal.startAt/endAt は異なる時刻 (11:00〜12:00) を指定
+				mockShiftMaybeSingle.mockResolvedValue({
+					data: { id: TEST_IDS.SCHEDULE_1 },
+					error: null,
+				});
+
+				const execute = await getExecute({ clientName: '利用者A' });
+
+				const result = await (
+					execute as unknown as (input: unknown) => Promise<unknown>
+				)?.({
+					type: 'update_shift_time',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					startAt: '2026-03-16T11:00:00+09:00',
+					endAt: '2026-03-16T12:00:00+09:00',
+				});
+
+				expect(result).toEqual({
+					type: 'update_shift_time',
+					shiftId: TEST_IDS.SCHEDULE_1,
+					startAt: '2026-03-16T11:00:00+09:00',
+					endAt: '2026-03-16T12:00:00+09:00',
+					_meta: {
+						shiftDate: '2026-03-16',
+						shiftStartTime: '11:00',
+						shiftEndTime: '12:00',
+						clientName: '利用者A',
+						serviceTypeName: '生活支援',
+					},
+				});
+			});
+
+			it('shiftContext あり + findById がエラーをスロー + AI 提供 _meta あり → _meta を除去して返す（フォールバック）', async () => {
+				mockStaffRepositoryFindById.mockRejectedValue(
+					new Error('DB connection error'),
+				);
+
+				const consoleErrorSpy = vi
+					.spyOn(console, 'error')
+					.mockImplementation(() => undefined);
+
+				try {
+					const execute = await getExecute();
+
+					const result = await (
+						execute as unknown as (input: unknown) => Promise<unknown>
+					)?.({
+						type: 'change_shift_staff',
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_1,
+						_meta: {
+							shiftDate: '2026-03-16',
+							shiftStartTime: '09:00',
+							shiftEndTime: '10:00',
+							clientName: 'AI提供の利用者名',
+						},
+					});
+
+					// AI 提供の _meta が除去されること
+					expect(result).toEqual({
+						type: 'change_shift_staff',
+						shiftId: TEST_IDS.SCHEDULE_1,
+						toStaffId: TEST_IDS.STAFF_1,
+					});
+				} finally {
+					consoleErrorSpy.mockRestore();
+				}
+			});
+
 			it('shiftContext あり + allowlistedStaffIds に toStaffId が含まれない → findById が呼ばれず toStaffName が付与されない（Thread 3）', async () => {
 				// allowlistedStaffIds に STAFF_2 のみ含む状態で STAFF_1 を指定
 				const request = new Request(
@@ -3592,6 +3663,103 @@ describe('POST /api/chat/shift-adjustment', () => {
 				} finally {
 					consoleErrorSpy.mockRestore();
 				}
+			});
+
+			it('ShiftRepository.findByIds がエラーをスロー + AI 提供 _meta あり → _meta を除去して返す（フォールバック）', async () => {
+				mockShiftRepositoryFindByIds.mockRejectedValue(
+					new Error('DB connection error'),
+				);
+
+				const consoleErrorSpy = vi
+					.spyOn(console, 'error')
+					.mockImplementation(() => undefined);
+
+				try {
+					const execute = await getExecute();
+
+					const result = await execute?.({
+						proposals: [
+							{
+								type: 'change_shift_staff' as const,
+								shiftId: TEST_IDS.SCHEDULE_1,
+								toStaffId: TEST_IDS.STAFF_2,
+								_meta: {
+									shiftDate: '2026-03-16',
+									shiftStartTime: '09:00',
+									shiftEndTime: '10:00',
+									clientName: 'AI提供の利用者名',
+									toStaffName: 'AI提供のスタッフ名',
+								},
+							},
+						],
+					});
+
+					// AI 提供の _meta が除去されること
+					expect(result).toEqual({
+						proposals: [
+							{
+								type: 'change_shift_staff',
+								shiftId: TEST_IDS.SCHEDULE_1,
+								toStaffId: TEST_IDS.STAFF_2,
+							},
+						],
+					});
+				} finally {
+					consoleErrorSpy.mockRestore();
+				}
+			});
+
+			it('findByIds 成功（update_shift_time）→ _meta の shiftStartTime/shiftEndTime/shiftDate が proposal.startAt/endAt から生成される', async () => {
+				mockShiftRepositoryFindByIds.mockResolvedValue([
+					{
+						id: TEST_IDS.SCHEDULE_1,
+						client_id: TEST_IDS.CLIENT_1,
+						service_type_id: 'life-support',
+						staff_id: TEST_IDS.STAFF_1,
+						date: new Date('2026-03-16T00:00:00+09:00'),
+						time: {
+							start: { hour: 9, minute: 0 }, // DB 元の時刻（変更前）
+							end: { hour: 10, minute: 0 },
+						},
+						status: 'scheduled',
+						is_unassigned: false,
+						created_at: new Date('2024-01-01T00:00:00.000Z'),
+						updated_at: new Date('2024-01-01T00:00:00.000Z'),
+						client_name: '利用者A',
+					},
+				]);
+				mockStaffRepositoryFindByIds.mockResolvedValue([]);
+
+				const execute = await getExecute();
+
+				const result = await execute?.({
+					proposals: [
+						{
+							type: 'update_shift_time',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							startAt: '2026-03-16T11:00:00+09:00',
+							endAt: '2026-03-16T12:00:00+09:00',
+						},
+					],
+				});
+
+				expect(result).toEqual({
+					proposals: [
+						{
+							type: 'update_shift_time',
+							shiftId: TEST_IDS.SCHEDULE_1,
+							startAt: '2026-03-16T11:00:00+09:00',
+							endAt: '2026-03-16T12:00:00+09:00',
+							_meta: {
+								shiftDate: '2026-03-16',
+								shiftStartTime: '11:00',
+								shiftEndTime: '12:00',
+								clientName: '利用者A',
+								serviceTypeName: '生活支援',
+							},
+						},
+					],
+				});
 			});
 
 			it('findByIds で shiftId が見つからない場合 → AI 提供の _meta を除去して返す', async () => {

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -820,7 +820,10 @@ const createProposeShiftChangesTool = (
 
 				const proposalsWithMeta = proposal.proposals.map((p) => {
 					const shift = shiftMap.get(p.shiftId);
-					if (!shift) return p;
+					if (!shift) {
+						const { _meta: _ignored, ...pWithoutMeta } = p;
+						return pWithoutMeta;
+					}
 
 					const meta: ShiftMeta = {
 						shiftDate: formatJstDateString(shift.date),

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -7,6 +7,7 @@ import { createSearchStaffsTool } from '@/backend/tools/searchStaffs';
 import {
 	AiChatMutationBatchProposalSchema,
 	AiChatMutationProposalSchema,
+	type ShiftMeta,
 } from '@/models/aiChatMutationProposal';
 import { createJstDateStringSchema } from '@/models/valueObjects/jstDate';
 import {
@@ -513,19 +514,6 @@ ${shiftLines.join('\n')}${buildShiftSelectionPrompt(context.shifts.length)}`;
 
 const isRecord = (input: unknown): input is Record<string, unknown> =>
 	typeof input === 'object' && input !== null;
-
-/**
- * AI 参照専用のシフトメタ情報
- * UI 確定処理・永続化には影響しない
- */
-type ShiftMeta = {
-	shiftDate: string; // "2026-05-10"
-	shiftStartTime: string; // "09:00"
-	shiftEndTime: string; // "10:00"
-	clientName?: string;
-	serviceTypeName: string;
-	toStaffName?: string; // change_shift_staff のみ
-};
 
 const hasNestedToolInput = (
 	input: Record<string, unknown>,

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -599,6 +599,17 @@ const extractToStaffId = (
 const getContextStaffIds = (context: ChatRequest['context']): string[] =>
 	context?.staffIds ?? [];
 
+/**
+ * ISO 8601 オフセット付き文字列（例: "2026-03-16T09:00:00+09:00"）から
+ * HH:mm を抽出する。T の直後の時刻部分はオフセット時刻そのもの。
+ */
+const isoToHHmm = (isoString: string): string => isoString.slice(11, 16);
+
+/**
+ * ISO 8601 オフセット付き文字列から YYYY-MM-DD を抽出する。
+ */
+const isoToDate = (isoString: string): string => isoString.slice(0, 10);
+
 /** proposeShiftChange ツール用の _meta を構築する（失敗時は undefined を返す） */
 const buildProposeShiftChangeMeta = async (
 	proposal: z.infer<typeof AiChatMutationProposalSchema>,
@@ -609,10 +620,20 @@ const buildProposeShiftChangeMeta = async (
 	const shiftContext = shiftContextMap.get(proposal.shiftId);
 	if (!shiftContext) return undefined;
 
+	// update_shift_time は変更後の時刻 (proposal.startAt/endAt) を _meta に使う
+	// change_shift_staff は DB のシフト情報 (shiftContext) を使う
+	const isUpdateShiftTime = proposal.type === 'update_shift_time';
+
 	const baseMeta: ShiftMeta = {
-		shiftDate: shiftContext.date,
-		shiftStartTime: shiftContext.startTime,
-		shiftEndTime: shiftContext.endTime,
+		shiftDate: isUpdateShiftTime
+			? isoToDate(proposal.startAt)
+			: shiftContext.date,
+		shiftStartTime: isUpdateShiftTime
+			? isoToHHmm(proposal.startAt)
+			: shiftContext.startTime,
+		shiftEndTime: isUpdateShiftTime
+			? isoToHHmm(proposal.endAt)
+			: shiftContext.endTime,
 		clientName: shiftContext.clientName,
 		serviceTypeName: ServiceTypeLabels[shiftContext.serviceTypeId],
 	};
@@ -733,7 +754,13 @@ const createProposeShiftChangeTool = (
 				);
 			}
 
-			return meta ? { ...proposal, _meta: meta } : proposal;
+			if (meta) {
+				return { ...proposal, _meta: meta };
+			}
+
+			// _meta 構築失敗時は AI 提供の _meta も除去してフォールバック返却
+			const { _meta: _ignored, ...proposalWithoutMeta } = proposal;
+			return proposalWithoutMeta;
 		},
 	});
 };
@@ -825,10 +852,20 @@ const createProposeShiftChangesTool = (
 						return pWithoutMeta;
 					}
 
+					// update_shift_time は変更後の時刻 (p.startAt/endAt) を _meta に使う
+					// change_shift_staff は DB のシフト情報を使う
+					const isUpdateShiftTime = p.type === 'update_shift_time';
+
 					const meta: ShiftMeta = {
-						shiftDate: formatJstDateString(shift.date),
-						shiftStartTime: timeObjectToString(shift.time.start),
-						shiftEndTime: timeObjectToString(shift.time.end),
+						shiftDate: isUpdateShiftTime
+							? isoToDate(p.startAt)
+							: formatJstDateString(shift.date),
+						shiftStartTime: isUpdateShiftTime
+							? isoToHHmm(p.startAt)
+							: timeObjectToString(shift.time.start),
+						shiftEndTime: isUpdateShiftTime
+							? isoToHHmm(p.endAt)
+							: timeObjectToString(shift.time.end),
 						clientName: shift.client_name,
 						serviceTypeName: ServiceTypeLabels[shift.service_type_id],
 					};
@@ -851,7 +888,12 @@ const createProposeShiftChangesTool = (
 					logContext,
 					{ toolName: 'proposeShiftChanges' },
 				);
-				return proposal;
+				// AI 提供の _meta も除去してフォールバック返却
+				const proposalsWithoutMeta = proposal.proposals.map((p) => {
+					const { _meta: _ignored, ...pWithoutMeta } = p;
+					return pWithoutMeta;
+				});
+				return { proposals: proposalsWithoutMeta };
 			}
 		},
 	});

--- a/src/models/aiChatMutationProposal.test.ts
+++ b/src/models/aiChatMutationProposal.test.ts
@@ -10,7 +10,50 @@ import {
 	ExecuteAiChatMutationBatchResultSchema,
 	ExecuteAiChatMutationInputSchema,
 	ProposalAllowlistSchema,
+	ShiftMetaSchema,
 } from './aiChatMutationProposal';
+
+describe('ShiftMetaSchema', () => {
+	it('正常なフォーマットを受け入れる', () => {
+		const result = ShiftMetaSchema.safeParse({
+			shiftDate: '2026-03-16',
+			shiftStartTime: '09:00',
+			shiftEndTime: '10:00',
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('shiftDate が日付フォーマット（YYYY-MM-DD）でない場合はエラー', () => {
+		const result = ShiftMetaSchema.safeParse({
+			shiftDate: '2026/03/16',
+			shiftStartTime: '09:00',
+			shiftEndTime: '10:00',
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it('shiftStartTime が HH:MM フォーマットでない場合はエラー', () => {
+		const result = ShiftMetaSchema.safeParse({
+			shiftDate: '2026-03-16',
+			shiftStartTime: '9:00',
+			shiftEndTime: '10:00',
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it('shiftEndTime が HH:MM フォーマットでない場合はエラー', () => {
+		const result = ShiftMetaSchema.safeParse({
+			shiftDate: '2026-03-16',
+			shiftStartTime: '09:00',
+			shiftEndTime: '10:00:00',
+		});
+
+		expect(result.success).toBe(false);
+	});
+});
 
 describe('AiChatMutationProposalSchema', () => {
 	it('change_shift_staff proposal を受け入れる', () => {

--- a/src/models/aiChatMutationProposal.ts
+++ b/src/models/aiChatMutationProposal.ts
@@ -17,9 +17,9 @@ export const ALLOWLIST_MAX_STAFF_IDS = 500;
  * UI 確認表示に使用される。確定処理・永続化には影響しない。
  */
 export const ShiftMetaSchema = z.object({
-	shiftDate: z.string(),
-	shiftStartTime: z.string(),
-	shiftEndTime: z.string(),
+	shiftDate: z.string().date(),
+	shiftStartTime: z.string().regex(/^\d{2}:\d{2}$/),
+	shiftEndTime: z.string().regex(/^\d{2}:\d{2}$/),
 	clientName: z.string().optional(),
 	serviceTypeName: z.string().optional(),
 	toStaffName: z.string().optional(),

--- a/src/models/aiChatMutationProposal.ts
+++ b/src/models/aiChatMutationProposal.ts
@@ -12,11 +12,25 @@ export const AiChatMutationProposalTypeSchema = z.enum(
 export const ALLOWLIST_MAX_SHIFT_IDS = 200;
 export const ALLOWLIST_MAX_STAFF_IDS = 500;
 
+/**
+ * AI 参照専用のシフトメタ情報
+ * UI 確認表示に使用される。確定処理・永続化には影響しない。
+ */
+export const ShiftMetaSchema = z.object({
+	shiftDate: z.string(),
+	shiftStartTime: z.string(),
+	shiftEndTime: z.string(),
+	clientName: z.string().optional(),
+	serviceTypeName: z.string().optional(),
+	toStaffName: z.string().optional(),
+});
+
 const ChangeShiftStaffProposalSchema = z.object({
 	type: z.literal('change_shift_staff'),
 	shiftId: z.uuid(),
 	toStaffId: z.uuid(),
 	reason: z.string().trim().min(1).optional(),
+	_meta: ShiftMetaSchema.optional(),
 });
 
 const UpdateShiftTimeProposalSchema = z
@@ -28,6 +42,7 @@ const UpdateShiftTimeProposalSchema = z
 		startAt: z.string().datetime({ offset: true }),
 		endAt: z.string().datetime({ offset: true }),
 		reason: z.string().trim().min(1).optional(),
+		_meta: ShiftMetaSchema.optional(),
 	})
 	.superRefine((proposal, ctx) => {
 		if (new Date(proposal.startAt) >= new Date(proposal.endAt)) {
@@ -120,6 +135,8 @@ export const ExecuteAiChatMutationBatchResultSchema = z.object({
 export type AiChatMutationProposal = z.infer<
 	typeof AiChatMutationProposalSchema
 >;
+
+export type ShiftMeta = z.infer<typeof ShiftMetaSchema>;
 
 export type ProposalAllowlist = z.infer<typeof ProposalAllowlistSchema>;
 


### PR DESCRIPTION
## 背景・目的

AI シフト提案の「一括変更提案」確定確認ダイアログ（BatchProposalConfirmCard）で、シフトIDや担当者IDがそのまま表示されていた問題を修正する。`_meta` フィールドを活用して、利用者名・担当者名・日付・時間帯を表示するようにした。

## 主な変更点

### 1. `src/models/aiChatMutationProposal.ts`
- `ShiftMetaSchema` / `ShiftMeta` 型を追加（`date` と時刻は `z.string().date()` / `z.string().regex` でフォーマット検証）
- `ChangeShiftStaffProposalSchema` / `UpdateShiftTimeProposalSchema` に `_meta?: ShiftMeta` を追加

### 2. `src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/BatchProposalConfirmCard/BatchProposalConfirmCard.tsx`
- `change_shift_staff`：`_meta` があれば「2025-01-15 山田太郎様 → 鈴木花子」形式で表示、なければ従来のID表示にフォールバック
- `update_shift_time`：`_meta` があれば「2025-01-15 山田太郎様 09:00～17:00」形式で clientName も含めて表示
- 10件のテスト追加・`WithMeta` Story 追加

### 3. `src/app/api/chat/shift-adjustment/route.ts`
- ローカル `ShiftMeta` 型を削除し、共通 `ShiftMeta` を import
- `proposeShiftChanges` で `shiftMap.get(p.shiftId)` がヒットしない場合に AI 提供の `_meta` を destructuring で除去（不正メタ情報の流入防止）

## テスト

- 全 1291 テスト pass ✅