### PR TITLE
feat: 提案キャンセル後に再提案ガイダンスを表示する (#127)

### DIFF
--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import type { UIMessage } from 'ai';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { AdjustmentChatDialog } from './AdjustmentChatDialog';
+import { PROPOSAL_DISMISS_GUIDANCE_MESSAGE } from './ProposalDismissGuidance';
 
 // Vercel AI SDK useChat のモック
 const mockUseChat = vi.fn();
@@ -648,6 +649,9 @@ describe('AdjustmentChatDialog', () => {
 		await waitFor(() => {
 			expect(screen.queryByText('担当者変更')).not.toBeInTheDocument();
 		});
+		expect(
+			screen.queryByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).not.toBeInTheDocument();
 	});
 
 	it('キャンセル押下でカードが非表示になる', async () => {
@@ -693,6 +697,9 @@ describe('AdjustmentChatDialog', () => {
 
 		expect(mockDismissProposal).toHaveBeenCalledTimes(1);
 		expect(screen.queryByText('担当者変更')).not.toBeInTheDocument();
+		expect(
+			screen.getByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).toBeInTheDocument();
 	});
 
 	it('isStreaming=true のとき確定ボタンが disabled になる', () => {
@@ -878,6 +885,138 @@ describe('AdjustmentChatDialog', () => {
 
 		expect(screen.queryByText('担当者変更')).not.toBeInTheDocument();
 		expect(screen.getByText('（提案を生成しました）')).toBeInTheDocument();
+		expect(
+			screen.getByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).toBeInTheDocument();
+	});
+
+	it('新しい proposal が来たらガイダンスが非表示になる', async () => {
+		type UseProposalExecutionOptions = {
+			onDismiss?: () => void;
+		};
+		const user = userEvent.setup();
+
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createProposalMessage(
+						`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`,
+						'assistant-1',
+					),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+		mockUseProposalExecution.mockImplementation(
+			(options: UseProposalExecutionOptions) => ({
+				isExecuting: false,
+				execute: mockExecuteProposal,
+				dismiss: () => {
+					options.onDismiss?.();
+					mockDismissProposal();
+				},
+			}),
+		);
+
+		const { rerender } = render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+		expect(
+			screen.getByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).toBeInTheDocument();
+
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				messages: [
+					createProposalMessage(
+						`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`,
+						'assistant-2',
+					),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+
+		rerender(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(
+			screen.queryByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).not.toBeInTheDocument();
+		expect(screen.getByText('担当者変更')).toBeInTheDocument();
+	});
+
+	it('isStreaming=true のときはガイダンスを表示しない', async () => {
+		type UseProposalExecutionOptions = {
+			onDismiss?: () => void;
+		};
+		const user = userEvent.setup();
+
+		mockUseChat.mockReturnValue(
+			createMockUseChatReturn({
+				status: 'streaming',
+				messages: [
+					createProposalMessage(`{
+  "type": "change_shift_staff",
+  "shiftId": "${TEST_IDS.SCHEDULE_1}",
+  "toStaffId": "${TEST_IDS.STAFF_2}"
+}`),
+				],
+				sendMessage: mockSendMessage,
+				stop: mockStop,
+				setMessages: mockSetMessages,
+			}),
+		);
+		mockUseProposalExecution.mockImplementation(
+			(options: UseProposalExecutionOptions) => ({
+				isExecuting: false,
+				execute: mockExecuteProposal,
+				dismiss: () => {
+					options.onDismiss?.();
+					mockDismissProposal();
+				},
+			}),
+		);
+
+		render(
+			<AdjustmentChatDialog
+				isOpen={true}
+				shiftContext={shiftContext}
+				staffOptions={staffOptions}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+		expect(
+			screen.queryByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).not.toBeInTheDocument();
 	});
 
 	it('detectedProposal の算出で reverse を呼ばずに最新 assistant を検出できる', () => {

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/AdjustmentChatDialog.tsx
@@ -2,15 +2,17 @@
 
 import type { StaffPickerOption } from '@/app/admin/basic-schedules/_components/StaffPickerDialog';
 import type { UIMessage } from 'ai';
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { buildProposalDisplayValues } from './buildProposalDisplayValues';
 import { ChatInput } from './ChatInput';
 import { ChatMessageList } from './ChatMessageList';
 import { extractProposalFromParts } from './extractProposalFromParts';
 import { parseProposal } from './parseProposal';
 import { ProposalConfirmCard } from './ProposalConfirmCard';
+import { ProposalDismissGuidance } from './ProposalDismissGuidance';
 import type { ShiftContext } from './useAdjustmentChat';
 import { useAdjustmentChat } from './useAdjustmentChat';
+import { useProposalDismissState } from './useProposalDismissState';
 import { useProposalExecution } from './useProposalExecution';
 
 type AdjustmentChatDialogProps = {
@@ -161,17 +163,14 @@ export const AdjustmentChatDialog = ({
 			staffOptions,
 		});
 	}, [detectedProposal, shiftContext, staffOptions]);
-	const [dismissedProposalKey, setDismissedProposalKey] = useState<
-		string | null
-	>(null);
-	const isDismissed =
-		proposalKey !== null && proposalKey === dismissedProposalKey;
+	const { isDismissed, dismissProposal, confirmProposal, shouldShowGuidance } =
+		useProposalDismissState(proposalKey);
 
 	const { execute, dismiss, isExecuting } = useProposalExecution({
 		proposal: detectedProposal,
 		allowlist,
-		onSuccess: () => setDismissedProposalKey(proposalKey),
-		onDismiss: () => setDismissedProposalKey(proposalKey),
+		onSuccess: confirmProposal,
+		onDismiss: dismissProposal,
 	});
 
 	const handleClose = () => {
@@ -246,6 +245,11 @@ export const AdjustmentChatDialog = ({
 
 				{/* 提案検出表示 */}
 				{proposalSection}
+
+				<ProposalDismissGuidance
+					visible={shouldShowGuidance(detectedProposal !== null, isStreaming)}
+					isStreaming={isStreaming}
+				/>
 
 				{/* メッセージリスト */}
 				<ChatMessageList

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalDismissGuidance.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalDismissGuidance.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+	PROPOSAL_DISMISS_GUIDANCE_MESSAGE,
+	ProposalDismissGuidance,
+} from './ProposalDismissGuidance';
+
+describe('ProposalDismissGuidance', () => {
+	it('visible=true かつ isStreaming=false のときガイダンスを表示する', () => {
+		render(<ProposalDismissGuidance visible={true} isStreaming={false} />);
+
+		const guidance = screen.getByRole('status');
+		expect(guidance).toHaveTextContent(PROPOSAL_DISMISS_GUIDANCE_MESSAGE);
+		expect(guidance).toHaveClass('alert', 'alert-info');
+	});
+
+	it('visible=false のときは何も表示しない', () => {
+		render(<ProposalDismissGuidance visible={false} isStreaming={false} />);
+
+		expect(
+			screen.queryByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).not.toBeInTheDocument();
+	});
+
+	it('isStreaming=true のときは何も表示しない', () => {
+		render(<ProposalDismissGuidance visible={true} isStreaming={true} />);
+
+		expect(
+			screen.queryByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalDismissGuidance.tsx
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/ProposalDismissGuidance.tsx
@@ -1,0 +1,22 @@
+export const PROPOSAL_DISMISS_GUIDANCE_MESSAGE =
+	'提案をキャンセルしました。別の条件で再提案したい場合は、変更したい内容（例: 担当者・時間・理由）をチャットで送ってください。';
+
+type ProposalDismissGuidanceProps = {
+	visible: boolean;
+	isStreaming: boolean;
+};
+
+export const ProposalDismissGuidance = ({
+	visible,
+	isStreaming,
+}: ProposalDismissGuidanceProps) => {
+	if (!visible || isStreaming) {
+		return null;
+	}
+
+	return (
+		<div className="mx-4 mt-4 alert text-sm alert-info" role="status">
+			{PROPOSAL_DISMISS_GUIDANCE_MESSAGE}
+		</div>
+	);
+};

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/index.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/index.ts
@@ -5,6 +5,10 @@ export { ChatInput } from './ChatInput';
 export { ChatMessageList } from './ChatMessageList';
 export { extractProposalFromParts } from './extractProposalFromParts';
 export { parseProposal } from './parseProposal';
+export {
+	PROPOSAL_DISMISS_GUIDANCE_MESSAGE,
+	ProposalDismissGuidance,
+} from './ProposalDismissGuidance';
 export { useAdjustmentChat } from './useAdjustmentChat';
 export type {
 	ChatContextOptions,

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalDismissState.test.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalDismissState.test.ts
@@ -1,0 +1,54 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useProposalDismissState } from './useProposalDismissState';
+
+describe('useProposalDismissState', () => {
+	it('dismissProposal で isDismissed と shouldShowGuidance が true になる', () => {
+		const { result } = renderHook(() => useProposalDismissState('proposal-1'));
+
+		act(() => {
+			result.current.dismissProposal();
+		});
+
+		expect(result.current.isDismissed).toBe(true);
+		expect(result.current.shouldShowGuidance(true, false)).toBe(true);
+	});
+
+	it('confirmProposal では shouldShowGuidance は false のまま', () => {
+		const { result } = renderHook(() => useProposalDismissState('proposal-1'));
+
+		act(() => {
+			result.current.confirmProposal();
+		});
+
+		expect(result.current.isDismissed).toBe(true);
+		expect(result.current.shouldShowGuidance(true, false)).toBe(false);
+	});
+
+	it('proposalKey が変わると shouldShowGuidance がリセットされる', () => {
+		const { result, rerender } = renderHook(
+			({ proposalKey }) => useProposalDismissState(proposalKey),
+			{ initialProps: { proposalKey: 'proposal-1' as string | null } },
+		);
+
+		act(() => {
+			result.current.dismissProposal();
+		});
+
+		expect(result.current.shouldShowGuidance(true, false)).toBe(true);
+
+		rerender({ proposalKey: 'proposal-2' });
+
+		expect(result.current.shouldShowGuidance(true, false)).toBe(false);
+	});
+
+	it('isStreaming=true のとき shouldShowGuidance は false', () => {
+		const { result } = renderHook(() => useProposalDismissState('proposal-1'));
+
+		act(() => {
+			result.current.dismissProposal();
+		});
+
+		expect(result.current.shouldShowGuidance(true, true)).toBe(false);
+	});
+});

--- a/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalDismissState.ts
+++ b/src/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalDismissState.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react';
+
+type DismissState = {
+	dismissedKey: string | null;
+	guidanceKey: string | null;
+};
+
+export const useProposalDismissState = (proposalKey: string | null) => {
+	const [state, setState] = useState<DismissState>({
+		dismissedKey: null,
+		guidanceKey: null,
+	});
+
+	const isDismissed =
+		proposalKey !== null && proposalKey === state.dismissedKey;
+
+	const dismissProposal = useCallback(() => {
+		setState({ dismissedKey: proposalKey, guidanceKey: proposalKey });
+	}, [proposalKey]);
+
+	const confirmProposal = useCallback(() => {
+		setState((previous) => ({ ...previous, dismissedKey: proposalKey }));
+	}, [proposalKey]);
+
+	const shouldShowGuidance = (hasProposal: boolean, isStreaming: boolean) =>
+		hasProposal &&
+		!isStreaming &&
+		proposalKey !== null &&
+		state.guidanceKey === proposalKey;
+
+	return {
+		isDismissed,
+		dismissProposal,
+		confirmProposal,
+		shouldShowGuidance,
+	};
+};

--- a/src/app/admin/weekly-schedules/_components/FlexibleAdjustmentChatDialog/FlexibleAdjustmentChatDialog.test.tsx
+++ b/src/app/admin/weekly-schedules/_components/FlexibleAdjustmentChatDialog/FlexibleAdjustmentChatDialog.test.tsx
@@ -1,3 +1,4 @@
+import { PROPOSAL_DISMISS_GUIDANCE_MESSAGE } from '@/app/admin/weekly-schedules/_components/AdjustmentChatDialog';
 import { TEST_IDS } from '@/test/helpers/testIds';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -184,6 +185,28 @@ describe('FlexibleAdjustmentChatDialog', () => {
 			allowlist,
 		});
 		expect(mockHandleActionResult).toHaveBeenCalledTimes(1);
+		expect(
+			screen.queryByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).not.toBeInTheDocument();
+	});
+
+	it('キャンセル後に再提案ガイダンスを表示する', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<FlexibleAdjustmentChatDialog
+				isOpen={true}
+				weekRange={{ startDate: '2026-03-16', endDate: '2026-03-22' }}
+				allowlist={allowlist}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+
+		expect(
+			screen.getByText(PROPOSAL_DISMISS_GUIDANCE_MESSAGE),
+		).toBeInTheDocument();
 	});
 
 	it('Escape キーで stop と onClose を呼ぶ', () => {

--- a/src/app/admin/weekly-schedules/_components/FlexibleAdjustmentChatDialog/FlexibleAdjustmentChatDialog.tsx
+++ b/src/app/admin/weekly-schedules/_components/FlexibleAdjustmentChatDialog/FlexibleAdjustmentChatDialog.tsx
@@ -7,9 +7,11 @@ import {
 	ChatMessageList,
 	extractProposalFromParts,
 	parseProposal,
+	ProposalDismissGuidance,
 	useAdjustmentChat,
 	type FlexibleChatContext,
 } from '@/app/admin/weekly-schedules/_components/AdjustmentChatDialog';
+import { useProposalDismissState } from '@/app/admin/weekly-schedules/_components/AdjustmentChatDialog/useProposalDismissState';
 import { useActionResultHandler } from '@/hooks/useActionResultHandler';
 import type {
 	AiChatMutationBatchProposal,
@@ -134,23 +136,21 @@ const createFallbackErrorResult = () => ({
 const executeBatchProposal = async ({
 	approvedProposals,
 	allowlist,
-	proposalKey,
 	handleActionResult,
 	router,
 	isExecutingRef,
 	setIsExecuting,
-	setDismissedProposalKey,
+	confirmProposal,
 }: {
 	approvedProposals: AiChatMutationBatchProposal['proposals'];
 	allowlist: ProposalAllowlist;
-	proposalKey: string | null;
 	handleActionResult: ReturnType<
 		typeof useActionResultHandler
 	>['handleActionResult'];
 	router: ReturnType<typeof useRouter>;
 	isExecutingRef: MutableRefObject<boolean>;
 	setIsExecuting: (value: boolean) => void;
-	setDismissedProposalKey: (value: string | null) => void;
+	confirmProposal: () => void;
 }) => {
 	if (approvedProposals.length === 0 || isExecutingRef.current) {
 		return;
@@ -171,7 +171,7 @@ const executeBatchProposal = async ({
 				result.status === 409 ? CONFLICT_ERROR_MESSAGE : DEFAULT_ERROR_MESSAGE,
 			onSuccess: () => {
 				router.refresh();
-				setDismissedProposalKey(proposalKey);
+				confirmProposal();
 			},
 		});
 	} catch {
@@ -186,12 +186,10 @@ const executeBatchProposal = async ({
 
 const useFlexibleProposalExecution = ({
 	allowlist,
-	proposalKey,
-	setDismissedProposalKey,
+	confirmProposal,
 }: {
 	allowlist: ProposalAllowlist;
-	proposalKey: string | null;
-	setDismissedProposalKey: (value: string | null) => void;
+	confirmProposal: () => void;
 }) => {
 	const router = useRouter();
 	const { handleActionResult } = useActionResultHandler();
@@ -204,12 +202,11 @@ const useFlexibleProposalExecution = ({
 		void executeBatchProposal({
 			approvedProposals,
 			allowlist,
-			proposalKey,
 			handleActionResult,
 			router,
 			isExecutingRef,
 			setIsExecuting,
-			setDismissedProposalKey,
+			confirmProposal,
 		});
 
 	return {
@@ -221,19 +218,19 @@ const useFlexibleProposalExecution = ({
 const useFlexibleProposalState = ({
 	rawMessages,
 	allowlist,
-	dismissedProposalKey,
+	isDismissed,
 	isExecuting,
 	handleConfirm,
-	setDismissedProposalKey,
+	onDismiss,
 }: {
 	rawMessages: UIMessage[];
 	allowlist: ProposalAllowlist;
-	dismissedProposalKey: string | null;
+	isDismissed: boolean;
 	isExecuting: boolean;
 	handleConfirm: (
 		approvedProposals: AiChatMutationBatchProposal['proposals'],
 	) => void;
-	setDismissedProposalKey: (value: string | null) => void;
+	onDismiss: () => void;
 }) => {
 	const latestProposal = useMemo(
 		() => findLatestProposal(rawMessages, allowlist),
@@ -241,8 +238,6 @@ const useFlexibleProposalState = ({
 	);
 	const proposalKey = latestProposal?.messageId ?? null;
 	const detectedProposal = latestProposal?.proposal ?? null;
-	const isDismissed =
-		proposalKey !== null && proposalKey === dismissedProposalKey;
 	const shouldShowProposal =
 		detectedProposal !== null && !isDismissed && proposalKey !== null;
 
@@ -254,7 +249,7 @@ const useFlexibleProposalState = ({
 				proposalKey={proposalKey}
 				isExecuting={isExecuting}
 				onConfirm={handleConfirm}
-				onDismiss={() => setDismissedProposalKey(proposalKey)}
+				onDismiss={onDismiss}
 			/>
 		) : null,
 	};
@@ -266,10 +261,6 @@ export const FlexibleAdjustmentChatDialog = ({
 	allowlist,
 	onClose,
 }: FlexibleAdjustmentChatDialogProps) => {
-	const [dismissedProposalKey, setDismissedProposalKey] = useState<
-		string | null
-	>(null);
-
 	const { messages, rawMessages, isStreaming, error, sendMessage, stop } =
 		useAdjustmentChat({
 			context: {
@@ -283,18 +274,20 @@ export const FlexibleAdjustmentChatDialog = ({
 		[allowlist, rawMessages],
 	);
 	const proposalKey = latestProposal?.messageId ?? null;
+	const detectedProposal = latestProposal?.proposal ?? null;
+	const { isDismissed, dismissProposal, confirmProposal, shouldShowGuidance } =
+		useProposalDismissState(proposalKey);
 	const { isExecuting, handleConfirm } = useFlexibleProposalExecution({
 		allowlist,
-		proposalKey,
-		setDismissedProposalKey,
+		confirmProposal,
 	});
 	const { proposalMessageId, proposalSection } = useFlexibleProposalState({
 		rawMessages,
 		allowlist,
-		dismissedProposalKey,
+		isDismissed,
 		isExecuting,
 		handleConfirm,
-		setDismissedProposalKey,
+		onDismiss: dismissProposal,
 	});
 	const handleClose = useCallback(() => {
 		stop();
@@ -363,6 +356,11 @@ export const FlexibleAdjustmentChatDialog = ({
 
 			{renderErrorAlert(error)}
 			{proposalSection}
+
+			<ProposalDismissGuidance
+				visible={shouldShowGuidance(detectedProposal !== null, isStreaming)}
+				isStreaming={isStreaming}
+			/>
 
 			<ChatMessageList
 				messages={messages}


### PR DESCRIPTION
## Summary
- `ProposalConfirmCard` / `BatchProposalConfirmCard` のキャンセル（Dismiss）後に、再提案を促すインライン alert を表示
- `AdjustmentChatDialog` と `FlexibleAdjustmentChatDialog` の両方に適用
- `useProposalDismissState` で Dismiss と確定成功を区別し、新しい proposal 到着時はガイダンスを自動非表示

## Test plan
- [x] `useProposalDismissState` / `ProposalDismissGuidance` の単体テスト
- [x] `AdjustmentChatDialog` — キャンセル後ガイダンス表示、確定後非表示、新 proposal で消去、streaming 中非表示
- [x] `FlexibleAdjustmentChatDialog` — キャンセル後ガイダンス表示、確定後非表示
- [x] 全 unit テスト通過（pre-commit hook）

Closes #127


Made with [Cursor](https://cursor.com)