### PR TITLE
ci: lint と prettier check を CI に追加する

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Lint (ESLint)
+        run: pnpm lint
+
+      - name: Format check (Prettier)
+        run: pnpm exec prettier --check .
+
       - name: Install Playwright
         run: pnpm exec playwright install --with-deps
       - name: Run Vitest

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "next dev",
 		"build": "next build",
 		"start": "next start",
-		"lint": "eslint",
+		"lint": "eslint .",
 		"test": "vitest",
 		"typecheck": "tsc --noEmit",
 		"test:ut": "vitest --project unit",


### PR DESCRIPTION
## 概要

CI ワークフロー（`.github/workflows/main.yml`）に ESLint と Prettier のチェックステップを追加しました。

Eslint`package.json` の `lint` スクリプトを `eslint` → `eslint .` に修正しました。 v9 ではターゲットパスを明示しないと検査が実行され

## 変更内容

### `.github/workflows/main.yml`
- **Lint (ESLint)** ステップを追加: `pnpm lint` を実行
- **Format check (Prettier)** ステップを追加: `pnpm exec prettier --check .` を実行

### `package.json`
- `lint` スクリプトを `eslint` → `eslint .` に変更（ESLint v9 でターゲットパス未指定だと検査が走らないため）

PR 時にコードスタイルの一貫性を自動検証できるようになりまecho

## 関連 Issue

Closes #182