### PR TITLE
feat: 週次スケジュール画面のデフォルト表示を grid に変更 & ?view= クエ (#188)

### DIFF
--- a/src/app/admin/weekly-schedules/_components/WeeklyScheduleContent/WeeklyScheduleContent.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklyScheduleContent/WeeklyScheduleContent.tsx
@@ -2,16 +2,19 @@ import { getServiceUsersAction } from '@/app/actions/serviceUsers';
 import { listStaffsAction } from '@/app/actions/staffs';
 import { listShiftsAction } from '@/app/actions/weeklySchedules';
 import { addJstDays, formatJstDateString } from '@/utils/date';
+import type { WeeklyViewMode } from '../../helpers';
 import type { CreateOneOffShiftDialogClientOption } from '../CreateOneOffShiftDialog';
 import type { ShiftDisplayRow } from '../ShiftTable';
 import { WeeklySchedulePage } from '../WeeklySchedulePage';
 
 export interface WeeklyScheduleContentProps {
 	weekStartDate: Date;
+	viewMode: WeeklyViewMode;
 }
 
 export const WeeklyScheduleContent = async ({
 	weekStartDate,
+	viewMode,
 }: WeeklyScheduleContentProps) => {
 	const weekEndDate = addJstDays(weekStartDate, 6);
 
@@ -80,6 +83,7 @@ export const WeeklyScheduleContent = async ({
 			initialShifts={shifts}
 			staffOptions={staffOptions}
 			clientOptions={clientOptions}
+			initialViewMode={viewMode}
 		/>
 	);
 };

--- a/src/app/admin/weekly-schedules/_components/WeeklyScheduleContent/WeeklyScheduleContent.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklyScheduleContent/WeeklyScheduleContent.tsx
@@ -2,19 +2,16 @@ import { getServiceUsersAction } from '@/app/actions/serviceUsers';
 import { listStaffsAction } from '@/app/actions/staffs';
 import { listShiftsAction } from '@/app/actions/weeklySchedules';
 import { addJstDays, formatJstDateString } from '@/utils/date';
-import type { WeeklyViewMode } from '../../helpers';
 import type { CreateOneOffShiftDialogClientOption } from '../CreateOneOffShiftDialog';
 import type { ShiftDisplayRow } from '../ShiftTable';
 import { WeeklySchedulePage } from '../WeeklySchedulePage';
 
 export interface WeeklyScheduleContentProps {
 	weekStartDate: Date;
-	viewMode: WeeklyViewMode;
 }
 
 export const WeeklyScheduleContent = async ({
 	weekStartDate,
-	viewMode,
 }: WeeklyScheduleContentProps) => {
 	const weekEndDate = addJstDays(weekStartDate, 6);
 
@@ -83,7 +80,6 @@ export const WeeklyScheduleContent = async ({
 			initialShifts={shifts}
 			staffOptions={staffOptions}
 			clientOptions={clientOptions}
-			initialViewMode={viewMode}
 		/>
 	);
 };

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
@@ -5,12 +5,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
+const mockSearchParamsGet = vi.fn();
 
 vi.mock('next/navigation', () => ({
 	useRouter: () => ({
 		push: mockPush,
 		refresh: mockRefresh,
 	}),
+	useSearchParams: () => ({ get: mockSearchParamsGet }),
 }));
 
 vi.mock('@/app/actions/weeklySchedules', () => ({
@@ -144,6 +146,9 @@ import {
 describe('WeeklySchedulePage (Adjustment entry)', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockSearchParamsGet.mockImplementation((key: string) =>
+			key === 'view' ? 'list' : null,
+		);
 	});
 	const sampleShifts: ShiftDisplayRow[] = [
 		{
@@ -166,7 +171,6 @@ describe('WeeklySchedulePage (Adjustment entry)', () => {
 		initialShifts: sampleShifts,
 		staffOptions: [],
 		clientOptions: [{ id: TEST_IDS.CLIENT_1, name: '田中太郎' }],
-		initialViewMode: 'list',
 	};
 
 	it('ChangeStaffDialog の調整相談ボタンクリックで AdjustmentWizardDialog が開く', async () => {

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.adjustment.test.tsx
@@ -166,6 +166,7 @@ describe('WeeklySchedulePage (Adjustment entry)', () => {
 		initialShifts: sampleShifts,
 		staffOptions: [],
 		clientOptions: [{ id: TEST_IDS.CLIENT_1, name: '田中太郎' }],
+		initialViewMode: 'list',
 	};
 
 	it('ChangeStaffDialog の調整相談ボタンクリックで AdjustmentWizardDialog が開く', async () => {

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.memo.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.memo.test.tsx
@@ -97,6 +97,7 @@ describe('WeeklySchedulePage staffOptions', () => {
 			},
 		],
 		clientOptions: [{ id: TEST_IDS.CLIENT_1, name: '田中太郎' }],
+		initialViewMode: 'list',
 	};
 
 	beforeEach(() => {

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.memo.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.memo.test.tsx
@@ -11,12 +11,14 @@ import {
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
 const capturedStaffIds: string[][] = [];
+const mockSearchParamsGet = vi.fn();
 
 vi.mock('next/navigation', () => ({
 	useRouter: () => ({
 		push: mockPush,
 		refresh: mockRefresh,
 	}),
+	useSearchParams: () => ({ get: mockSearchParamsGet }),
 }));
 
 vi.mock('@/app/actions/weeklySchedules', () => ({
@@ -97,17 +99,19 @@ describe('WeeklySchedulePage staffOptions', () => {
 			},
 		],
 		clientOptions: [{ id: TEST_IDS.CLIENT_1, name: '田中太郎' }],
-		initialViewMode: 'list',
 	};
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		capturedStaffIds.length = 0;
+		mockSearchParamsGet.mockImplementation((key: string) =>
+			key === 'view' ? 'list' : null,
+		);
 	});
 
 	it('再レンダー時もダイアログへ同じスタッフID一覧が渡る', async () => {
 		const user = userEvent.setup();
-		render(<WeeklySchedulePage {...defaultProps} />);
+		const { rerender } = render(<WeeklySchedulePage {...defaultProps} />);
 
 		await user.click(screen.getByRole('button', { name: '担当者を変更' }));
 		await user.click(screen.getByRole('button', { name: 'AIに相談' }));
@@ -115,9 +119,11 @@ describe('WeeklySchedulePage staffOptions', () => {
 		expect(capturedStaffIds).toHaveLength(1);
 		expect(capturedStaffIds[0]).toEqual([TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]);
 
-		await user.click(
-			screen.getByRole('button', { name: '利用者別グリッド表示' }),
+		// searchParams が変わった場合の再レンダーをシミュレート
+		mockSearchParamsGet.mockImplementation((key: string) =>
+			key === 'view' ? 'staff-grid' : null,
 		);
+		rerender(<WeeklySchedulePage {...defaultProps} />);
 
 		expect(capturedStaffIds).toHaveLength(2);
 		expect(capturedStaffIds[1]).toEqual([TEST_IDS.STAFF_1, TEST_IDS.STAFF_2]);

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.test.tsx
@@ -114,6 +114,7 @@ describe('WeeklySchedulePage', () => {
 			{ id: TEST_IDS.CLIENT_1, name: '田中太郎' },
 			{ id: TEST_IDS.CLIENT_2, name: '鈴木一郎' },
 		],
+		initialViewMode: 'grid',
 	};
 
 	beforeEach(() => {
@@ -144,7 +145,11 @@ describe('WeeklySchedulePage', () => {
 
 	it('シフトがある場合はShiftTableが表示される', () => {
 		render(
-			<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
+			<WeeklySchedulePage
+				{...defaultProps}
+				initialShifts={sampleShifts}
+				initialViewMode="list"
+			/>,
 		);
 
 		expect(screen.getByText('田中太郎')).toBeInTheDocument();
@@ -166,7 +171,18 @@ describe('WeeklySchedulePage', () => {
 		await user.click(screen.getByRole('button', { name: '前週' }));
 
 		expect(mockPush).toHaveBeenCalledWith(
-			'/admin/weekly-schedules?week=2026-01-12',
+			'/admin/weekly-schedules?week=2026-01-12&view=grid',
+		);
+	});
+
+	it('ビュー切替でrouter.pushに?view=が付いて呼ばれる', async () => {
+		const user = userEvent.setup();
+		render(<WeeklySchedulePage {...defaultProps} />);
+
+		await user.click(screen.getByRole('button', { name: 'リスト表示' }));
+
+		expect(mockPush).toHaveBeenCalledWith(
+			'/admin/weekly-schedules?week=2026-01-19&view=list',
 		);
 	});
 
@@ -199,7 +215,11 @@ describe('WeeklySchedulePage', () => {
 		it('担当者変更ダイアログのAIに相談ボタンをクリックするとAdjustmentChatDialogが開く', async () => {
 			const user = userEvent.setup();
 			render(
-				<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
+				<WeeklySchedulePage
+					{...defaultProps}
+					initialShifts={sampleShifts}
+					initialViewMode="list"
+				/>,
 			);
 
 			await user.click(screen.getByRole('button', { name: '担当者を変更' }));
@@ -214,7 +234,11 @@ describe('WeeklySchedulePage', () => {
 			vi.useFakeTimers();
 			try {
 				render(
-					<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
+					<WeeklySchedulePage
+						{...defaultProps}
+						initialShifts={sampleShifts}
+						initialViewMode="list"
+					/>,
 				);
 
 				fireEvent.click(screen.getByRole('button', { name: '担当者を変更' }));
@@ -253,6 +277,7 @@ describe('WeeklySchedulePage', () => {
 					<WeeklySchedulePage
 						{...defaultProps}
 						initialShifts={[...sampleShifts, secondShift]}
+						initialViewMode="list"
 					/>,
 				);
 
@@ -287,7 +312,11 @@ describe('WeeklySchedulePage', () => {
 		it('AIチャットには未保存編集ではなく初期シフトが渡される', async () => {
 			const user = userEvent.setup();
 			render(
-				<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
+				<WeeklySchedulePage
+					{...defaultProps}
+					initialShifts={sampleShifts}
+					initialViewMode="list"
+				/>,
 			);
 
 			await user.click(screen.getByRole('button', { name: '担当者を変更' }));
@@ -309,7 +338,11 @@ describe('WeeklySchedulePage', () => {
 		it('AdjustmentChatDialogの閉じるボタンでダイアログが閉じる', async () => {
 			const user = userEvent.setup();
 			render(
-				<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
+				<WeeklySchedulePage
+					{...defaultProps}
+					initialShifts={sampleShifts}
+					initialViewMode="list"
+				/>,
 			);
 
 			await user.click(screen.getByRole('button', { name: '担当者を変更' }));

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.test.tsx
@@ -10,12 +10,14 @@ import {
 
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
+const mockSearchParamsGet = vi.fn();
 
 vi.mock('next/navigation', () => ({
 	useRouter: () => ({
 		push: mockPush,
 		refresh: mockRefresh,
 	}),
+	useSearchParams: () => ({ get: mockSearchParamsGet }),
 }));
 
 vi.mock('@/app/actions/weeklySchedules', () => ({
@@ -114,11 +116,13 @@ describe('WeeklySchedulePage', () => {
 			{ id: TEST_IDS.CLIENT_1, name: '田中太郎' },
 			{ id: TEST_IDS.CLIENT_2, name: '鈴木一郎' },
 		],
-		initialViewMode: 'grid',
 	};
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockSearchParamsGet.mockImplementation((key: string) =>
+			key === 'view' ? 'grid' : null,
+		);
 	});
 
 	it('WeekSelectorが表示される', () => {
@@ -144,12 +148,11 @@ describe('WeeklySchedulePage', () => {
 	});
 
 	it('シフトがある場合はShiftTableが表示される', () => {
+		mockSearchParamsGet.mockImplementation((key: string) =>
+			key === 'view' ? 'list' : null,
+		);
 		render(
-			<WeeklySchedulePage
-				{...defaultProps}
-				initialShifts={sampleShifts}
-				initialViewMode="list"
-			/>,
+			<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
 		);
 
 		expect(screen.getByText('田中太郎')).toBeInTheDocument();
@@ -213,13 +216,12 @@ describe('WeeklySchedulePage', () => {
 
 	describe('AdjustmentChatDialog 統合', () => {
 		it('担当者変更ダイアログのAIに相談ボタンをクリックするとAdjustmentChatDialogが開く', async () => {
+			mockSearchParamsGet.mockImplementation((key: string) =>
+				key === 'view' ? 'list' : null,
+			);
 			const user = userEvent.setup();
 			render(
-				<WeeklySchedulePage
-					{...defaultProps}
-					initialShifts={sampleShifts}
-					initialViewMode="list"
-				/>,
+				<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
 			);
 
 			await user.click(screen.getByRole('button', { name: '担当者を変更' }));
@@ -231,14 +233,13 @@ describe('WeeklySchedulePage', () => {
 		});
 
 		it('AIチャットは担当者変更ダイアログを閉じた後に開く', () => {
+			mockSearchParamsGet.mockImplementation((key: string) =>
+				key === 'view' ? 'list' : null,
+			);
 			vi.useFakeTimers();
 			try {
 				render(
-					<WeeklySchedulePage
-						{...defaultProps}
-						initialShifts={sampleShifts}
-						initialViewMode="list"
-					/>,
+					<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
 				);
 
 				fireEvent.click(screen.getByRole('button', { name: '担当者を変更' }));
@@ -264,6 +265,9 @@ describe('WeeklySchedulePage', () => {
 		});
 
 		it('AI相談後に別シフトの担当者変更ダイアログを開き直した場合、通常クローズでAIチャットは開かない', () => {
+			mockSearchParamsGet.mockImplementation((key: string) =>
+				key === 'view' ? 'list' : null,
+			);
 			vi.useFakeTimers();
 			try {
 				const secondShift: ShiftDisplayRow = {
@@ -277,7 +281,6 @@ describe('WeeklySchedulePage', () => {
 					<WeeklySchedulePage
 						{...defaultProps}
 						initialShifts={[...sampleShifts, secondShift]}
-						initialViewMode="list"
 					/>,
 				);
 
@@ -310,13 +313,12 @@ describe('WeeklySchedulePage', () => {
 		});
 
 		it('AIチャットには未保存編集ではなく初期シフトが渡される', async () => {
+			mockSearchParamsGet.mockImplementation((key: string) =>
+				key === 'view' ? 'list' : null,
+			);
 			const user = userEvent.setup();
 			render(
-				<WeeklySchedulePage
-					{...defaultProps}
-					initialShifts={sampleShifts}
-					initialViewMode="list"
-				/>,
+				<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
 			);
 
 			await user.click(screen.getByRole('button', { name: '担当者を変更' }));
@@ -336,13 +338,12 @@ describe('WeeklySchedulePage', () => {
 		});
 
 		it('AdjustmentChatDialogの閉じるボタンでダイアログが閉じる', async () => {
+			mockSearchParamsGet.mockImplementation((key: string) =>
+				key === 'view' ? 'list' : null,
+			);
 			const user = userEvent.setup();
 			render(
-				<WeeklySchedulePage
-					{...defaultProps}
-					initialShifts={sampleShifts}
-					initialViewMode="list"
-				/>,
+				<WeeklySchedulePage {...defaultProps} initialShifts={sampleShifts} />,
 			);
 
 			await user.click(screen.getByRole('button', { name: '担当者を変更' }));

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
@@ -4,8 +4,13 @@ import { generateWeeklyShiftsAction } from '@/app/actions/weeklySchedules';
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
 import { ServiceTypeLabels } from '@/models/valueObjects/serviceTypeId';
 import { addJstDays, formatJstDateString, getJstDateOnly } from '@/utils/date';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import {
+	DEFAULT_VIEW_MODE,
+	isWeeklyViewMode,
+	type WeeklyViewMode,
+} from '../../helpers';
 import { AdjustmentChatDialog } from '../AdjustmentChatDialog';
 import type { ShiftContext } from '../AdjustmentChatDialog/useAdjustmentChat';
 import {
@@ -32,17 +37,13 @@ import {
 import { ShiftTable, type ShiftDisplayRow } from '../ShiftTable';
 import { WeekSelector } from '../WeekSelector';
 import { StaffWeeklyShiftGrid, WeeklyShiftGrid } from '../WeeklyShiftGrid';
-import {
-	WeeklyViewToggleButton,
-	type WeeklyViewMode,
-} from '../WeeklyViewToggleButton';
+import { WeeklyViewToggleButton } from '../WeeklyViewToggleButton';
 
 export interface WeeklySchedulePageProps {
 	weekStartDate: Date;
 	initialShifts: ShiftDisplayRow[];
 	staffOptions: StaffPickerOption[];
 	clientOptions: { id: string; name: string }[];
-	initialViewMode: WeeklyViewMode;
 }
 
 const shiftToDateTime = (
@@ -218,11 +219,13 @@ export const WeeklySchedulePage = ({
 	initialShifts,
 	staffOptions,
 	clientOptions,
-	initialViewMode,
 }: WeeklySchedulePageProps) => {
 	const router = useRouter();
+	const searchParams = useSearchParams();
+	const viewMode: WeeklyViewMode = isWeeklyViewMode(searchParams.get('view'))
+		? (searchParams.get('view') as WeeklyViewMode)
+		: DEFAULT_VIEW_MODE;
 	const weekStartDateStr = formatJstDateString(weekStartDate);
-	const [viewMode, setViewMode] = useState<WeeklyViewMode>(initialViewMode);
 	const [changeDialogShift, setChangeDialogShift] =
 		useState<ShiftDisplayRow | null>(null);
 	const [cancelDialogShift, setCancelDialogShift] =
@@ -370,7 +373,6 @@ export const WeeklySchedulePage = ({
 					<WeeklyViewToggleButton
 						currentView={viewMode}
 						onViewChange={(newView) => {
-							setViewMode(newView);
 							router.push(
 								`/admin/weekly-schedules?week=${weekStartDateStr}&view=${newView}`,
 							);

--- a/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklySchedulePage/WeeklySchedulePage.tsx
@@ -42,6 +42,7 @@ export interface WeeklySchedulePageProps {
 	initialShifts: ShiftDisplayRow[];
 	staffOptions: StaffPickerOption[];
 	clientOptions: { id: string; name: string }[];
+	initialViewMode: WeeklyViewMode;
 }
 
 const shiftToDateTime = (
@@ -217,10 +218,11 @@ export const WeeklySchedulePage = ({
 	initialShifts,
 	staffOptions,
 	clientOptions,
+	initialViewMode,
 }: WeeklySchedulePageProps) => {
 	const router = useRouter();
 	const weekStartDateStr = formatJstDateString(weekStartDate);
-	const [viewMode, setViewMode] = useState<WeeklyViewMode>('list');
+	const [viewMode, setViewMode] = useState<WeeklyViewMode>(initialViewMode);
 	const [changeDialogShift, setChangeDialogShift] =
 		useState<ShiftDisplayRow | null>(null);
 	const [cancelDialogShift, setCancelDialogShift] =
@@ -254,7 +256,7 @@ export const WeeklySchedulePage = ({
 
 	const handleWeekChange = (date: Date) => {
 		const weekParam = formatJstDateString(date);
-		router.push(`/admin/weekly-schedules?week=${weekParam}`);
+		router.push(`/admin/weekly-schedules?week=${weekParam}&view=${viewMode}`);
 	};
 
 	const handleGenerated = (_result: GenerateResult) => {
@@ -367,7 +369,12 @@ export const WeeklySchedulePage = ({
 					</button>
 					<WeeklyViewToggleButton
 						currentView={viewMode}
-						onViewChange={setViewMode}
+						onViewChange={(newView) => {
+							setViewMode(newView);
+							router.push(
+								`/admin/weekly-schedules?week=${weekStartDateStr}&view=${newView}`,
+							);
+						}}
 					/>
 					<GenerateButton
 						weekStartDate={weekStartDate}

--- a/src/app/admin/weekly-schedules/_components/WeeklyViewToggleButton/WeeklyViewToggleButton.tsx
+++ b/src/app/admin/weekly-schedules/_components/WeeklyViewToggleButton/WeeklyViewToggleButton.tsx
@@ -2,8 +2,9 @@
 
 import { Icon } from '@/app/_components/Icon';
 import classNames from 'classnames';
+import type { WeeklyViewMode } from '../../helpers';
 
-export type WeeklyViewMode = 'list' | 'grid' | 'staff-grid';
+export type { WeeklyViewMode } from '../../helpers';
 
 interface WeeklyViewToggleButtonProps {
 	currentView: WeeklyViewMode;

--- a/src/app/admin/weekly-schedules/helpers.test.ts
+++ b/src/app/admin/weekly-schedules/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getMonday, parseSearchParams } from './helpers';
+import { DEFAULT_VIEW_MODE, getMonday, parseSearchParams } from './helpers';
 
 describe('getMonday', () => {
 	it('月曜日を渡すとそのまま返す', () => {
@@ -39,6 +39,7 @@ describe('parseSearchParams', () => {
 			expect(result).toEqual({
 				weekStartDate: null,
 				isValid: false,
+				viewMode: 'grid',
 			});
 		});
 
@@ -47,6 +48,7 @@ describe('parseSearchParams', () => {
 			expect(result).toEqual({
 				weekStartDate: null,
 				isValid: false,
+				viewMode: 'grid',
 			});
 		});
 	});
@@ -58,6 +60,7 @@ describe('parseSearchParams', () => {
 				weekStartDate: null,
 				isValid: false,
 				error: 'invalid_date',
+				viewMode: 'grid',
 			});
 		});
 
@@ -67,6 +70,7 @@ describe('parseSearchParams', () => {
 				weekStartDate: null,
 				isValid: false,
 				error: 'invalid_date',
+				viewMode: 'grid',
 			});
 		});
 	});
@@ -103,5 +107,45 @@ describe('parseSearchParams', () => {
 			expect(result.isValid).toBe(true);
 			expect(result.weekStartDate).not.toBeNull();
 		});
+	});
+});
+
+describe('parseSearchParams - viewMode', () => {
+	it('view 未指定の場合は DEFAULT_VIEW_MODE を返す', () => {
+		const result = parseSearchParams({ week: '2026-01-19' });
+		expect(result.viewMode).toBe(DEFAULT_VIEW_MODE);
+	});
+
+	it('view=list の場合は "list" を返す', () => {
+		const result = parseSearchParams({ week: '2026-01-19', view: 'list' });
+		expect(result.viewMode).toBe('list');
+	});
+
+	it('view=grid の場合は "grid" を返す', () => {
+		const result = parseSearchParams({ week: '2026-01-19', view: 'grid' });
+		expect(result.viewMode).toBe('grid');
+	});
+
+	it('view=staff-grid の場合は "staff-grid" を返す', () => {
+		const result = parseSearchParams({
+			week: '2026-01-19',
+			view: 'staff-grid',
+		});
+		expect(result.viewMode).toBe('staff-grid');
+	});
+
+	it('不正な view 値は DEFAULT_VIEW_MODE にフォールバック', () => {
+		const result = parseSearchParams({ week: '2026-01-19', view: 'invalid' });
+		expect(result.viewMode).toBe(DEFAULT_VIEW_MODE);
+	});
+
+	it('week が無効でも viewMode は正しくパースされる', () => {
+		const result = parseSearchParams({ week: 'invalid-date', view: 'list' });
+		expect(result.viewMode).toBe('list');
+	});
+
+	it('week 未指定でも viewMode は返される', () => {
+		const result = parseSearchParams({ view: 'staff-grid' });
+		expect(result.viewMode).toBe('staff-grid');
 	});
 });

--- a/src/app/admin/weekly-schedules/helpers.ts
+++ b/src/app/admin/weekly-schedules/helpers.ts
@@ -38,6 +38,12 @@ export const VALID_VIEW_MODES: WeeklyViewMode[] = [
 export const DEFAULT_VIEW_MODE: WeeklyViewMode = 'grid';
 
 /**
+ * 値が WeeklyViewMode かどうかを判定する型ガード
+ */
+export const isWeeklyViewMode = (value: unknown): value is WeeklyViewMode =>
+	(VALID_VIEW_MODES as unknown[]).includes(value);
+
+/**
  * Next.js page の searchParams の型
  */
 export type SearchParams = {
@@ -64,10 +70,9 @@ export const parseSearchParams = (params: SearchParams): ParsedSearchParams => {
 	// view パラメータのパース
 	const viewRaw = params.view;
 	const viewStr = typeof viewRaw === 'string' ? viewRaw : undefined;
-	const viewMode: WeeklyViewMode =
-		viewStr && (VALID_VIEW_MODES as string[]).includes(viewStr)
-			? (viewStr as WeeklyViewMode)
-			: DEFAULT_VIEW_MODE;
+	const viewMode: WeeklyViewMode = isWeeklyViewMode(viewStr)
+		? viewStr
+		: DEFAULT_VIEW_MODE;
 
 	// week 未指定または空文字
 	if (!week) {

--- a/src/app/admin/weekly-schedules/helpers.ts
+++ b/src/app/admin/weekly-schedules/helpers.ts
@@ -19,6 +19,25 @@ export const getMonday = (date: Date): Date => {
 };
 
 /**
+ * ビュー表示モード
+ */
+export type WeeklyViewMode = 'list' | 'grid' | 'staff-grid';
+
+/**
+ * 有効なビュー表示モードの一覧
+ */
+export const VALID_VIEW_MODES: WeeklyViewMode[] = [
+	'list',
+	'grid',
+	'staff-grid',
+];
+
+/**
+ * デフォルトのビュー表示モード
+ */
+export const DEFAULT_VIEW_MODE: WeeklyViewMode = 'grid';
+
+/**
  * Next.js page の searchParams の型
  */
 export type SearchParams = {
@@ -32,6 +51,7 @@ export type ParsedSearchParams = {
 	weekStartDate: Date | null;
 	isValid: boolean;
 	error?: 'invalid_date' | 'not_monday';
+	viewMode: WeeklyViewMode;
 };
 
 /**
@@ -41,11 +61,20 @@ export const parseSearchParams = (params: SearchParams): ParsedSearchParams => {
 	const weekRaw = params.week;
 	const week = typeof weekRaw === 'string' ? weekRaw : undefined;
 
+	// view パラメータのパース
+	const viewRaw = params.view;
+	const viewStr = typeof viewRaw === 'string' ? viewRaw : undefined;
+	const viewMode: WeeklyViewMode =
+		viewStr && (VALID_VIEW_MODES as string[]).includes(viewStr)
+			? (viewStr as WeeklyViewMode)
+			: DEFAULT_VIEW_MODE;
+
 	// week 未指定または空文字
 	if (!week) {
 		return {
 			weekStartDate: null,
 			isValid: false,
+			viewMode,
 		};
 	}
 
@@ -56,6 +85,7 @@ export const parseSearchParams = (params: SearchParams): ParsedSearchParams => {
 			weekStartDate: null,
 			isValid: false,
 			error: 'invalid_date',
+			viewMode,
 		};
 	}
 
@@ -69,11 +99,13 @@ export const parseSearchParams = (params: SearchParams): ParsedSearchParams => {
 			weekStartDate: parsedDate,
 			isValid: false,
 			error: 'not_monday',
+			viewMode,
 		};
 	}
 
 	return {
 		weekStartDate: parsedDate,
 		isValid: true,
+		viewMode,
 	};
 };

--- a/src/app/admin/weekly-schedules/page.test.tsx
+++ b/src/app/admin/weekly-schedules/page.test.tsx
@@ -68,12 +68,13 @@ describe('WeeklySchedulesPage', () => {
 			vi.mocked(parseSearchParams).mockReturnValue({
 				weekStartDate: null,
 				isValid: false,
+				viewMode: 'grid',
 			});
 
 			await WeeklySchedulesPage({ searchParams: Promise.resolve({}) });
 
 			expect(redirect).toHaveBeenCalledWith(
-				'/admin/weekly-schedules?week=2026-01-19',
+				'/admin/weekly-schedules?week=2026-01-19&view=grid',
 			);
 		});
 	});
@@ -84,6 +85,7 @@ describe('WeeklySchedulesPage', () => {
 				weekStartDate: null,
 				isValid: false,
 				error: 'invalid_date',
+				viewMode: 'grid',
 			});
 
 			await WeeklySchedulesPage({
@@ -91,7 +93,7 @@ describe('WeeklySchedulesPage', () => {
 			});
 
 			expect(redirect).toHaveBeenCalledWith(
-				'/admin/weekly-schedules?week=2026-01-19',
+				'/admin/weekly-schedules?week=2026-01-19&view=grid',
 			);
 		});
 	});
@@ -105,6 +107,7 @@ describe('WeeklySchedulesPage', () => {
 				weekStartDate: tuesday,
 				isValid: false,
 				error: 'not_monday',
+				viewMode: 'grid',
 			});
 			vi.mocked(getMonday).mockReturnValue(monday);
 			vi.mocked(formatJstDateString).mockReturnValue('2026-01-19');
@@ -115,7 +118,7 @@ describe('WeeklySchedulesPage', () => {
 
 			expect(getMonday).toHaveBeenCalledWith(tuesday);
 			expect(redirect).toHaveBeenCalledWith(
-				'/admin/weekly-schedules?week=2026-01-19',
+				'/admin/weekly-schedules?week=2026-01-19&view=grid',
 			);
 		});
 	});
@@ -127,6 +130,7 @@ describe('WeeklySchedulesPage', () => {
 			vi.mocked(parseSearchParams).mockReturnValue({
 				weekStartDate: monday,
 				isValid: true,
+				viewMode: 'grid',
 			});
 
 			const result = await WeeklySchedulesPage({
@@ -144,6 +148,7 @@ describe('WeeklySchedulesPage', () => {
 			vi.mocked(parseSearchParams).mockReturnValue({
 				weekStartDate: monday,
 				isValid: true,
+				viewMode: 'grid',
 			});
 
 			await WeeklySchedulesPage({

--- a/src/app/admin/weekly-schedules/page.tsx
+++ b/src/app/admin/weekly-schedules/page.tsx
@@ -29,7 +29,7 @@ const WeeklySchedulesPage = async ({
 		}
 
 		const weekStr = formatJstDateString(mondayDate);
-		redirect(`/admin/weekly-schedules?week=${weekStr}`);
+		redirect(`/admin/weekly-schedules?week=${weekStr}&view=${parsed.viewMode}`);
 	}
 
 	const weekStartDate = parsed.weekStartDate!;
@@ -45,7 +45,10 @@ const WeeklySchedulesPage = async ({
 				</section>
 
 				<Suspense fallback={<WeeklyScheduleSkeleton />}>
-					<WeeklyScheduleContent weekStartDate={weekStartDate} />
+					<WeeklyScheduleContent
+						weekStartDate={weekStartDate}
+						viewMode={parsed.viewMode}
+					/>
 				</Suspense>
 			</div>
 		</>

--- a/src/app/admin/weekly-schedules/page.tsx
+++ b/src/app/admin/weekly-schedules/page.tsx
@@ -45,10 +45,7 @@ const WeeklySchedulesPage = async ({
 				</section>
 
 				<Suspense fallback={<WeeklyScheduleSkeleton />}>
-					<WeeklyScheduleContent
-						weekStartDate={weekStartDate}
-						viewMode={parsed.viewMode}
-					/>
+					<WeeklyScheduleContent weekStartDate={weekStartDate} />
 				</Suspense>
 			</div>
 		</>


### PR DESCRIPTION
## 概要

: 1776035732:0;cd /home/node/.copilot/2点を実装しました。

1. **デフォルト表示の変更**: `'list'`（一覧）→ `'grid'`（利用者ごと）に変更
**: `?view=` で表示を切り替え可能にし、URL をブックマーク可能にする: 1776035732:0;cd ~/.copilot
3. **Back/Forward stale state の解消**: `useState` ベースから `useSearchParams` ベースに移行し、ブラウザの戻る/進むで表示が stale になる問題を修正

Closes #188

---

## 主な変更内容

### 1. `helpers.ts` の拡張
- `WeeklyViewMode` 型・`VALID_VIEW_MODES`・`DEFAULT_VIEW_MODE = 'grid'`・`isWeeklyViewMode` 型ガードを追加
- `parseSearchParams` が `?view=` パラメータをパースして `viewMode` を返すよう拡張
- 不正な値は `'grid'` にフォールバック

### 2. `WeeklySchedulePage.tsx` の変更
- `useSearchParams().get('view')` + `isWeeklyViewMode` で `viewMode` を URL から直接導出
- `initialViewMode` prop を廃止（`useSearchParams` から取得するため不要）
- 週移動・ビュー切替時に `router.push` へ `&view=` を付与することで URL と状態を同期

### 3. `WeeklyViewToggleButton.tsx`
- `WeeklyViewMode` 型を `helpers.ts` から re-export に変更（型の一元管理）

### 4. `page.tsx` / `WeeklyScheduleContent.tsx`
- `initialViewMode` prop の伝播を廃止（Server Component 側はシンプルに）

### 5. テスト
- `useSearchParams` モック追加
- 全 307 テスト Pass

---

## 受け入れ条件の確認

- [x] 画面を初めて開いたとき（`?view` なし）、「利用者ごと」グリッド（`grid`）がデフォルト表示
- [x] `?view=list` / `?view=grid` / `?view=staff-grid` で各表示に切り替え可能
- [X] 表示切り替えボタンを押すと URL の `view` パラメータが更新
- [x] 週を移動しても `view` パラメータが引き継がれる
- [x] 不正な `view` 値（例: `?view=unknown`）はデフォルト（`grid`）にフォールバック
: 1776035732:0;cd ~/.copilot stale にならない

---

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `helpers.ts` | `WeeklyViewMode`・型ガード・`DEFAULT_VIEW_MODE`・`parseSearchParams` 拡張 |
| `WeeklySchedulePage.tsx` | `useSearchParams` ベースに移行・URL 同期 |
| `WeeklyScheduleContent.tsx` | `initialViewMode` prop 廃止 |
| `page.tsx` | `initialViewMode` prop 伝播廃止 |
| `WeeklyViewToggleButton.tsx` | `WeeklyViewMode` を `helpers.ts` から re-export |
| テストファイル 3本 | `useSearchParams` モック追加・全 307 テスト Pass |