### PR TITLE
fix: flexible AIチャットでツール取得可能な情報の聞き返しを防止する (#194)

### DIFF
--- a/src/app/api/chat/shift-adjustment/route.test.ts
+++ b/src/app/api/chat/shift-adjustment/route.test.ts
@@ -22,6 +22,7 @@ const {
 	mockStaffRepositoryListByOffice,
 	mockStaffRepositoryFindById,
 	mockStaffRepositoryFindByIds,
+	mockStaffRepositorySearchByNameOrKana,
 	mockStepCountIs,
 } = vi.hoisted(() => ({
 	mockStreamText: vi.fn(),
@@ -43,6 +44,7 @@ const {
 	mockStaffRepositoryListByOffice: vi.fn(),
 	mockStaffRepositoryFindById: vi.fn(),
 	mockStaffRepositoryFindByIds: vi.fn(),
+	mockStaffRepositorySearchByNameOrKana: vi.fn(),
 	mockStepCountIs: vi.fn((n: number) => ({ type: 'stepCountIs', count: n })),
 }));
 
@@ -97,6 +99,7 @@ vi.mock('@/backend/repositories/staffRepository', () => ({
 			listByOffice: mockStaffRepositoryListByOffice,
 			findById: mockStaffRepositoryFindById,
 			findByIds: mockStaffRepositoryFindByIds,
+			searchByNameOrKana: mockStaffRepositorySearchByNameOrKana,
 		};
 	},
 }));
@@ -171,6 +174,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 		mockStaffRepositoryListByOffice.mockResolvedValue([]);
 		mockStaffRepositoryFindById.mockResolvedValue(null);
 		mockStaffRepositoryFindByIds.mockResolvedValue([]);
