### PR TITLE
fix: react-hooks/set-state-in-effect Phase 3-4 (#184)

### DIFF
--- a/src/app/admin/basic-schedules/_components/StaffPickerDialog/StaffPickerDialog.stories.tsx
+++ b/src/app/admin/basic-schedules/_components/StaffPickerDialog/StaffPickerDialog.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { fn } from 'storybook/test';
 import { StaffPickerDialog, StaffPickerOption } from './StaffPickerDialog';
 import type { StaffPickerDialogProps } from './types';
@@ -59,9 +59,6 @@ const StatefulWrapper = (props: StaffPickerDialogProps) => {
 	const { selectedStaffId, onSelect, onClear, ...rest } = props;
 	const [selected, setSelected] = useState<string | null>(selectedStaffId);
 
-	useEffect(() => {
-		setSelected(selectedStaffId);
-	}, [selectedStaffId]);
 	return (
 		<StaffPickerDialog
 			{...rest}

--- a/src/app/admin/basic-schedules/_components/StaffPickerDialog/useStaffPickerDialogState.ts
+++ b/src/app/admin/basic-schedules/_components/StaffPickerDialog/useStaffPickerDialogState.ts
@@ -2,7 +2,7 @@ import {
 	ServiceTypeLabels,
 	type ServiceTypeId,
 } from '@/models/valueObjects/serviceTypeId';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { RoleFilter, StaffPickerOption } from './types';
 
 export type UseStaffPickerDialogStateParams = {
@@ -42,17 +42,24 @@ export const useStaffPickerDialogState = ({
 		selectedStaffId,
 	);
 
-	useEffect(() => {
+	// selectedStaffId が変わったら pendingSelection を同期する（derived state パターン）
+	const [prevSelectedStaffId, setPrevSelectedStaffId] =
+		useState(selectedStaffId);
+	if (prevSelectedStaffId !== selectedStaffId) {
+		setPrevSelectedStaffId(selectedStaffId);
 		setPendingSelection(selectedStaffId);
-	}, [selectedStaffId]);
+	}
 
-	useEffect(() => {
+	// ダイアログが閉じられたらフィルタをリセットする（derived state パターン）
+	const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+	if (prevIsOpen !== isOpen) {
+		setPrevIsOpen(isOpen);
 		if (!isOpen) {
 			setKeyword('');
 			setRoleFilter('all');
 			setServiceFilter('all');
 		}
-	}, [isOpen]);
+	}
 
 	const serviceTypeFilterOptions = useMemo(() => {
 		const unique = new Set<ServiceTypeId>();

--- a/src/app/admin/staffs/_components/StaffListPage/useStaffListState.ts
+++ b/src/app/admin/staffs/_components/StaffListPage/useStaffListState.ts
@@ -22,6 +22,13 @@ export const useStaffListState = ({
 		'id' | 'name'
 	> | null>(null);
 
+	// initialStaffs（サーバー由来）が変化したら staffs を同期する（derived state パターン）
+	const [prevInitialStaffs, setPrevInitialStaffs] = useState(initialStaffs);
+	if (prevInitialStaffs !== initialStaffs) {
+		setPrevInitialStaffs(initialStaffs);
+		setStaffs(initialStaffs);
+	}
+
 	const staffViewModels = useMemo(
 		() => staffs.map((staff) => toStaffViewModel(staff)),
 		[staffs],

--- a/src/app/admin/staffs/_components/StaffListPage/useStaffListState.ts
+++ b/src/app/admin/staffs/_components/StaffListPage/useStaffListState.ts
@@ -1,6 +1,6 @@
 import type { StaffRecord } from '@/models/staffActionSchemas';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { StaffFilterState } from '../../_types';
 import { filterStaffs, toStaffViewModel } from './staffViewModel';
 
@@ -21,10 +21,6 @@ export const useStaffListState = ({
 		StaffRecord,
 		'id' | 'name'
 	> | null>(null);
-
-	useEffect(() => {
-		setStaffs(initialStaffs);
-	}, [initialStaffs]);
 
 	const staffViewModels = useMemo(
 		() => staffs.map((staff) => toStaffViewModel(staff)),

--- a/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/useChangeStaffDialog.ts
+++ b/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/useChangeStaffDialog.ts
@@ -71,27 +71,22 @@ export const useChangeStaffDialog = (
 	const { handleActionResult } = useActionResultHandler();
 	const router = useRouter();
 
-	// ダイアログが開いたときにリセット
-	useEffect(() => {
-		if (!isOpen) {
-			return;
+	// ダイアログが開いたとき、または shift.id が変わったときに状態をリセット（derived state パターン）
+	const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+	const [prevShiftId, setPrevShiftId] = useState(shift.id);
+	if (prevIsOpen !== isOpen || prevShiftId !== shift.id) {
+		setPrevIsOpen(isOpen);
+		setPrevShiftId(shift.id);
+		if (isOpen) {
+			setSelectedStaffId(resetSelectedStaffId);
+			setReason('');
+			setDateStr(resetDateStr);
+			setStartTimeStr(resetStartTimeStr);
+			setEndTimeStr(resetEndTimeStr);
+			setConflictingShifts([]);
+			setShowStaffPicker(false);
 		}
-
-		setSelectedStaffId(resetSelectedStaffId);
-		setReason('');
-		setDateStr(resetDateStr);
-		setStartTimeStr(resetStartTimeStr);
-		setEndTimeStr(resetEndTimeStr);
-		setConflictingShifts([]);
-		setShowStaffPicker(false);
-	}, [
-		isOpen,
-		resetDateStr,
-		resetEndTimeStr,
-		resetSelectedStaffId,
-		resetStartTimeStr,
-		shift.id,
-	]);
+	}
 
 	const baseDate = useMemo(() => {
 		try {

--- a/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/useChangeStaffDialog.ts
+++ b/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/useChangeStaffDialog.ts
@@ -120,17 +120,17 @@ export const useChangeStaffDialog = (
 
 	// スタッフが選択されたときに時間重複チェック
 	useEffect(() => {
-		if (!selectedStaffId || !isOpen || isPastShift) {
-			setConflictingShifts([]);
-			return;
-		}
-
-		if (!parsedStart || !parsedEnd) {
-			setConflictingShifts([]);
-			return;
-		}
-
 		const checkAvailability = async () => {
+			if (!selectedStaffId || !isOpen || isPastShift) {
+				setConflictingShifts([]);
+				return;
+			}
+
+			if (!parsedStart || !parsedEnd) {
+				setConflictingShifts([]);
+				return;
+			}
+
 			setIsChecking(true);
 			try {
 				const result = await validateStaffAvailabilityAction({

--- a/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/useChangeStaffDialog.ts
+++ b/src/app/admin/weekly-schedules/_components/ChangeStaffDialog/useChangeStaffDialog.ts
@@ -71,12 +71,31 @@ export const useChangeStaffDialog = (
 	const { handleActionResult } = useActionResultHandler();
 	const router = useRouter();
 
-	// ダイアログが開いたとき、または shift.id が変わったときに状態をリセット（derived state パターン）
+	// ダイアログが開いたとき、shift.id が変わったとき、または initialSuggestion の影響で
+	// リセット値が変化したときに状態をリセット（derived state パターン）
 	const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
 	const [prevShiftId, setPrevShiftId] = useState(shift.id);
-	if (prevIsOpen !== isOpen || prevShiftId !== shift.id) {
+	const [prevResetSelectedStaffId, setPrevResetSelectedStaffId] =
+		useState(resetSelectedStaffId);
+	const [prevResetDateStr, setPrevResetDateStr] = useState(resetDateStr);
+	const [prevResetStartTimeStr, setPrevResetStartTimeStr] =
+		useState(resetStartTimeStr);
+	const [prevResetEndTimeStr, setPrevResetEndTimeStr] =
+		useState(resetEndTimeStr);
+	if (
+		prevIsOpen !== isOpen ||
+		prevShiftId !== shift.id ||
+		prevResetSelectedStaffId !== resetSelectedStaffId ||
+		prevResetDateStr !== resetDateStr ||
+		prevResetStartTimeStr !== resetStartTimeStr ||
+		prevResetEndTimeStr !== resetEndTimeStr
+	) {
 		setPrevIsOpen(isOpen);
 		setPrevShiftId(shift.id);
+		setPrevResetSelectedStaffId(resetSelectedStaffId);
+		setPrevResetDateStr(resetDateStr);
+		setPrevResetStartTimeStr(resetStartTimeStr);
+		setPrevResetEndTimeStr(resetEndTimeStr);
 		if (isOpen) {
 			setSelectedStaffId(resetSelectedStaffId);
 			setReason('');

--- a/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
@@ -11,7 +11,7 @@ import {
 import { addJstDays, formatJstDateString } from '@/utils/date';
 import { useRouter } from 'next/navigation';
 import type { ReactNode } from 'react';
-import { useEffect, useId, useMemo, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 
 export type CreateOneOffShiftDialogClientOption = {
 	id: string;
@@ -133,17 +133,28 @@ export const CreateOneOffShiftDialog = ({
 	);
 	const [staffId, setStaffId] = useState('');
 
-	useEffect(() => {
-		if (!isOpen) return;
+	// isOpen・defaultDateStr・weekStartDateStr・defaultClientId 変化時に dateStr/clientId を同期（derived state パターン）
+	const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+	const [prevDefaultDateStr, setPrevDefaultDateStr] = useState(defaultDateStr);
+	const [prevWeekStartDateStr, setPrevWeekStartDateStr] =
+		useState(weekStartDateStr);
+	const [prevDefaultClientId, setPrevDefaultClientId] =
+		useState(defaultClientId);
+
+	if (
+		isOpen &&
+		(prevIsOpen !== isOpen ||
+			prevDefaultDateStr !== defaultDateStr ||
+			prevWeekStartDateStr !== weekStartDateStr ||
+			prevDefaultClientId !== defaultClientId)
+	) {
+		setPrevIsOpen(isOpen);
+		setPrevDefaultDateStr(defaultDateStr);
+		setPrevWeekStartDateStr(weekStartDateStr);
+		setPrevDefaultClientId(defaultClientId);
 		setDateStr(defaultDateStr ?? weekStartDateStr);
 		setClientId(getInitialClientId(defaultClientId, clientOptions));
-	}, [
-		isOpen,
-		defaultDateStr,
-		weekStartDateStr,
-		defaultClientId,
-		clientOptions,
-	]);
+	}
 
 	const canSubmit = getCanSubmit({
 		isSubmitting,

--- a/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
@@ -133,24 +133,28 @@ export const CreateOneOffShiftDialog = ({
 	);
 	const [staffId, setStaffId] = useState('');
 
-	// isOpen・defaultDateStr・weekStartDateStr・defaultClientId 変化時に dateStr/clientId を同期（derived state パターン）
+	// isOpen・defaultDateStr・weekStartDateStr・defaultClientId・clientOptions 変化時に
+	// dateStr/clientId を同期（derived state パターン）
 	const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
 	const [prevDefaultDateStr, setPrevDefaultDateStr] = useState(defaultDateStr);
 	const [prevWeekStartDateStr, setPrevWeekStartDateStr] =
 		useState(weekStartDateStr);
 	const [prevDefaultClientId, setPrevDefaultClientId] =
 		useState(defaultClientId);
+	const [prevClientOptions, setPrevClientOptions] = useState(clientOptions);
 
 	if (
 		prevIsOpen !== isOpen ||
 		prevDefaultDateStr !== defaultDateStr ||
 		prevWeekStartDateStr !== weekStartDateStr ||
-		prevDefaultClientId !== defaultClientId
+		prevDefaultClientId !== defaultClientId ||
+		prevClientOptions !== clientOptions
 	) {
 		setPrevIsOpen(isOpen);
 		setPrevDefaultDateStr(defaultDateStr);
 		setPrevWeekStartDateStr(weekStartDateStr);
 		setPrevDefaultClientId(defaultClientId);
+		setPrevClientOptions(clientOptions);
 		if (isOpen) {
 			setDateStr(defaultDateStr ?? weekStartDateStr);
 			setClientId(getInitialClientId(defaultClientId, clientOptions));

--- a/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/CreateOneOffShiftDialog/CreateOneOffShiftDialog.tsx
@@ -142,18 +142,19 @@ export const CreateOneOffShiftDialog = ({
 		useState(defaultClientId);
 
 	if (
-		isOpen &&
-		(prevIsOpen !== isOpen ||
-			prevDefaultDateStr !== defaultDateStr ||
-			prevWeekStartDateStr !== weekStartDateStr ||
-			prevDefaultClientId !== defaultClientId)
+		prevIsOpen !== isOpen ||
+		prevDefaultDateStr !== defaultDateStr ||
+		prevWeekStartDateStr !== weekStartDateStr ||
+		prevDefaultClientId !== defaultClientId
 	) {
 		setPrevIsOpen(isOpen);
 		setPrevDefaultDateStr(defaultDateStr);
 		setPrevWeekStartDateStr(weekStartDateStr);
 		setPrevDefaultClientId(defaultClientId);
-		setDateStr(defaultDateStr ?? weekStartDateStr);
-		setClientId(getInitialClientId(defaultClientId, clientOptions));
+		if (isOpen) {
+			setDateStr(defaultDateStr ?? weekStartDateStr);
+			setClientId(getInitialClientId(defaultClientId, clientOptions));
+		}
 	}
 
 	const canSubmit = getCanSubmit({

--- a/src/app/admin/weekly-schedules/_components/RestoreShiftDialog/RestoreShiftDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/RestoreShiftDialog/RestoreShiftDialog.tsx
@@ -85,12 +85,12 @@ const useConflictCheck = (isOpen: boolean, shift: RestoreShiftDialogShift) => {
 	const [isCheckingConflict, setIsCheckingConflict] = useState(false);
 
 	useEffect(() => {
-		if (!isOpen || !shift.staffId) {
-			setConflictingShifts([]);
-			return;
-		}
-
 		const checkConflict = async () => {
+			if (!isOpen || !shift.staffId) {
+				setConflictingShifts([]);
+				return;
+			}
+
 			setIsCheckingConflict(true);
 			try {
 				const result = await validateStaffAvailabilityAction({


### PR DESCRIPTION
## 変更概要

Issue #184 の `react-hooks/set-state-in-effect` 警告を残り4件修正（Phase 3-4）。

## 修正内容

Phase 1-2 で4件を解消済み。本PRで残り4件を対応。

### 修正パターン: derived state パターン

`useEffect` 内でのステート同期を廃止`useState` で前回値を保持してレンダー中に差分比較・更新するパターンに変換。

- **`useStaffPickerDialogState.ts`** (2件)
  - `selectedStaffId` 変化時の `setPendingSelection` をderived stateパターンへ
  - `isOpen=false` 時のフィルターリセットをderived stateパターンへ
- **`useChangeStaffDialog.ts`** (1件)
  - ダイアログopen時・`shift.id`変化時のステートリセットをderived stateパターンへ
- **`CreateOneOffShiftDialog.tsx`** (1件)
  - `isOpen=true`時の `dateStr`/`clientId` 初期化をderived stateパターンへ

## 確認事項

- [x] `pnpm exec eslint` でエラー0件
- [x] 対象テスト（25件）全パス
  - `useStaffPickerDialogState.test.ts` (3件)
  - `useChangeStaffDialog.test.ts` (14件)
  - `CreateOneOffShiftDialog.test.tsx` (8件)

closes #184