+		mockStaffRepositorySearchByNameOrKana.mockResolvedValue([]);
 
 		// デフォルトのstreamTextモック
 		mockToUIMessageStreamResponse.mockReturnValue(
@@ -346,7 +350,7 @@ describe('POST /api/chat/shift-adjustment', () => {
 		expect(mockStreamText).toHaveBeenCalledWith(
 			expect.objectContaining({
 				system: expect.stringContaining(
-					'必要な情報をユーザーに質問して対象シフトを特定する',
+					'searchStaffs / getShifts で対象シフトを特定する',
 				),
 			}),
 		);
@@ -1611,6 +1615,136 @@ describe('POST /api/chat/shift-adjustment', () => {
 					},
 				],
 			});
+		});
+
+		it('flexible モードの system prompt に情報取得優先順位を含める', async () => {
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [{ role: 'user', content: '週次で調整したい' }],
+						context: {
+							mode: 'flexible',
+							weekRange: {
+								startDate: '2026-06-23',
+								endDate: '2026-06-29',
+							},
+						},
+					}),
+				},
+			);
+
+			const response = await POST(request);
+
+			expect(response.status).toBe(200);
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					system: expect.stringContaining(
+						'情報取得の優先順位（flexible モード）',
+					),
+				}),
+			);
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					system: expect.stringContaining(
+						'searchStaffs / getShifts / searchAvailableHelpers で取得できる情報は、ユーザーに確認せず先にツールで取得する',
+					),
+				}),
+			);
+		});
+
+		it('flexible モードでスタッフ名と日付を含むメッセージの場合、事前確認済みシフト情報を system prompt に注入する', async () => {
+			mockShiftRepositoryList
+				.mockResolvedValueOnce([
+					{ id: TEST_IDS.SCHEDULE_1, staff_id: TEST_IDS.STAFF_1 },
+				])
+				.mockResolvedValueOnce([
+					{
+						id: TEST_IDS.SCHEDULE_1,
+						client_id: TEST_IDS.CLIENT_1,
+						client_name: '利用者A',
+						staff_name: 'ヘルパー-01',
+						service_type_id: 'physical-care',
+						time: {
+							start: { hour: 9, minute: 0 },
+							end: { hour: 10, minute: 0 },
+						},
+					},
+				]);
+			mockStaffRepositoryListByOffice.mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					role: 'helper' as const,
+					service_type_ids: [TEST_IDS.SERVICE_TYPE_1],
+				},
+			]);
+			mockStaffRepositorySearchByNameOrKana.mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					name: 'ヘルパー-01',
+					role: 'helper',
+					kana: null,
+					service_type_ids: ['physical-care'],
+				},
+			]);
+
+			const request = new Request(
+				'http://localhost/api/chat/shift-adjustment',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						'x-ai-response-format': 'uimessage',
+					},
+					body: JSON.stringify({
+						messages: [
+							{
+								role: 'user',
+								content:
+									'6/27 の ヘルパー-01 さんの代わりの人を候補をあげてください',
+							},
+						],
+						context: {
+							mode: 'flexible',
+							weekRange: {
+								startDate: '2026-06-23',
+								endDate: '2026-06-29',
+							},
+						},
+					}),
+				},
+			);
+
+			const response = await POST(request);
+
+			expect(response.status).toBe(200);
+			expect(mockStaffRepositorySearchByNameOrKana).toHaveBeenCalledWith(
+				TEST_IDS.OFFICE_1,
+				'ヘルパー-01',
+				10,
+			);
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					system: expect.stringContaining(
+						'事前確認済みの情報（サーバー自動取得）',
+					),
+				}),
+			);
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					system: expect.stringContaining(`shiftId: ${TEST_IDS.SCHEDULE_1}`),
+				}),
+			);
+			expect(mockStreamText).toHaveBeenCalledWith(
+				expect.objectContaining({
+					system: expect.stringContaining('追加確認は行わないでください'),
+				}),
+			);
 		});
 
 		it('single モードでは getShifts / proposeShiftChanges を追加しない', async () => {

--- a/src/app/api/chat/shift-adjustment/route.ts
+++ b/src/app/api/chat/shift-adjustment/route.ts
@@ -1,3 +1,4 @@
+import { resolveFlexibleChatContext } from '@/backend/chat/flexibleChatPreResolve';
 import { ShiftRepository } from '@/backend/repositories/shiftRepository';
 import { StaffRepository } from '@/backend/repositories/staffRepository';
 import { createGetShiftsTool } from '@/backend/tools/getShifts';
@@ -323,8 +324,8 @@ const BATCH_PROPOSAL_TOOL_PROMPT = `
 const UI_MESSAGE_NO_PROPOSAL_PROMPT = `
 - proposeShiftChange ツールは利用できません
 - assistant 本文に JSON やコードブロックを出力してはならない
-- シフト変更の提案を行う前に、必要な情報をユーザーに質問して対象シフトを特定する
-- 対象シフト（shiftId）が未特定など情報不足時は、必要な確認質問のみを行う
+- シフト変更の提案を行う前に、searchStaffs / getShifts で対象シフトを特定する（サーバー事前取得済みの情報がある場合はそれを前提とする）
+- ツールでも特定できない場合のみ、必要な確認質問を行う
 - proposeShiftChange が使えない前提で、確定操作前の候補案は自然文で簡潔に説明する`;
 
 const BASE_SYSTEM_PROMPT = `あなたは訪問介護事業所のシフト調整をサポートするAIアシスタントです。
@@ -369,8 +370,18 @@ const COMMON_CONSTRAINTS_PROMPT = `
 
 ## 制約
 - 提案は具体的かつ実行可能なものにする
-- 不明な点があれば確認を求める
+- searchStaffs / getShifts / searchAvailableHelpers で取得できる情報は、ユーザーに確認せず先にツールで取得する（サーバー事前取得済みの情報がある場合はそれを前提とする）。ツールでも特定できない場合のみ質問する
 - スタッフや利用者の負担を考慮する`;
+
+const FLEXIBLE_LOOKUP_PROMPT = `
+
+## 情報取得の優先順位（flexible モード）
+1. ユーザーがスタッフ名を述べた場合、まず searchStaffs を呼び出す（サーバー事前取得済みの情報がある場合はそれを優先利用する）
+2. 日付が特定できる場合、getShifts(date, staffId) を呼び出す（サーバー事前取得済みの情報がある場合はそれを優先利用する）
+3. 対象シフトが1件に特定できる場合、日時・サービス内容・利用者の追加確認は行わず searchAvailableHelpers を呼び出す
+4. 対象シフトが複数ある場合のみ、日時・利用者名などユーザーが識別できる情報で確認する
+5. 上記のツール（または事前取得情報）でも特定できない場合のみユーザーに質問する
+- shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください`;
 
 const SHIFT_ID_MISSING_PROMPT = `
 
@@ -401,6 +412,7 @@ type ProposalToolMode = 'none' | 'single' | 'batch';
 const buildSystemPromptBase = (
 	useUIMessageStream: boolean,
 	proposalToolMode: ProposalToolMode,
+	isFlexibleMode: boolean = false,
 ): string =>
 	BASE_SYSTEM_PROMPT +
 	(proposalToolMode === 'single'
@@ -439,6 +451,7 @@ const buildSystemPromptBase = (
 - processStaffAbsence の結果として代替スタッフが決まった場合は、必ず proposeShiftChanges ツールを使って変更提案を作成すること
 - テキストのみで提案内容を報告して終わることは禁止`
 			: '') +
+	(isFlexibleMode ? FLEXIBLE_LOOKUP_PROMPT : '') +
 	SHIFT_ID_MISSING_PROMPT +
 	SUCCESS_ASSERTION_PROMPT;
 
@@ -453,7 +466,7 @@ const buildFlexibleContextPrompt = (
 ## 調整対象期間
 - ${weekRange.startDate} 〜 ${weekRange.endDate}
 - この期間にはシフトが登録されていないため、シフト変更の提案はできません
-- 必要に応じて getShifts を使い、日単位でシフト状況を確認してください`;
+- スタッフ名・日付がメッセージに含まれる場合は searchStaffs / getShifts で状況を確認してください`;
 	}
 
 	const proposalGuide = showProposalGuide
@@ -465,7 +478,7 @@ const buildFlexibleContextPrompt = (
 
 ## 調整対象期間
 - ${weekRange.startDate} 〜 ${weekRange.endDate}
-- 必要に応じて getShifts を使い、日単位でシフト状況を確認してください${proposalGuide}`;
+- スタッフ名・日付がメッセージに含まれる場合は searchStaffs / getShifts で状況を確認してください（サーバー事前取得済みの情報がある場合は追加取得不要）${proposalGuide}`;
 };
 
 const buildShiftSelectionPrompt = (shiftCount: number): string =>
@@ -1165,26 +1178,33 @@ const resolveStreamMode = (
 	useUIMessageStream: boolean,
 	context: ChatRequest['context'],
 	flexibleAllowlist: FlexibleAllowlist | null,
+	preResolvedPromptSection: string = '',
 ) => {
 	const proposalToolMode = resolveProposalToolMode(
 		useUIMessageStream,
 		context,
 		flexibleAllowlist,
 	);
+	const isFlexibleMode = context?.mode === 'flexible';
 
 	return {
 		useUIMessageStream,
 		proposalToolMode,
 		useProposalTool: proposalToolMode !== 'none',
 		systemPrompt:
-			buildSystemPromptBase(useUIMessageStream, proposalToolMode) +
+			buildSystemPromptBase(
+				useUIMessageStream,
+				proposalToolMode,
+				isFlexibleMode,
+			) +
 			buildContextPrompt(
 				context,
 				useUIMessageStream &&
-					context?.mode === 'flexible' &&
+					isFlexibleMode &&
 					(flexibleAllowlist?.shiftIds.length ?? 0) === 0,
 				proposalToolMode === 'batch',
-			),
+			) +
+			preResolvedPromptSection,
 	};
 };
 
@@ -1252,6 +1272,35 @@ const createBaseTools = (
 	}),
 });
 
+const resolveFlexiblePreResolvedPromptSection = async (
+	supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
+	context: ChatRequest['context'],
+	messages: ChatMessage[],
+	officeId: string,
+	logContext: RequestLogContext,
+): Promise<string> => {
+	if (context?.mode !== 'flexible' || !context.weekRange) {
+		return '';
+	}
+
+	try {
+		const preResolved = await resolveFlexibleChatContext({
+			supabase,
+			officeId,
+			weekRange: context.weekRange,
+			messages,
+		});
+		return preResolved?.promptSection ?? '';
+	} catch (error) {
+		logChatError(
+			'Failed to pre-resolve flexible chat context',
+			error,
+			logContext,
+		);
+		return '';
+	}
+};
+
 const handlePost = async (
 	request: Request,
 	logContext: RequestLogContext,
@@ -1297,10 +1346,20 @@ const handlePost = async (
 	logContext.shiftsCount = shiftIds.length;
 	logContext.shiftIds = shiftIds;
 
+	const preResolvedPromptSection =
+		await resolveFlexiblePreResolvedPromptSection(
+			supabase,
+			context,
+			messages,
+			staffData.office_id,
+			logContext,
+		);
+
 	const { useProposalTool, proposalToolMode, systemPrompt } = resolveStreamMode(
 		useUIMessageStream,
 		context,
 		flexibleAllowlist,
+		preResolvedPromptSection,
 	);
 	logContext.mode = useUIMessageStream ? 'uimessage' : 'legacy';
 	logContext.useProposalTool = useProposalTool;

--- a/src/backend/chat/flexibleChatPreResolve.test.ts
+++ b/src/backend/chat/flexibleChatPreResolve.test.ts
@@ -1,0 +1,179 @@
+import { TEST_IDS } from '@/test/helpers/testIds';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	buildPreResolvedContextPrompt,
+	extractDateFromMessage,
+	extractLatestUserMessageText,
+	extractStaffSearchQuery,
+	resolveDateInWeekRange,
+	resolveFlexibleChatContext,
+} from './flexibleChatPreResolve';
+
+const WEEK_RANGE = {
+	startDate: '2026-06-23',
+	endDate: '2026-06-29',
+};
+
+describe('flexibleChatPreResolve', () => {
+	describe('extractLatestUserMessageText', () => {
+		it('parts 形式の最新 user メッセージからテキストを抽出する', () => {
+			const text = extractLatestUserMessageText([
+				{ role: 'user', content: '古いメッセージ' },
+				{
+					role: 'assistant',
+					content: '了解しました',
+				},
+				{
+					role: 'user',
+					parts: [{ type: 'text', text: '6/27 の ヘルパー-01 さんの代わり' }],
+				},
+			]);
+
+			expect(text).toBe('6/27 の ヘルパー-01 さんの代わり');
+		});
+	});
+
+	describe('extractStaffSearchQuery', () => {
+		it('ヘルパー-01 形式を抽出する', () => {
+			expect(
+				extractStaffSearchQuery(
+					'6/27 の ヘルパー-01 さんの代わりの人を候補をあげてください',
+				),
+			).toBe('ヘルパー-01');
+		});
+
+		it('田中さん形式を抽出する', () => {
+			expect(extractStaffSearchQuery('田中さんが欠勤になりました')).toBe(
+				'田中',
+			);
+		});
+	});
+
+	describe('extractDateFromMessage', () => {
+		it('6/27 を weekRange 内の YYYY-MM-DD に解決する', () => {
+			expect(
+				extractDateFromMessage(
+					'6/27 の ヘルパー-01 さんの代わりの人を候補をあげてください',
+					WEEK_RANGE,
+				),
+			).toBe('2026-06-27');
+		});
+
+		it('weekRange 外の日付は null を返す', () => {
+			expect(extractDateFromMessage('7/15 のシフト', WEEK_RANGE)).toBeNull();
+		});
+	});
+
+	describe('resolveDateInWeekRange', () => {
+		it('年跨ぎ weekRange でも日付を解決する', () => {
+			expect(
+				resolveDateInWeekRange(1, 1, {
+					startDate: '2025-12-29',
+					endDate: '2026-01-04',
+				}),
+			).toBe('2026-01-01');
+		});
+	});
+
+	describe('buildPreResolvedContextPrompt', () => {
+		it('単一シフト時は追加確認不要の指示を含める', () => {
+			const prompt = buildPreResolvedContextPrompt({
+				staffSearchQuery: 'ヘルパー-01',
+				matchedStaffs: [
+					{ staffId: TEST_IDS.STAFF_1, name: 'ヘルパー-01', role: 'helper' },
+				],
+				extractedDate: '2026-06-27',
+				shifts: [
+					{
+						id: TEST_IDS.SCHEDULE_1,
+						date: '2026-06-27',
+						startTime: '09:00',
+						endTime: '10:00',
+						clientId: TEST_IDS.CLIENT_1,
+						clientName: '利用者A',
+						staffName: 'ヘルパー-01',
+						serviceTypeId: 'physical-care',
+						serviceTypeLabel: '身体介護',
+					},
+				],
+			});
+
+			expect(prompt).toContain('事前確認済みの情報');
+			expect(prompt).toContain('shiftId:');
+			expect(prompt).toContain('追加確認は行わないでください');
+			expect(prompt).toContain('searchAvailableHelpers');
+		});
+	});
+
+	describe('resolveFlexibleChatContext', () => {
+		it('スタッフ名と日付からシフト情報を取得して prompt を返す', async () => {
+			const mockSearchByNameOrKana = vi.fn().mockResolvedValue([
+				{
+					id: TEST_IDS.STAFF_1,
+					name: 'ヘルパー-01',
+					role: 'helper',
+					kana: null,
+					service_type_ids: ['physical-care'],
+				},
+			]);
+			const mockList = vi.fn().mockResolvedValue([
+				{
+					id: TEST_IDS.SCHEDULE_1,
+					client_id: TEST_IDS.CLIENT_1,
+					client_name: '利用者A',
+					staff_name: 'ヘルパー-01',
+					service_type_id: 'physical-care',
+					time: {
+						start: { hour: 9, minute: 0 },
+						end: { hour: 10, minute: 0 },
+					},
+				},
+			]);
+
+			const result = await resolveFlexibleChatContext({
+				supabase: {} as never,
+				officeId: TEST_IDS.OFFICE_1,
+				weekRange: WEEK_RANGE,
+				messages: [
+					{
+						role: 'user',
+						content:
+							'6/27 の ヘルパー-01 さんの代わりの人を候補をあげてください',
+					},
+				],
+				staffRepository: { searchByNameOrKana: mockSearchByNameOrKana },
+				shiftRepository: { list: mockList },
+			});
+
+			expect(result).not.toBeNull();
+			expect(result?.staffSearchQuery).toBe('ヘルパー-01');
+			expect(result?.extractedDate).toBe('2026-06-27');
+			expect(result?.shiftCount).toBe(1);
+			expect(mockSearchByNameOrKana).toHaveBeenCalledWith(
+				TEST_IDS.OFFICE_1,
+				'ヘルパー-01',
+				10,
+			);
+			expect(mockList).toHaveBeenCalledWith(
+				expect.objectContaining({
+					officeId: TEST_IDS.OFFICE_1,
+					staffId: TEST_IDS.STAFF_1,
+					includeNames: true,
+				}),
+			);
+		});
+
+		it('抽出できないメッセージでは null を返す', async () => {
+			const result = await resolveFlexibleChatContext({
+				supabase: {} as never,
+				officeId: TEST_IDS.OFFICE_1,
+				weekRange: WEEK_RANGE,
+				messages: [{ role: 'user', content: 'こんにちは' }],
+				staffRepository: { searchByNameOrKana: vi.fn() },
+				shiftRepository: { list: vi.fn() },
+			});
+
+			expect(result).toBeNull();
+		});
+	});
+});

--- a/src/backend/chat/flexibleChatPreResolve.ts
+++ b/src/backend/chat/flexibleChatPreResolve.ts
@@ -1,0 +1,348 @@
+import { ShiftRepository } from '@/backend/repositories/shiftRepository';
+import { StaffRepository } from '@/backend/repositories/staffRepository';
+import { isValidDate } from '@/backend/tools/_shared/dateValidation';
+import { Database } from '@/backend/types/supabase';
+import { ServiceTypeLabels } from '@/models/valueObjects/serviceTypeId';
+import { parseJstDateString, timeObjectToString } from '@/utils/date';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+const ISO_DATE_PATTERN = /(\d{4}-\d{2}-\d{2})/;
+const SLASH_DATE_PATTERN = /(\d{1,2})\/(\d{1,2})(?=\s|$|の|に|、|[^0-9])/;
+const JP_DATE_PATTERN = /(\d{1,2})月(\d{1,2})日/;
+const HELPER_NAME_PATTERN = /(ヘルパー[-\s]?\d+)/i;
+const NAME_BEFORE_SAN_PATTERN =
+	/([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{L}\p{N}-]+?)さん/u;
+
+const GENERIC_NAME_BEFORE_SAN = /^(代わり|担当|該当|この|その|本人)$/;
+
+export type WeekRange = {
+	startDate: string;
+	endDate: string;
+};
+
+export type ChatMessageForPreResolve = {
+	role: string;
+	content?: string;
+	parts?: Array<{ type: string; text?: string }>;
+};
+
+export type PreResolvedShift = {
+	id: string;
+	date: string;
+	startTime: string;
+	endTime: string;
+	clientId: string;
+	clientName: string;
+	staffName: string;
+	serviceTypeId: string;
+	serviceTypeLabel: string;
+};
+
+export type FlexiblePreResolveResult = {
+	promptSection: string;
+	staffSearchQuery?: string;
+	extractedDate?: string;
+	matchedStaffCount: number;
+	shiftCount: number;
+};
+
+type ResolveFlexibleChatContextOptions = {
+	supabase: SupabaseClient<Database>;
+	officeId: string;
+	weekRange: WeekRange;
+	messages: ChatMessageForPreResolve[];
+	shiftRepository?: Pick<ShiftRepository, 'list'>;
+	staffRepository?: Pick<StaffRepository, 'searchByNameOrKana'>;
+};
+
+const isDateInWeekRange = (date: string, weekRange: WeekRange): boolean => {
+	const target = parseJstDateString(date);
+	const start = parseJstDateString(weekRange.startDate);
+	const end = parseJstDateString(weekRange.endDate);
+	return target >= start && target <= end;
+};
+
+export const resolveDateInWeekRange = (
+	month: number,
+	day: number,
+	weekRange: WeekRange,
+): string | null => {
+	if (month < 1 || month > 12 || day < 1 || day > 31) {
+		return null;
+	}
+
+	const startYear = Number(weekRange.startDate.slice(0, 4));
+	const endYear = Number(weekRange.endDate.slice(0, 4));
+	const years = startYear === endYear ? [startYear] : [startYear, endYear];
+
+	for (const year of years) {
+		const candidate = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+		if (!isValidDate(candidate)) {
+			continue;
+		}
+		if (isDateInWeekRange(candidate, weekRange)) {
+			return candidate;
+		}
+	}
+
+	return null;
+};
+
+export const extractDateFromMessage = (
+	message: string,
+	weekRange: WeekRange,
+): string | null => {
+	const isoMatch = message.match(ISO_DATE_PATTERN);
+	if (isoMatch && isDateInWeekRange(isoMatch[1], weekRange)) {
+		return isoMatch[1];
+	}
+
+	const slashMatch = message.match(SLASH_DATE_PATTERN);
+	if (slashMatch) {
+		return resolveDateInWeekRange(
+			Number(slashMatch[1]),
+			Number(slashMatch[2]),
+			weekRange,
+		);
+	}
+
+	const jpMatch = message.match(JP_DATE_PATTERN);
+	if (jpMatch) {
+		return resolveDateInWeekRange(
+			Number(jpMatch[1]),
+			Number(jpMatch[2]),
+			weekRange,
+		);
+	}
+
+	return null;
+};
+
+export const extractStaffSearchQuery = (message: string): string | null => {
+	const trimmed = message.trim();
+	if (!trimmed) {
+		return null;
+	}
+
+	const helperMatch = trimmed.match(HELPER_NAME_PATTERN);
+	if (helperMatch) {
+		return helperMatch[1].replace(/\s+/g, '');
+	}
+
+	const sanMatch = trimmed.match(NAME_BEFORE_SAN_PATTERN);
+	if (sanMatch) {
+		const name = sanMatch[1].trim();
+		if (name.length >= 2 && !GENERIC_NAME_BEFORE_SAN.test(name)) {
+			return name;
+		}
+	}
+
+	return null;
+};
+
+export const extractLatestUserMessageText = (
+	messages: ChatMessageForPreResolve[],
+): string | null => {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (message.role !== 'user') {
+			continue;
+		}
+
+		if (typeof message.content === 'string' && message.content.trim()) {
+			return message.content.trim();
+		}
+
+		if (message.parts?.length) {
+			const text = message.parts
+				.filter((part) => part.type === 'text')
+				.map((part) => part.text ?? '')
+				.join('')
+				.trim();
+			if (text) {
+				return text;
+			}
+		}
+	}
+
+	return null;
+};
+
+const buildShiftSelectionPrompt = (shiftCount: number): string =>
+	shiftCount === 1
+		? `
+
+### 対象シフトの扱い
+- 上記1件を対象シフトとして扱い、日時・サービス内容・利用者の追加確認は行わないでください
+- date / clientId / serviceTypeId をそのまま searchAvailableHelpers の入力に使用してください
+- shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください
+- ユーザーが代替ヘルパーの提案を求めている場合は、追加質問なしで searchAvailableHelpers を呼び出してください`
+		: `
+
+### 対象シフトの扱い
+- 複数シフトがあるため、どのシフトを対象にするかを日時・利用者名でユーザーに確認してください
+- shiftId は内部識別子のため、ユーザーに shiftId を尋ねたり提示したりしないでください`;
+
+export const buildPreResolvedContextPrompt = (input: {
+	staffSearchQuery?: string;
+	matchedStaffs: Array<{ staffId: string; name: string; role?: string }>;
+	extractedDate?: string;
+	shifts: PreResolvedShift[];
+}): string => {
+	const sections: string[] = [
+		'',
+		'## 事前確認済みの情報（サーバー自動取得）',
+		'以下はユーザーの最新メッセージから自動取得した情報です。この情報を前提として対応してください。',
+	];
+
+	if (input.staffSearchQuery && input.matchedStaffs.length > 0) {
+		const staffLines = input.matchedStaffs.map(
+			(staff) =>
+				`- ${staff.name} (staffId: ${staff.staffId}${staff.role ? `, role: ${staff.role}` : ''})`,
+		);
+		sections.push(
+			'',
+			`### スタッフ検索結果（query: "${input.staffSearchQuery}"）`,
+			...staffLines,
+		);
+	}
+
+	if (input.extractedDate && input.shifts.length > 0) {
+		const shiftLines = input.shifts.map(
+			(shift) =>
+				`- ${shift.date} ${shift.startTime}〜${shift.endTime}: ${shift.clientName} / ${shift.staffName} (${shift.serviceTypeLabel}（serviceTypeId: ${shift.serviceTypeId}）, clientId: ${shift.clientId}, shiftId: ${shift.id})`,
+		);
+		sections.push(
+			'',
+			`### ${input.extractedDate} のシフト`,
+			...shiftLines,
+			buildShiftSelectionPrompt(input.shifts.length),
+		);
+	} else if (input.extractedDate && input.shifts.length === 0) {
+		sections.push(
+			'',
+			`### ${input.extractedDate} のシフト`,
+			'- 該当するシフトは見つかりませんでした',
+		);
+	}
+
+	return sections.join('\n');
+};
+
+const mapShiftToPreResolved = (
+	shift: Awaited<ReturnType<ShiftRepository['list']>>[number],
+	date: string,
+): PreResolvedShift => ({
+	id: shift.id,
+	date,
+	startTime: timeObjectToString(shift.time.start),
+	endTime: timeObjectToString(shift.time.end),
+	clientId: shift.client_id,
+	clientName: shift.client_name ?? '(利用者不明)',
+	staffName: shift.staff_name ?? '(未割当)',
+	serviceTypeId: shift.service_type_id,
+	serviceTypeLabel: ServiceTypeLabels[shift.service_type_id],
+});
+
+const fetchPreResolvedShifts = async (
+	shiftRepository: Pick<ShiftRepository, 'list'>,
+	officeId: string,
+	extractedDate: string,
+	staffIdForShifts?: string,
+): Promise<PreResolvedShift[]> => {
+	const rawShifts = await shiftRepository.list({
+		officeId,
+		date: extractedDate,
+		includeNames: true,
+		...(staffIdForShifts ? { staffId: staffIdForShifts } : {}),
+	});
+
+	return rawShifts.map((shift) => mapShiftToPreResolved(shift, extractedDate));
+};
+
+const hasUsefulPreResolveData = (
+	matchedStaffCount: number,
+	extractedDate: string | null,
+	shiftCount: number,
+): boolean =>
+	matchedStaffCount > 0 || (extractedDate !== null && shiftCount > 0);
+
+const fetchFlexiblePreResolveData = async (
+	options: ResolveFlexibleChatContextOptions,
+	staffSearchQuery: string | null,
+	extractedDate: string | null,
+) => {
+	const shiftRepository =
+		options.shiftRepository ?? new ShiftRepository(options.supabase);
+	const staffRepository =
+		options.staffRepository ?? new StaffRepository(options.supabase);
+
+	const matchedStaffs = staffSearchQuery
+		? await staffRepository.searchByNameOrKana(
+				options.officeId,
+				staffSearchQuery,
+				10,
+			)
+		: [];
+
+	const staffIdForShifts =
+		matchedStaffs.length === 1 ? matchedStaffs[0].id : undefined;
+
+	const shifts = extractedDate
+		? await fetchPreResolvedShifts(
+				shiftRepository,
+				options.officeId,
+				extractedDate,
+				staffIdForShifts,
+			)
+		: [];
+
+	return { matchedStaffs, shifts };
+};
+
+export const resolveFlexibleChatContext = async (
+	options: ResolveFlexibleChatContextOptions,
+): Promise<FlexiblePreResolveResult | null> => {
+	const userMessage = extractLatestUserMessageText(options.messages);
+	if (!userMessage) {
+		return null;
+	}
+
+	const staffSearchQuery = extractStaffSearchQuery(userMessage);
+	const extractedDate = extractDateFromMessage(userMessage, options.weekRange);
+
+	if (!staffSearchQuery && !extractedDate) {
+		return null;
+	}
+
+	const { matchedStaffs, shifts } = await fetchFlexiblePreResolveData(
+		options,
+		staffSearchQuery,
+		extractedDate,
+	);
+
+	if (
+		!hasUsefulPreResolveData(matchedStaffs.length, extractedDate, shifts.length)
+	) {
+		return null;
+	}
+
+	const promptSection = buildPreResolvedContextPrompt({
+		staffSearchQuery: staffSearchQuery ?? undefined,
+		matchedStaffs: matchedStaffs.map((staff) => ({
+			staffId: staff.id,
+			name: staff.name,
+			role: staff.role,
+		})),
+		extractedDate: extractedDate ?? undefined,
+		shifts,
+	});
+
+	return {
+		promptSection,
+		staffSearchQuery: staffSearchQuery ?? undefined,
+		extractedDate: extractedDate ?? undefined,
+		matchedStaffCount: matchedStaffs.length,
+		shiftCount: shifts.length,
+	};
+};


### PR DESCRIPTION
## Summary

- flexible AIチャット（週次画面の Drawer）で、スタッフ名・日付などツールで取得できる情報をユーザーに聞き返してしまう問題を修正
- ユーザーメッセージからスタッフ名・日付をサーバー側で事前解決し、シフト情報を system prompt に注入する（single モードの `context.shifts` 注入と同じパターン）
- flexible 向けプロンプトをツール優先に整理し、「確認を求める」と「ツールで取得する」の矛盾を解消

Closes #194

## 変更内容

### サーバー側事前解決（`src/backend/chat/flexibleChatPreResolve.ts`）
- 最新ユーザーメッセージからスタッフ名（`ヘルパー-01`、`田中さん` 等）と日付（`6/27`、`6月27日` 等）を抽出
- `searchByNameOrKana` + `ShiftRepository.list` でシフト情報を取得
- 「事前確認済みの情報」セクションを system prompt に注入

### プロンプト整理（`route.ts`）
- `COMMON_CONSTRAINTS`: ツールで取得可能な情報は先にツールで取得
- `FLEXIBLE_LOOKUP_PROMPT`: flexible 向けの情報取得優先順位（5段階）を追加
- `UI_MESSAGE_NO_PROPOSAL_PROMPT`: ユーザー質問優先 → `searchStaffs` / `getShifts` 優先

## Test plan

- [x] `pnpm test:ut --run src/backend/chat/flexibleChatPreResolve.test.ts`
- [x] `pnpm test:ut --run src/app/api/chat/shift-adjustment/route.test.ts`
- [x] pre-commit（tsc / eslint / prettier / vitest 全件）通過
- [ ] 週次スケジュール画面の AIアシスタントで「6/27 の ヘルパー-01 さんの代わりの人を候補をあげてください」と入力し、日時・サービス内容を聞き返さず候補提示に進むことを確認
- [ ] single モード（ChangeStaffDialog 経由）の既存挙動に回帰がないことを確認


Made with [Cursor](https://cursor.com)